### PR TITLE
fix: deleted duplicated endpoints when specifying --target

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -86,7 +86,7 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte)) http.Handle
 			req.URL.Host = target.Host
 			req.Host = target.Host
 			if target.Path != "" && target.Path != "/" {
-				req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+				req.URL.Path = target.Path
 			}
 		},
 		ModifyResponse: func(resp *http.Response) error {
@@ -142,18 +142,6 @@ func emitFrames(emit func(Direction, []byte), dir Direction, body []byte) {
 		}
 	}
 	emit(dir, b)
-}
-
-func singleJoiningSlash(a, b string) string {
-	aslash := strings.HasSuffix(a, "/")
-	bslash := strings.HasPrefix(b, "/")
-	switch {
-	case aslash && bslash:
-		return a + b[1:]
-	case !aslash && !bslash:
-		return a + "/" + b
-	}
-	return a + b
 }
 
 // sseTap passes SSE bytes through unchanged while extracting each event's

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -52,6 +52,28 @@ func TestHTTPProxyJSON(t *testing.T) {
 	}
 }
 
+func TestHTTPProxyTargetPathIsEndpoint(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			t.Fatalf("backend path = %q, want /mcp", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer backend.Close()
+
+	target, _ := url.Parse(backend.URL + "/mcp")
+	sink := &captureSink{}
+	front := httptest.NewServer(httpProxyHandler(target, emitterTo(sink)))
+	defer front.Close()
+
+	resp, err := http.Post(front.URL+"/mcp", "application/json", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+}
+
 func TestHTTPProxySSE(t *testing.T) {
 	msgs := []string{
 		`{"jsonrpc":"2.0","id":1,"result":{"step":1}}`,


### PR DESCRIPTION
fix: deleted duplicated endpoints when specifiying --target

## What and why

Fixes HTTP proxy routing when --target includes an MCP endpoint path. Previously, a client request to /mcp with --target http://host/mcp was forwarded to /mcp/mcp, causing endpoint-backed streamable HTTP servers to return 404/EOF. The proxy now treats the target path as the exact upstream endpoint and includes a regression test for that case.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
