### PR TITLE
chore: docs update for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ mcpsnoop http --target http://localhost:3000/mcp --listen :7000
 ```
 
 No server of your own to test against? [docs/DEMO.md](docs/DEMO.md) walks through
-pointing Claude at a published test server through mcpsnoop.
+pointing Codex or Claude at a published test server through mcpsnoop.
 
 ## Features
 

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,7 +1,7 @@
 # Trying mcpsnoop for real
 
 You don't need to write a server. Wrap a **published** one with `mcpsnoop` and
-drive it with a **real client** (Claude). The `everything` test server is ideal
+drive it with a **real client** (Codex or Claude). The `everything` test server is ideal
 because its tools have no built-in equivalent, so the client is forced to go
 through MCP (with a filesystem server, Claude/Cursor often use their own native
 file tools and you'd only see the handshake).
@@ -15,6 +15,9 @@ go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@latest   # puts mcpsnoop o
 # Claude Code:
 claude mcp add everything -- mcpsnoop -- npx -y @modelcontextprotocol/server-everything
 
+# Codex:
+codex mcp add everything -- mcpsnoop -- npx -y @modelcontextprotocol/server-everything
+
 # …or Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json):
 # { "mcpServers": { "everything": {
 #     "command": "mcpsnoop",
@@ -24,7 +27,7 @@ claude mcp add everything -- mcpsnoop -- npx -y @modelcontextprotocol/server-eve
 ## Watch it live
 
 1. In one terminal: `mcpsnoop`  (the TUI, which shows "Waiting for MCP traffic…").
-2. Start a **new** client session (MCP servers load at session start), e.g. `claude`.
+2. Start a **new** client session (MCP servers load at session start), e.g. `codex` or `claude`.
    The `server-everything` session appears live with the handshake.
 3. Ask the client to use the tools:
    > Use the everything MCP server: echo "hello", get-sum 40+2, then trigger-long-running-operation.


### PR DESCRIPTION
Updated docs for Codex, improved clarity.

## What and why

Documents mcpsnoop setup for Codex CLI using native `codex mcp add`, matching the Claude Code flow so users can trace Codex MCP traffic quickly.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
