### PR TITLE
feat: add session export with text/json/html view

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ matches the method, tool, id and payload, while `tool:` `method:` `id:` `kind:`
 to a search tool, and `dir:s2c kind:req` surfaces server-initiated requests
 (sampling, roots). The `?` help lists each token and the values it accepts.
 
+## Exporting sessions
+
+`mcpsnoop export -T json|html|text [-o file|-] [session-id|log.jsonl]` reads a
+captured JSONL session and writes a portable export. `json` includes correlated
+calls, durations, status, tool-level `isError`, capabilities, and the raw
+frames. `html` is a self-contained browser file with search and collapsible
+JSON. `text` is a pretty plain dump. Omit the session argument to export the
+newest saved session, and use `-o -` to write to stdout.
+
+In the TUI, press `e` to export the selected session as HTML, or run
+`:export json|html|text [path]` from command mode.
+
 ## Security
 
 mcpsnoop runs the server command you wrap, so only wrap servers you trust and

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/tui"
@@ -49,6 +50,10 @@ func main() {
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "http" {
 		os.Exit(runHTTP(args[1:]))
 	}
+	// `mcpsnoop export` renders a captured JSONL session to json/html/text.
+	if args := os.Args[1:]; len(args) > 0 && args[0] == "export" {
+		os.Exit(runExport(args[1:]))
+	}
 	// `mcpsnoop version` mirrors the --version flag (what most CLIs expect).
 	if args := os.Args[1:]; len(args) == 1 && (args[0] == "version" || args[0] == "-v") {
 		fmt.Println("mcpsnoop", appVersion())
@@ -71,6 +76,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage:\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop [flags] -- <server command> [args...]   run as transparent stdio shim\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop http --target <url> [--listen :7000]     run as transparent HTTP proxy\n")
+		fmt.Fprintf(os.Stderr, "  mcpsnoop export [-T json|html|text] [-o file|-] [session-id|log.jsonl]\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop                                          run the live TUI (collector)\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop demo                                     play a scripted session (no setup)\n\n")
 		fmt.Fprintf(os.Stderr, "Flags:\n")
@@ -135,6 +141,62 @@ func labelFor(command []string) string {
 		return filepath.Base(command[0])
 	}
 	return pick
+}
+
+// runExport reads a persisted JSONL session and writes a portable export.
+func runExport(args []string) int {
+	fs := flag.NewFlagSet("mcpsnoop export", flag.ExitOnError)
+	var (
+		formatFlag = fs.String("T", "json", "output format: json, html, or text")
+		outFlag    = fs.String("o", "-", "output path, or - for stdout")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop export [-T json|html|text] [-o file|-] [session-id|log.jsonl]\n\n")
+		fmt.Fprintf(os.Stderr, "If no session is provided, the newest session log is exported.\n\n")
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	if fs.NArg() > 1 {
+		fmt.Fprintln(os.Stderr, "mcpsnoop export: expected at most one session id or log path")
+		return 2
+	}
+	format, err := exporter.ParseFormat(*formatFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+		return 2
+	}
+	var arg string
+	if fs.NArg() == 1 {
+		arg = fs.Arg(0)
+	}
+	inPath, err := exporter.ResolveSessionPath(arg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+		return 1
+	}
+
+	var out *os.File
+	if *outFlag == "-" {
+		out = os.Stdout
+	} else {
+		if err := os.MkdirAll(filepath.Dir(*outFlag), 0o700); err != nil {
+			fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+			return 1
+		}
+		f, err := os.OpenFile(*outFlag, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+			return 1
+		}
+		defer f.Close()
+		out = f
+	}
+	if err := exporter.ExportFile(inPath, out, exporter.Options{Format: format}); err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+		return 1
+	}
+	return 0
 }
 
 // runShim runs the transparent stdio proxy. It writes the durable session log

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -1,0 +1,427 @@
+package exporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+type Format string
+
+const (
+	FormatJSON Format = "json"
+	FormatHTML Format = "html"
+	FormatText Format = "text"
+)
+
+type Options struct {
+	Format Format
+}
+
+type SessionExport struct {
+	GeneratedAt  time.Time           `json:"generated_at"`
+	Session      SessionSummary      `json:"session"`
+	Capabilities *CapabilitiesExport `json:"capabilities,omitempty"`
+	Calls        []CallExport        `json:"calls"`
+	Events       []EventExport       `json:"events"`
+}
+
+type SessionSummary struct {
+	ID            string    `json:"id"`
+	Label         string    `json:"label"`
+	First         time.Time `json:"first"`
+	Last          time.Time `json:"last"`
+	Requests      int       `json:"requests"`
+	Responses     int       `json:"responses"`
+	Notifications int       `json:"notifications"`
+	Errors        int       `json:"errors"`
+	Pending       int       `json:"pending"`
+}
+
+type CapabilitiesExport struct {
+	ProtocolVersion string          `json:"protocol_version,omitempty"`
+	ClientInfo      json.RawMessage `json:"client_info,omitempty"`
+	ServerInfo      json.RawMessage `json:"server_info,omitempty"`
+	Client          json.RawMessage `json:"client,omitempty"`
+	Server          json.RawMessage `json:"server,omitempty"`
+}
+
+type CallExport struct {
+	Index      int             `json:"index"`
+	ID         string          `json:"id"`
+	Method     string          `json:"method"`
+	Direction  proxy.Direction `json:"direction"`
+	State      string          `json:"state"`
+	Status     string          `json:"status"`
+	IsTool     bool            `json:"is_tool"`
+	ToolName   string          `json:"tool_name,omitempty"`
+	IsError    bool            `json:"is_error"`
+	ToolError  bool            `json:"tool_error"`
+	StartedAt  time.Time       `json:"started_at"`
+	EndedAt    *time.Time      `json:"ended_at,omitempty"`
+	DurationMS *float64        `json:"duration_ms,omitempty"`
+	Params     json.RawMessage `json:"params,omitempty"`
+	Result     json.RawMessage `json:"result,omitempty"`
+	Error      *proxy.RPCError `json:"error,omitempty"`
+}
+
+type EventExport struct {
+	Seq       uint64          `json:"seq"`
+	Timestamp time.Time       `json:"timestamp"`
+	Direction proxy.Direction `json:"direction"`
+	Kind      string          `json:"kind"`
+	Method    string          `json:"method,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	CallIndex *int            `json:"call_index,omitempty"`
+	Raw       json.RawMessage `json:"raw,omitempty"`
+	Text      string          `json:"text,omitempty"`
+}
+
+func ParseFormat(s string) (Format, error) {
+	switch Format(strings.ToLower(strings.TrimSpace(s))) {
+	case FormatJSON:
+		return FormatJSON, nil
+	case FormatHTML:
+		return FormatHTML, nil
+	case FormatText:
+		return FormatText, nil
+	default:
+		return "", fmt.Errorf("unknown export format %q (want json, html, or text)", s)
+	}
+}
+
+func ResolveSessionPath(arg string) (string, error) {
+	if arg != "" {
+		if _, err := os.Stat(arg); err == nil {
+			return arg, nil
+		}
+		if filepath.Ext(arg) == ".jsonl" || strings.ContainsRune(arg, filepath.Separator) {
+			return "", errPathNotFound(arg)
+		}
+		path := paths.SessionLogPath(arg)
+		if _, err := os.Stat(path); err != nil {
+			return "", errPathNotFound(path)
+		}
+		return path, nil
+	}
+
+	files, err := filepath.Glob(filepath.Join(paths.SessionsDir(), "*.jsonl"))
+	if err != nil || len(files) == 0 {
+		return "", errors.New("no session logs found")
+	}
+	var latest string
+	var latestMod time.Time
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			continue
+		}
+		if latest == "" || info.ModTime().After(latestMod) {
+			latest = f
+			latestMod = info.ModTime()
+		}
+	}
+	if latest == "" {
+		return "", errors.New("no readable session logs found")
+	}
+	return latest, nil
+}
+
+func DefaultOutputPath(sessionID string, format Format) string {
+	ext := string(format)
+	if format == FormatText {
+		ext = "txt"
+	}
+	return filepath.Join(paths.ExportsDir(), safeFileName(sessionID)+"."+ext)
+}
+
+func LoadFile(path string) (*store.Store, string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer f.Close()
+
+	st := store.New(0)
+	var firstSession string
+	dec := json.NewDecoder(f)
+	for {
+		var env proxy.Envelope
+		if err := dec.Decode(&env); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, "", fmt.Errorf("%s: invalid JSONL envelope: %w", path, err)
+		}
+		if firstSession == "" {
+			firstSession = env.SessionID
+		}
+		st.Ingest(env)
+	}
+	if firstSession == "" {
+		return nil, "", fmt.Errorf("%s: no envelopes found", path)
+	}
+	return st, firstSession, nil
+}
+
+func Build(st *store.Store, sessionID string) (SessionExport, error) {
+	var header store.SessionHeader
+	found := false
+	for _, h := range st.Sessions() {
+		if h.ID == sessionID {
+			header = h
+			found = true
+			break
+		}
+	}
+	if !found {
+		return SessionExport{}, fmt.Errorf("session %q not found", sessionID)
+	}
+
+	calls := st.Calls(sessionID)
+	callIndex := make(map[string]int, len(calls))
+	outCalls := make([]CallExport, 0, len(calls))
+	for i, c := range calls {
+		callIndex[callKey(c)] = i
+		outCalls = append(outCalls, exportCall(i, c))
+	}
+
+	events := st.Timeline(sessionID)
+	outEvents := make([]EventExport, 0, len(events))
+	for _, ev := range events {
+		outEvents = append(outEvents, exportEvent(ev, callIndex))
+	}
+
+	out := SessionExport{
+		GeneratedAt: time.Now().UTC(),
+		Session: SessionSummary{
+			ID:            header.ID,
+			Label:         header.Label,
+			First:         header.First,
+			Last:          header.Last,
+			Requests:      header.Requests,
+			Responses:     header.Responses,
+			Notifications: header.Notifications,
+			Errors:        header.Errors,
+			Pending:       header.Pending,
+		},
+		Calls:  outCalls,
+		Events: outEvents,
+	}
+	if caps, ok := st.Capabilities(sessionID); ok {
+		out.Capabilities = &CapabilitiesExport{
+			ProtocolVersion: caps.ProtocolVersion,
+			ClientInfo:      caps.ClientInfo,
+			ServerInfo:      caps.ServerInfo,
+			Client:          caps.Client,
+			Server:          caps.Server,
+		}
+	}
+	return out, nil
+}
+
+func Write(w io.Writer, data SessionExport, opts Options) error {
+	format := opts.Format
+	if format == "" {
+		format = FormatJSON
+	}
+	switch format {
+	case FormatJSON:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
+	case FormatHTML:
+		return writeHTML(w, data)
+	case FormatText:
+		return writeText(w, data)
+	default:
+		return fmt.Errorf("unknown export format %q", format)
+	}
+}
+
+func ExportFile(inputPath string, w io.Writer, opts Options) error {
+	st, sessionID, err := LoadFile(inputPath)
+	if err != nil {
+		return err
+	}
+	data, err := Build(st, sessionID)
+	if err != nil {
+		return err
+	}
+	return Write(w, data, opts)
+}
+
+func exportCall(index int, c store.CallView) CallExport {
+	status := "ok"
+	if c.State == store.Pending {
+		status = "pending"
+	} else if c.Failed() {
+		status = "error"
+	}
+	out := CallExport{
+		Index:     index,
+		ID:        c.ID,
+		Method:    c.Method,
+		Direction: c.ReqDir,
+		State:     c.State.String(),
+		Status:    status,
+		IsTool:    c.IsTool,
+		ToolName:  c.ToolName,
+		IsError:   c.Failed(),
+		ToolError: c.ToolErr,
+		StartedAt: c.Start,
+		Params:    c.Params,
+		Result:    c.Result,
+		Error:     c.Err,
+	}
+	if c.Done() {
+		end := c.End
+		dur := float64(c.End.Sub(c.Start)) / float64(time.Millisecond)
+		out.EndedAt = &end
+		out.DurationMS = &dur
+	}
+	return out
+}
+
+func exportEvent(ev store.EventView, callIndex map[string]int) EventExport {
+	out := EventExport{
+		Seq:       ev.Seq,
+		Timestamp: ev.TS,
+		Direction: ev.Dir,
+		Kind:      eventKind(ev.Kind),
+		Method:    ev.Method,
+		ID:        ev.ID,
+		Raw:       ev.Raw,
+		Text:      ev.Text,
+	}
+	if ev.Call != nil {
+		if idx, ok := callIndex[callKey(*ev.Call)]; ok {
+			out.CallIndex = &idx
+		}
+	}
+	return out
+}
+
+func writeText(w io.Writer, data SessionExport) error {
+	_, err := fmt.Fprintf(w, "mcpsnoop session %s (%s)\n", data.Session.ID, data.Session.Label)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "frames: %d  calls: %d  requests: %d  responses: %d  errors: %d  pending: %d\n\n",
+		len(data.Events), len(data.Calls), data.Session.Requests, data.Session.Responses, data.Session.Errors, data.Session.Pending)
+	if err != nil {
+		return err
+	}
+	for _, ev := range data.Events {
+		title := fmt.Sprintf("#%d %s %s %s", ev.Seq, ev.Timestamp.Format(time.RFC3339Nano), ev.Direction, ev.Kind)
+		if ev.Method != "" {
+			title += " " + ev.Method
+		}
+		if ev.ID != "" {
+			title += " id=" + ev.ID
+		}
+		if ev.CallIndex != nil {
+			c := data.Calls[*ev.CallIndex]
+			title += fmt.Sprintf(" status=%s duration_ms=%s", c.Status, formatDuration(c.DurationMS))
+			if c.ToolName != "" {
+				title += " tool=" + c.ToolName
+			}
+		}
+		if _, err := fmt.Fprintln(w, title); err != nil {
+			return err
+		}
+		if ev.Text != "" {
+			if _, err := fmt.Fprintln(w, ev.Text); err != nil {
+				return err
+			}
+		} else if len(ev.Raw) > 0 {
+			var pretty bytes.Buffer
+			if json.Indent(&pretty, ev.Raw, "", "  ") == nil {
+				if _, err := fmt.Fprintln(w, pretty.String()); err != nil {
+					return err
+				}
+			} else if _, err := fmt.Fprintln(w, string(ev.Raw)); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeHTML(w io.Writer, data SessionExport) error {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return htmlTemplate.Execute(w, struct {
+		Title string
+		Data  template.JS
+	}{
+		Title: "mcpsnoop " + data.Session.Label,
+		Data:  template.JS(payload),
+	})
+}
+
+func eventKind(k store.EventKind) string {
+	switch k {
+	case store.EventRequest:
+		return "request"
+	case store.EventResponse:
+		return "response"
+	case store.EventNotification:
+		return "notification"
+	case store.EventStderr:
+		return "stderr"
+	default:
+		return "other"
+	}
+}
+
+func callKey(c store.CallView) string {
+	return string(c.ReqDir) + "\x00" + c.ID
+}
+
+func formatDuration(ms *float64) string {
+	if ms == nil {
+		return "pending"
+	}
+	return fmt.Sprintf("%.3f", *ms)
+}
+
+func safeFileName(s string) string {
+	if s == "" {
+		return "session"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := strings.Trim(b.String(), "._-")
+	if out == "" {
+		return "session"
+	}
+	return out
+}
+
+func errPathNotFound(path string) error {
+	return fmt.Errorf("session log %q not found", path)
+}

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1,0 +1,85 @@
+package exporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func writeEnv(t *testing.T, path string, env proxy.Envelope) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sampleLog(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`),
+	})
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: t0.Add(25 * time.Millisecond),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"content":[],"isError":false}}`),
+	})
+	return path
+}
+
+func TestBuildCorrelatedExport(t *testing.T) {
+	st, id, err := LoadFile(sampleLog(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Session.ID != "s1" || out.Session.Requests != 1 || out.Session.Responses != 1 {
+		t.Fatalf("bad summary: %+v", out.Session)
+	}
+	if len(out.Calls) != 1 || out.Calls[0].ToolName != "echo" || out.Calls[0].DurationMS == nil {
+		t.Fatalf("bad calls: %+v", out.Calls)
+	}
+	if len(out.Events) != 2 || out.Events[1].CallIndex == nil || *out.Events[1].CallIndex != 0 {
+		t.Fatalf("bad event correlation: %+v", out.Events)
+	}
+}
+
+func TestWriteFormats(t *testing.T) {
+	st, id, err := LoadFile(sampleLog(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, format := range []Format{FormatJSON, FormatHTML, FormatText} {
+		var buf bytes.Buffer
+		if err := Write(&buf, out, Options{Format: format}); err != nil {
+			t.Fatalf("%s write failed: %v", format, err)
+		}
+		got := buf.String()
+		if !strings.Contains(got, "echo") {
+			t.Fatalf("%s export missing tool name:\n%s", format, got)
+		}
+	}
+}

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -1,0 +1,113 @@
+package exporter
+
+import "html/template"
+
+var htmlTemplate = template.Must(template.New("html").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{.Title}}</title>
+<style>
+:root { color-scheme: light dark; --bg:#f8f8f5; --fg:#202124; --muted:#6b6f76; --line:#d8d9d3; --panel:#ffffff; --accent:#0b6f6a; --err:#b3261e; --code:#f0f1ec; }
+@media (prefers-color-scheme: dark) { :root { --bg:#171817; --fg:#eceee8; --muted:#aeb4ad; --line:#343832; --panel:#20221f; --accent:#53c2b8; --err:#ff8a80; --code:#151714; } }
+* { box-sizing: border-box; }
+body { margin:0; background:var(--bg); color:var(--fg); font:14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+header { position:sticky; top:0; z-index:2; padding:18px 24px 14px; background:color-mix(in srgb, var(--bg) 92%, transparent); border-bottom:1px solid var(--line); backdrop-filter:blur(10px); }
+h1 { margin:0 0 10px; font-size:22px; letter-spacing:0; }
+.meta { display:flex; flex-wrap:wrap; gap:10px 18px; color:var(--muted); }
+.meta b, .pill b { color:var(--fg); font-weight:600; }
+.toolbar { margin-top:14px; display:flex; gap:10px; align-items:center; }
+input { width:min(680px, 100%); padding:9px 11px; border:1px solid var(--line); border-radius:6px; background:var(--panel); color:var(--fg); font:inherit; }
+main { padding:18px 24px 40px; max-width:1180px; margin:0 auto; }
+.section-title { margin:22px 0 10px; color:var(--muted); font-size:12px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:10px; }
+.pill { padding:10px 12px; border:1px solid var(--line); border-radius:6px; background:var(--panel); }
+.event { border:1px solid var(--line); border-radius:6px; background:var(--panel); margin:10px 0; overflow:hidden; }
+.event[hidden] { display:none; }
+.head { display:grid; grid-template-columns:72px 110px minmax(120px,1fr) 105px 100px; gap:10px; align-items:center; padding:10px 12px; border-bottom:1px solid var(--line); }
+.seq { color:var(--muted); font-variant-numeric:tabular-nums; }
+.dir { font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color:var(--accent); }
+.method { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.status { text-transform:uppercase; font-size:12px; font-weight:700; color:var(--muted); }
+.status.error { color:var(--err); }
+.time { color:var(--muted); font-variant-numeric:tabular-nums; }
+details { padding:10px 12px; }
+summary { cursor:pointer; color:var(--accent); user-select:none; }
+pre { margin:10px 0 0; padding:12px; overflow:auto; border-radius:6px; background:var(--code); font:12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.empty { color:var(--muted); padding:30px 0; }
+@media (max-width:720px) { header, main { padding-left:14px; padding-right:14px; } .head { grid-template-columns:56px 70px 1fr; } .status, .time { display:none; } }
+</style>
+</head>
+<body>
+<header>
+  <h1 id="title">mcpsnoop export</h1>
+  <div class="meta" id="meta"></div>
+  <div class="toolbar"><input id="q" type="search" placeholder="Search method, id, tool, status, direction, or JSON"></div>
+</header>
+<main>
+  <div class="section-title">Summary</div>
+  <div class="grid" id="summary"></div>
+  <div class="section-title">Events</div>
+  <div id="events"></div>
+</main>
+<script>
+const data = {{.Data}};
+const fmtTime = (s) => s ? new Date(s).toLocaleString() : "";
+const textOf = (v) => v == null ? "" : (typeof v === "string" ? v : JSON.stringify(v, null, 2));
+const compact = (v) => v == null ? "" : (typeof v === "string" ? v : JSON.stringify(v));
+const esc = (s) => String(s ?? "").replace(/[&<>"']/g, ch => ({ "&":"&amp;", "<":"&lt;", ">":"&gt;", '"':"&quot;", "'":"&#39;" }[ch]));
+document.title = "mcpsnoop " + (data.session.label || data.session.id);
+document.getElementById("title").textContent = data.session.label || data.session.id;
+document.getElementById("meta").innerHTML = [
+  "<span><b>" + esc(data.session.id) + "</b></span>",
+  "<span>" + esc(fmtTime(data.session.first)) + "</span>",
+  "<span>" + data.events.length + " frames</span>",
+  "<span>" + data.calls.length + " calls</span>"
+].join("");
+document.getElementById("summary").innerHTML = [
+  ["Requests", data.session.requests],
+  ["Responses", data.session.responses],
+  ["Notifications", data.session.notifications],
+  ["Errors", data.session.errors],
+  ["Pending", data.session.pending],
+  ["Protocol", data.capabilities?.protocol_version || ""]
+].map(([k,v]) => "<div class=\"pill\">" + esc(k) + "<br><b>" + esc(v) + "</b></div>").join("");
+const calls = data.calls || [];
+const events = data.events || [];
+const eventSearch = (ev) => {
+  const call = ev.call_index == null ? null : calls[ev.call_index];
+  return [
+    ev.seq, ev.direction, ev.kind, ev.method, ev.id, ev.text, compact(ev.raw),
+    call?.method, call?.status, call?.tool_name, call?.id, compact(call?.params), compact(call?.result), compact(call?.error)
+  ].join(" ").toLowerCase();
+};
+const renderEvent = (ev) => {
+  const call = ev.call_index == null ? null : calls[ev.call_index];
+  const status = call?.status || "";
+  const raw = ev.text || textOf(ev.raw);
+  const callBlock = call ? "<details><summary>Correlated call</summary><pre>" + esc(JSON.stringify(call, null, 2)) + "</pre></details>" : "";
+  return "<article class=\"event\" data-search=\"" + esc(eventSearch(ev)) + "\">" +
+    "<div class=\"head\">" +
+      "<div class=\"seq\">#" + ev.seq + "</div>" +
+      "<div class=\"dir\">" + esc(ev.direction) + " " + esc(ev.kind) + "</div>" +
+      "<div class=\"method\">" + esc(ev.method || ev.id || ev.text || "") + "</div>" +
+      "<div class=\"status " + (status === "error" ? "error" : "") + "\">" + esc(status) + "</div>" +
+      "<div class=\"time\">" + esc(fmtTime(ev.timestamp)) + "</div>" +
+    "</div>" +
+    "<details open><summary>Frame</summary><pre>" + esc(raw) + "</pre></details>" +
+    callBlock +
+  "</article>";
+};
+const list = document.getElementById("events");
+list.innerHTML = events.length ? events.map(renderEvent).join("") : "<div class=\"empty\">No events</div>";
+document.getElementById("q").addEventListener("input", (e) => {
+  const q = e.target.value.trim().toLowerCase();
+  for (const row of document.querySelectorAll(".event")) {
+    row.hidden = q && !row.dataset.search.includes(q);
+  }
+});
+</script>
+</body>
+</html>
+`))

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -46,6 +46,13 @@ func SessionsDir() string {
 	return d
 }
 
+// ExportsDir holds files written from the TUI export action.
+func ExportsDir() string {
+	d := filepath.Join(Base(), "exports")
+	_ = os.MkdirAll(d, 0o700)
+	return d
+}
+
 // SessionLogPath returns the JSONL trace path for a given session id.
 func SessionLogPath(sessionID string) string {
 	return filepath.Join(SessionsDir(), sessionID+".jsonl")

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -24,6 +24,7 @@ type keyMap struct {
 	Pause  key.Binding
 	Follow key.Binding
 	Copy   key.Binding
+	Export key.Binding
 	Delete key.Binding
 
 	Quit key.Binding
@@ -49,6 +50,7 @@ func defaultKeys() keyMap {
 		Pause:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
 		Follow: key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
 		Copy:   key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
+		Export: key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
 		Delete: key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
 
 		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp(":q", "quit")),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"cmp"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
@@ -276,6 +278,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keys.Copy):
 		m.copyCurrent()
+	case key.Matches(msg, m.keys.Export):
+		m.exportCurrent("", "")
 	case key.Matches(msg, m.keys.Delete):
 		m.deleteCurrentSession()
 
@@ -336,9 +340,14 @@ func (m Model) handleInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 	}
 }
 
-// runCommand handles ":" commands: q/quit, sessions, stream, or a session name.
+// runCommand handles ":" commands: q/quit, sessions, stream, export, or a session name.
 func (m Model) runCommand(cmd string) (Model, tea.Cmd) {
-	switch strings.ToLower(cmd) {
+	fields := strings.Fields(cmd)
+	base := strings.ToLower(cmd)
+	if len(fields) > 0 {
+		base = strings.ToLower(fields[0])
+	}
+	switch base {
 	case "":
 		return m, nil
 	case "q", "quit", "exit":
@@ -355,6 +364,16 @@ func (m Model) runCommand(cmd string) (Model, tea.Cmd) {
 			m.enterStream(m.selSession)
 		}
 		return m, nil
+	case "export":
+		format, out := "", ""
+		if len(fields) > 1 {
+			format = fields[1]
+		}
+		if len(fields) > 2 {
+			out = fields[2]
+		}
+		m.exportCurrent(format, out)
+		return m, nil
 	}
 	// Otherwise treat it as a session-name jump.
 	for i, s := range m.sessions {
@@ -370,7 +389,7 @@ func (m *Model) openInput(mode inputMode) {
 	m.inputMode = mode
 	if mode == inputCommand {
 		m.input.Prompt = ":"
-		m.input.Placeholder = "sessions · stream · <name> · q"
+		m.input.Placeholder = "sessions · stream · export [format] [path] · <name> · q"
 		m.input.SetValue("")
 	} else {
 		m.input.Prompt = "/"
@@ -823,6 +842,49 @@ func (m *Model) copyCurrent() {
 		return
 	}
 	m.setFlash("✓ copied " + label)
+}
+
+// exportCurrent writes the selected/open session to a portable file.
+func (m *Model) exportCurrent(formatArg, outPath string) {
+	id := m.currentSessionID()
+	if id == "" {
+		return
+	}
+	format := exporter.FormatHTML
+	if formatArg != "" {
+		var err error
+		format, err = exporter.ParseFormat(formatArg)
+		if err != nil {
+			m.setFlash("export failed: bad format")
+			return
+		}
+	}
+	data, err := exporter.Build(m.store, id)
+	if err != nil {
+		m.setFlash("export failed")
+		return
+	}
+	if outPath == "" {
+		outPath = exporter.DefaultOutputPath(id, format)
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o700); err != nil {
+		m.setFlash("export failed")
+		return
+	}
+	f, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		m.setFlash("export failed")
+		return
+	}
+	err = exporter.Write(f, data, exporter.Options{Format: format})
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		m.setFlash("export failed")
+		return
+	}
+	m.setFlash("✓ exported " + outPath)
 }
 
 // deleteCurrentSession removes the selected/open session and its on-disk log.

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -154,7 +154,7 @@ func (m Model) headerHints() string {
 		hs = []hint{
 			{"enter", "Inspect"}, {"r", "Replay"},
 			{"c", "Caps"}, {"y", "Copy JSON"},
-			{"/", "Filter"}, {"p", "Pause"},
+			{"e", "Export"}, {"/", "Filter"}, {"p", "Pause"},
 			{"f", "Follow"}, {"esc", "Back"},
 			{":", "Command"}, {"?", "Help"},
 			{"ctrl-d", "Delete"}, {":q", "Quit"},
@@ -162,7 +162,8 @@ func (m Model) headerHints() string {
 	} else {
 		hs = []hint{
 			{"enter", "Open"}, {"/", "Filter"},
-			{"y", "Copy path"}, {":", "Command"},
+			{"y", "Copy path"}, {"e", "Export"},
+			{":", "Command"},
 			{"g/G", "Top/Bot"}, {"ctrl-f", "Page"},
 			{"ctrl-d", "Delete"}, {"p", "Pause"},
 			{"?", "Help"}, {":q", "Quit"},
@@ -449,7 +450,7 @@ func (m Model) renderHelp(h int) string {
 		}},
 		{"VIEWS & SEARCH", [][2]string{
 			{"/", "filter the current table"},
-			{":", "command: sessions · stream · <name> · q"},
+			{":", "command: sessions · stream · export [format] [path] · <name> · q"},
 			{"shift+N/R/S/E/L", "sort sessions (name/req/resp/err/last)"},
 			{"shift+T/M/I/D/S", "sort stream (time/method/id/dur/status)"},
 			{"?", "toggle this help"},
@@ -475,6 +476,7 @@ func (m Model) renderHelp(h int) string {
 		}},
 		{"MANAGE", [][2]string{
 			{"y", "copy frame JSON / session log path"},
+			{"e", "export selected session as HTML"},
 			{"ctrl-d", "delete the selected session (and its log)"},
 		}},
 		{"GENERAL", [][2]string{


### PR DESCRIPTION
feat: add session export with text/json/html view

## What and why

Adds a `mcpsnoop export` command for turning saved JSONL sessions into portable
artifacts after the fact.

The command supports `-T json|html|text` and can write either to a file or
stdout. JSON exports include the derived session model, not just raw envelopes:
correlated request/response calls, durations, status, MCP tool-level
`isError`, capabilities, and the original frames. HTML exports produce a
self-contained browser-readable file with search and collapsible JSON, so users
can inspect or share a captured session without running a live web UI. Text
exports provide a lightweight pretty dump for terminal use.

The TUI also gets an export action: `e` writes the selected session as HTML, and
`:export json|html|text [path]` allows choosing the format and destination.

The PR solves issue #23 

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
