### PR TITLE
feat: implement open command

### DIFF
--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/store"
 	"github.com/kerlenton/mcpsnoop/internal/tui"
 )
 
@@ -312,5 +313,43 @@ func runHub() int {
 
 // runOpen opens a persisted JSONL session directly in the TUI.
 func runOpen(args []string) int {
-	panic("TODO")
+	fs := flag.NewFlagSet("mcpsnoop open", flag.ExitOnError)
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop open <session.jsonl>\n\n")
+		fmt.Fprintf(os.Stderr, "Open a persisted session log directly in the TUI.\n")
+	}
+
+	_ = fs.Parse(args)
+
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+
+	path := fs.Arg(0)
+
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+		return 1
+	}
+	defer f.Close()
+	st := store.New(0)
+	err = proxy.Decode(f, func(e proxy.Envelope) {
+		st.Ingest(e)
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+		return 1
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := tui.RunOpen(ctx, st); err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+		return 1
+	}
+
+	return 0
 }

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -54,6 +54,10 @@ func main() {
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "export" {
 		os.Exit(runExport(args[1:]))
 	}
+	// `mcpsnoop open <session.jsonl>` opens a session file directly in the TUI.
+	if args := os.Args[1:]; len(args) > 0 && args[0] == "open" {
+		os.Exit(runOpen(args[1:]))
+	}
 	// `mcpsnoop version` mirrors the --version flag (what most CLIs expect).
 	if args := os.Args[1:]; len(args) == 1 && (args[0] == "version" || args[0] == "-v") {
 		fmt.Println("mcpsnoop", appVersion())
@@ -304,4 +308,9 @@ func runHub() int {
 		return 1
 	}
 	return 0
+}
+
+// runOpen opens a persisted JSONL session directly in the TUI.
+func runOpen(args []string) int {
+	panic("TODO")
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -147,13 +147,21 @@ func (h *Hub) replayFile(path string) {
 		return
 	}
 	defer f.Close()
-	dec := json.NewDecoder(f)
+	_ = decodeEnvelopes(f, h.emit)
+}
+
+func decodeEnvelopes(r io.Reader, emit func(proxy.Envelope)) error {
+	dec := json.NewDecoder(r)
+
 	for {
 		var env proxy.Envelope
 		if err := dec.Decode(&env); err != nil {
-			return
+			if err == io.EOF {
+				return nil
+			}
+			return err
 		}
-		h.emit(env)
+		emit(env)
 	}
 }
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -147,22 +147,7 @@ func (h *Hub) replayFile(path string) {
 		return
 	}
 	defer f.Close()
-	_ = decodeEnvelopes(f, h.emit)
-}
-
-func decodeEnvelopes(r io.Reader, emit func(proxy.Envelope)) error {
-	dec := json.NewDecoder(r)
-
-	for {
-		var env proxy.Envelope
-		if err := dec.Decode(&env); err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			return err
-		}
-		emit(env)
-	}
+	_ = proxy.Decode(f, h.emit)
 }
 
 // emit deduplicates by per-session high-water-mark on Seq, then forwards.

--- a/internal/proxy/decode.go
+++ b/internal/proxy/decode.go
@@ -2,16 +2,20 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 )
 
+// Decode reads a stream of JSON-encoded envelopes from r and calls emit for
+// each decoded envelope. io.EOF and io.ErrUnexpectedEOF are treated as clean
+// ends of the input.
 func Decode(r io.Reader, emit func(Envelope)) error {
 	dec := json.NewDecoder(r)
 
 	for {
 		var env Envelope
 		if err := dec.Decode(&env); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				return nil
 			}
 			return err

--- a/internal/proxy/decode.go
+++ b/internal/proxy/decode.go
@@ -1,0 +1,21 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func Decode(r io.Reader, emit func(Envelope)) error {
+	dec := json.NewDecoder(r)
+
+	for {
+		var env Envelope
+		if err := dec.Decode(&env); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		emit(env)
+	}
+}

--- a/internal/proxy/decode_test.go
+++ b/internal/proxy/decode_test.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecode_EmitsBeforeError(t *testing.T) {
+	input := strings.Join([]string{
+		`{"session_id":"1"}`,
+		`{"session_id":"2"}`,
+		`not json`,
+	}, "\n")
+
+	count := 0
+	err := Decode(strings.NewReader(input), func(Envelope) {
+		count++
+	})
+
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 envelopes, got %d", count)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -135,7 +135,8 @@ func (m Model) flashActive() bool {
 func New(st *store.Store) Model {
 	ti := textinput.New()
 	ti.Prompt = ""
-	return Model{
+
+	m := Model{
 		store:  st,
 		keys:   defaultKeys(),
 		styles: newStyles(),
@@ -143,6 +144,10 @@ func New(st *store.Store) Model {
 		follow: true,
 		input:  ti,
 	}
+
+	m.refresh()
+
+	return m
 }
 
 func (m Model) Init() tea.Cmd { return tick() }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -36,3 +36,13 @@ func Run(ctx context.Context, socketPath, sessionsDir string, slow time.Duration
 	}
 	return err
 }
+
+func RunOpen(ctx context.Context, st *store.Store) error {
+	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
+
+	_, err := p.Run()
+	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -37,6 +37,7 @@ func Run(ctx context.Context, socketPath, sessionsDir string, slow time.Duration
 	return err
 }
 
+// RunOpen starts the TUI using a preloaded store without starting the live hub.
 func RunOpen(ctx context.Context, st *store.Store) error {
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
 


### PR DESCRIPTION
Implements the `mcpsnoop open` command.

- load a saved JSONL session into a fresh Store
- reuse `proxy.Decode` for reading envelopes
- open the session directly in the TUI without starting the hub

Closes #25