### PR TITLE
fix: preserve multiline SSE data separators

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -200,6 +200,9 @@ func (t *sseTap) line(l []byte) {
 		return
 	}
 	if rest, ok := bytes.CutPrefix(l, []byte("data:")); ok {
+		if t.dataBuf.Len() > 0 {
+			t.dataBuf.WriteByte('\n')
+		}
 		t.dataBuf.Write(bytes.TrimPrefix(rest, []byte(" ")))
 	}
 	// other SSE fields (event:, id:, retry:) are ignored

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -105,3 +105,14 @@ func TestSSETapMultiChunk(t *testing.T) {
 		t.Fatalf("sseTap parsed %v", got)
 	}
 }
+
+func TestSSETapMultilineData(t *testing.T) {
+	var got []string
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte) { got = append(got, string(d)) })
+
+	tap.feed([]byte("data: first line\ndata: second line\n\n"))
+
+	if len(got) != 1 || got[0] != "first line\nsecond line" {
+		t.Fatalf("sseTap parsed %v", got)
+	}
+}


### PR DESCRIPTION
## What and why

SSE allows one event to contain multiple `data:` lines. `sseTap` was concatenating those lines without a separator when emitting the observed payload, so a multiline event such as:

```
data: first line
data: second line
```

was observed as `first linesecond line` instead of `first line\nsecond line`.

This keeps the proxied bytes unchanged and only fixes the observed copy by inserting the newline separator between consecutive `data:` fields. It also adds a focused unit test for the multiline case.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [ ] Updated the README / docs if user-facing behaviour changed
