### PR TITLE
feat: add trace redaction keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ mcpsnoop http --target http://localhost:3000/mcp --listen :7000
 ```
 
 If payloads can contain secrets, opt in to key-based trace redaction. Matching
-JSON fields are scrubbed in saved session logs, while the proxied bytes still
-pass through unchanged.
+JSON fields are scrubbed in observed trace copies, while the proxied bytes still
+pass through unchanged. Redaction is best effort: it only scrubs values under
+matching JSON object keys, so secrets in stderr text, string values under other
+keys, or frames that are not valid JSON pass through.
 
 ```bash
 mcpsnoop --redact-key token,api_key,password -- node build/index.js

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mcpsnoop http --target http://localhost:3000/mcp --listen :7000
 
 If payloads can contain secrets, opt in to key-based trace redaction. Matching
 JSON fields are scrubbed in observed trace copies, while the proxied bytes still
-pass through unchanged. Redaction is best effort: it only scrubs values under
+pass through unchanged. Redaction is best effort and only scrubs values under
 matching JSON object keys, so secrets in stderr text, string values under other
 keys, or frames that are not valid JSON pass through.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ For a streamable-HTTP server, run mcpsnoop as a reverse proxy.
 mcpsnoop http --target http://localhost:3000/mcp --listen :7000
 ```
 
+If payloads can contain secrets, opt in to key-based trace redaction. Matching
+JSON fields are scrubbed in saved session logs, while the proxied bytes still
+pass through unchanged.
+
+```bash
+mcpsnoop --redact-key token,api_key,password -- node build/index.js
+mcpsnoop http --target http://localhost:3000/mcp --redact-key authorization
+```
+
 No server of your own? [Try it for real](docs/TRY_IT.md) against a published
 test server, driven by your own client. To inspect a session after it happened,
 see [review past sessions from logs](docs/POST_MORTEM.md).

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -45,6 +45,29 @@ func appVersion() string {
 	return version
 }
 
+type redactKeysFlag []string
+
+func (f *redactKeysFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	return strings.Join(*f, ",")
+}
+
+func (f *redactKeysFlag) Set(value string) error {
+	for _, key := range strings.Split(value, ",") {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			*f = append(*f, key)
+		}
+	}
+	return nil
+}
+
+func (f redactKeysFlag) config() proxy.RedactConfig {
+	return proxy.RedactConfig{Keys: []string(f)}
+}
+
 func main() {
 	// `mcpsnoop http ...` is a separate subcommand with its own flags.
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "http" {
@@ -65,12 +88,14 @@ func main() {
 	}
 
 	fs := flag.NewFlagSet("mcpsnoop", flag.ExitOnError)
+	var redactKeys redactKeysFlag
 	var (
 		label     = fs.String("label", "", "server label shown in the TUI (default: command name)")
 		traceFile = fs.String("trace-file", "", "override the JSONL trace path (default: well-known session log)")
 		noTrace   = fs.Bool("no-trace", false, "disable tracing; pure passthrough")
 		showVer   = fs.Bool("version", false, "print version and exit")
 	)
+	fs.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads (repeat or comma-separated)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "mcpsnoop %s — Wireshark for MCP\n\n", appVersion())
 		fmt.Fprintf(os.Stderr, "Usage:\n")
@@ -90,7 +115,7 @@ func main() {
 	}
 
 	if command := fs.Args(); len(command) > 0 {
-		os.Exit(runShim(command, *label, *traceFile, *noTrace))
+		os.Exit(runShim(command, *label, *traceFile, *noTrace, redactKeys.config()))
 	}
 	os.Exit(runHub())
 }
@@ -201,13 +226,13 @@ func runExport(args []string) int {
 
 // runShim runs the transparent stdio proxy. It writes the durable session log
 // AND streams live to the hub; neither has to be running first.
-func runShim(command []string, label, traceFile string, noTrace bool) int {
+func runShim(command []string, label, traceFile string, noTrace bool, redaction proxy.RedactConfig) int {
 	if label == "" {
 		label = labelFor(command)
 	}
 	sessionID := fmt.Sprintf("%s-%d", label, os.Getpid())
 
-	sink := traceSink(sessionID, traceFile, noTrace)
+	sink := traceSink(sessionID, traceFile, noTrace, redaction)
 	defer sink.Close()
 	if !noTrace {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: tracing %q (session %s)\n", strings.Join(command, " "), sessionID)
@@ -233,7 +258,7 @@ func runShim(command []string, label, traceFile string, noTrace bool) int {
 
 // traceSink builds the shared sink: a durable per-session JSONL log plus a
 // best-effort live stream to the hub. Returns a no-op sink when disabled.
-func traceSink(sessionID, traceFile string, noTrace bool) proxy.Sink {
+func traceSink(sessionID, traceFile string, noTrace bool, redaction proxy.RedactConfig) proxy.Sink {
 	if noTrace {
 		return proxy.NopSink()
 	}
@@ -244,7 +269,11 @@ func traceSink(sessionID, traceFile string, noTrace bool) proxy.Sink {
 	if f, err := os.OpenFile(traceFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: cannot open trace file %q: %v (continuing without file trace)\n", traceFile, err)
 	} else {
-		sinks = append(sinks, proxy.NewAsyncSink(f, 0))
+		fileSink := proxy.Sink(proxy.NewAsyncSink(f, 0))
+		if redaction.Enabled() {
+			fileSink = proxy.NewRedactingSink(fileSink, redaction)
+		}
+		sinks = append(sinks, fileSink)
 	}
 	sinks = append(sinks, proxy.NewSocketSink(paths.SocketPath(), 0))
 	return proxy.NewMultiSink(sinks...)
@@ -253,12 +282,14 @@ func traceSink(sessionID, traceFile string, noTrace bool) proxy.Sink {
 // runHTTP runs the transparent HTTP proxy subcommand.
 func runHTTP(args []string) int {
 	fs := flag.NewFlagSet("mcpsnoop http", flag.ExitOnError)
+	var redactKeys redactKeysFlag
 	var (
 		target  = fs.String("target", "", "real MCP server endpoint, e.g. http://localhost:3000/mcp (required)")
 		listen  = fs.String("listen", ":7000", "address to listen on")
 		label   = fs.String("label", "", "server label shown in the TUI (default: target host)")
 		noTrace = fs.Bool("no-trace", false, "disable tracing; pure passthrough")
 	)
+	fs.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads (repeat or comma-separated)")
 	_ = fs.Parse(args)
 	if *target == "" {
 		fmt.Fprintln(os.Stderr, "mcpsnoop http: --target is required")
@@ -274,7 +305,7 @@ func runHTTP(args []string) int {
 	}
 	sessionID := fmt.Sprintf("%s-%d", lbl, os.Getpid())
 
-	sink := traceSink(sessionID, "", *noTrace)
+	sink := traceSink(sessionID, "", *noTrace, redactKeys.config())
 	defer sink.Close()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -269,14 +269,14 @@ func traceSink(sessionID, traceFile string, noTrace bool, redaction proxy.Redact
 	if f, err := os.OpenFile(traceFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: cannot open trace file %q: %v (continuing without file trace)\n", traceFile, err)
 	} else {
-		fileSink := proxy.Sink(proxy.NewAsyncSink(f, 0))
-		if redaction.Enabled() {
-			fileSink = proxy.NewRedactingSink(fileSink, redaction)
-		}
-		sinks = append(sinks, fileSink)
+		sinks = append(sinks, proxy.NewAsyncSink(f, 0))
 	}
 	sinks = append(sinks, proxy.NewSocketSink(paths.SocketPath(), 0))
-	return proxy.NewMultiSink(sinks...)
+	sink := proxy.Sink(proxy.NewMultiSink(sinks...))
+	if redaction.Enabled() {
+		sink = proxy.NewRedactingSink(sink, redaction)
+	}
+	return sink
 }
 
 // runHTTP runs the transparent HTTP proxy subcommand.

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 )
 
@@ -48,18 +52,66 @@ func TestRedactKeysFlagParsesCommaSeparatedAndRepeatedValues(t *testing.T) {
 	}
 }
 
-func TestTraceSinkRedactsSavedTrace(t *testing.T) {
+func TestTraceSinkRedactsFileAndLiveSocket(t *testing.T) {
+	stateDir := filepath.Join(os.TempDir(), fmt.Sprintf("mcpsnoop-test-%d", os.Getpid()))
+	if err := os.RemoveAll(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stateDir) })
+	t.Setenv("MCPSNOOP_HOME", stateDir)
+
+	ln, err := net.Listen("unix", paths.SocketPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	live := make(chan proxy.Envelope, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		defer conn.Close()
+
+		var env proxy.Envelope
+		if err := json.NewDecoder(conn).Decode(&env); err != nil {
+			acceptErr <- err
+			return
+		}
+		live <- env
+	}()
+
 	traceFile := filepath.Join(t.TempDir(), "session.jsonl")
 	sink := traceSink("s1", traceFile, false, proxy.RedactConfig{Keys: []string{"token"}})
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = sink.Close()
+		}
+	})
 
 	sink.Emit(proxy.Envelope{
 		SessionID: "s1",
 		Direction: proxy.ClientToServer,
 		Raw:       json.RawMessage(`{"params":{"token":"secret","keep":"visible"}}`),
 	})
+
+	select {
+	case got := <-live:
+		assertRawTokenRedacted(t, got.Raw)
+	case err := <-acceptErr:
+		t.Fatal(err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for redacted live socket envelope")
+	}
+
 	if err := sink.Close(); err != nil {
 		t.Fatal(err)
 	}
+	closed = true
 
 	data, err := os.ReadFile(traceFile)
 	if err != nil {
@@ -72,11 +124,19 @@ func TestTraceSinkRedactsSavedTrace(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("trace is invalid JSONL envelope: %v", err)
 	}
-	var raw map[string]any
-	if err := json.Unmarshal(got.Raw, &raw); err != nil {
+	assertRawTokenRedacted(t, got.Raw)
+}
+
+func assertRawTokenRedacted(t *testing.T, raw json.RawMessage) {
+	t.Helper()
+	if strings.Contains(string(raw), "secret") {
+		t.Fatalf("raw payload contains unredacted secret: %s", raw)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
 		t.Fatalf("raw payload is invalid JSON: %v", err)
 	}
-	params := raw["params"].(map[string]any)
+	params := payload["params"].(map[string]any)
 	if params["token"] != "[REDACTED]" {
 		t.Fatalf("token = %v, want redacted", params["token"])
 	}

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -1,6 +1,15 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
 
 func TestLabelFor(t *testing.T) {
 	cases := []struct {
@@ -19,5 +28,59 @@ func TestLabelFor(t *testing.T) {
 		if got := labelFor(c.cmd); got != c.want {
 			t.Errorf("labelFor(%v) = %q, want %q", c.cmd, got, c.want)
 		}
+	}
+}
+
+func TestRedactKeysFlagParsesCommaSeparatedAndRepeatedValues(t *testing.T) {
+	var flag redactKeysFlag
+	if err := flag.Set("token, api_key"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Set("password"); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := flag.config().Keys, []string{"token", "api_key", "password"}; !slices.Equal(got, want) {
+		t.Fatalf("keys = %v, want %v", got, want)
+	}
+	if got := flag.String(); got != "token,api_key,password" {
+		t.Fatalf("String() = %q, want token,api_key,password", got)
+	}
+}
+
+func TestTraceSinkRedactsSavedTrace(t *testing.T) {
+	traceFile := filepath.Join(t.TempDir(), "session.jsonl")
+	sink := traceSink("s1", traceFile, false, proxy.RedactConfig{Keys: []string{"token"}})
+
+	sink.Emit(proxy.Envelope{
+		SessionID: "s1",
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"params":{"token":"secret","keep":"visible"}}`),
+	})
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(traceFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "secret") {
+		t.Fatalf("trace contains unredacted secret: %s", data)
+	}
+	var got proxy.Envelope
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("trace is invalid JSONL envelope: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(got.Raw, &raw); err != nil {
+		t.Fatalf("raw payload is invalid JSON: %v", err)
+	}
+	params := raw["params"].(map[string]any)
+	if params["token"] != "[REDACTED]" {
+		t.Fatalf("token = %v, want redacted", params["token"])
+	}
+	if params["keep"] != "visible" {
+		t.Fatalf("keep = %v, want visible", params["keep"])
 	}
 }

--- a/docs/POST_MORTEM.md
+++ b/docs/POST_MORTEM.md
@@ -65,6 +65,13 @@ lives outside the sessions directory it will not show up in the backfill on a
 later start. For a session that reappears automatically, leave `--trace-file`
 off and use the default location.
 
+To keep common secret fields out of saved traces, pass one or more
+`--redact-key` values when you wrap the server.
+
+```bash
+mcpsnoop --redact-key token --redact-key api_key -- node build/index.js
+```
+
 ## What to include in a bug report
 
 A useful report about a past session covers a few things.

--- a/internal/proxy/redact.go
+++ b/internal/proxy/redact.go
@@ -1,0 +1,125 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+const redactedValue = "[REDACTED]"
+
+// RedactConfig configures best-effort scrubbing for observed trace copies.
+type RedactConfig struct {
+	// Keys are JSON object field names whose values should be replaced.
+	Keys []string
+}
+
+// Enabled reports whether cfg has any key-based redaction rule.
+func (cfg RedactConfig) Enabled() bool {
+	for _, key := range cfg.Keys {
+		if strings.TrimSpace(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// Redactor redacts JSON payloads according to a prepared config.
+type Redactor struct {
+	keys map[string]struct{}
+}
+
+// NewRedactor prepares cfg for repeated use.
+func NewRedactor(cfg RedactConfig) Redactor {
+	keys := make(map[string]struct{})
+	for _, key := range cfg.Keys {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key != "" {
+			keys[key] = struct{}{}
+		}
+	}
+	return Redactor{keys: keys}
+}
+
+func (r Redactor) enabled() bool { return len(r.keys) > 0 }
+
+// RedactEnvelope returns a copy of env with matching JSON Raw fields scrubbed.
+func (r Redactor) RedactEnvelope(env Envelope) Envelope {
+	if !r.enabled() || len(env.Raw) == 0 {
+		return env
+	}
+	redacted, ok := r.redactRaw(env.Raw)
+	if !ok {
+		return env
+	}
+	env.Raw = redacted
+	return env
+}
+
+func (r Redactor) redactRaw(raw json.RawMessage) (json.RawMessage, bool) {
+	var v any
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&v); err != nil {
+		return nil, false
+	}
+	if !r.redactValue(v) {
+		return nil, false
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+func (r Redactor) redactValue(v any) bool {
+	switch x := v.(type) {
+	case map[string]any:
+		changed := false
+		for key, child := range x {
+			if _, ok := r.keys[strings.ToLower(key)]; ok {
+				x[key] = redactedValue
+				changed = true
+				continue
+			}
+			if r.redactValue(child) {
+				changed = true
+			}
+		}
+		return changed
+	case []any:
+		changed := false
+		for _, child := range x {
+			if r.redactValue(child) {
+				changed = true
+			}
+		}
+		return changed
+	default:
+		return false
+	}
+}
+
+type redactingSink struct {
+	next     Sink
+	redactor Redactor
+}
+
+// NewRedactingSink wraps next and scrubs envelopes before forwarding them.
+func NewRedactingSink(next Sink, cfg RedactConfig) Sink {
+	if next == nil {
+		next = NopSink()
+	}
+	redactor := NewRedactor(cfg)
+	if !redactor.enabled() {
+		return next
+	}
+	return &redactingSink{next: next, redactor: redactor}
+}
+
+func (s *redactingSink) Emit(env Envelope) {
+	s.next.Emit(s.redactor.RedactEnvelope(env))
+}
+
+func (s *redactingSink) Close() error { return s.next.Close() }

--- a/internal/proxy/redact_test.go
+++ b/internal/proxy/redact_test.go
@@ -1,0 +1,83 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRedactingSinkScrubsMatchingKeysRecursively(t *testing.T) {
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{
+		Keys: []string{"authorization", "token", "api_key", "password"},
+	})
+
+	redacted.Emit(Envelope{
+		Raw: json.RawMessage(`{
+			"jsonrpc":"2.0",
+			"id":1,
+			"method":"tools/call",
+			"params":{
+				"authorization":"Bearer secret",
+				"arguments":{
+					"token":"abc123",
+					"nested":[{"api_key":"k-123","keep":"visible"}],
+					"Password":{"inner":"secret"}
+				}
+			}
+		}`),
+		Text: "stderr token=secret",
+	})
+
+	got := sink.byDir("")[0]
+	if got.Text != "stderr token=secret" {
+		t.Fatalf("Text = %q, want unchanged stderr text", got.Text)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(got.Raw, &obj); err != nil {
+		t.Fatalf("redacted Raw is invalid JSON: %v", err)
+	}
+	params := obj["params"].(map[string]any)
+	if params["authorization"] != redactedValue {
+		t.Fatalf("authorization = %v, want redacted", params["authorization"])
+	}
+	args := params["arguments"].(map[string]any)
+	if args["token"] != redactedValue {
+		t.Fatalf("token = %v, want redacted", args["token"])
+	}
+	if args["Password"] != redactedValue {
+		t.Fatalf("Password = %v, want redacted case-insensitively", args["Password"])
+	}
+	nested := args["nested"].([]any)[0].(map[string]any)
+	if nested["api_key"] != redactedValue {
+		t.Fatalf("api_key = %v, want redacted", nested["api_key"])
+	}
+	if nested["keep"] != "visible" {
+		t.Fatalf("keep = %v, want visible", nested["keep"])
+	}
+}
+
+func TestRedactingSinkLeavesPayloadUnchangedWithoutConfig(t *testing.T) {
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{})
+	raw := json.RawMessage(`{"params":{"token":"abc123"}}`)
+
+	redacted.Emit(Envelope{Raw: raw})
+
+	got := sink.byDir("")[0]
+	if string(got.Raw) != string(raw) {
+		t.Fatalf("Raw = %s, want unchanged %s", got.Raw, raw)
+	}
+}
+
+func TestRedactingSinkLeavesInvalidJSONUnchanged(t *testing.T) {
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{Keys: []string{"token"}})
+	raw := json.RawMessage(`{"params":{"token":`)
+
+	redacted.Emit(Envelope{Raw: raw})
+
+	got := sink.byDir("")[0]
+	if string(got.Raw) != string(raw) {
+		t.Fatalf("Raw = %s, want unchanged %s", got.Raw, raw)
+	}
+}


### PR DESCRIPTION
## Summary
- Add opt-in `--redact-key` parsing for stdio and HTTP shim modes.
- Scrub matching JSON object keys recursively before observed trace copies are written or streamed.
- Document key-based trace redaction and its best-effort limits.

## Scope
This redacts trace copies that feed the JSONL log, export, live TUI, and `y` copy path. The proxied client/server bytes remain unchanged, preserving the transparency contract.

## Validation
- `PATH="$PATH:$(go env GOPATH)/bin" make check`
  - `go vet ./...`
  - `staticcheck ./...`
  - `go test -race ./...`

Fixes #20

AI assistance: Implemented with AI assistance from OpenAI Codex; I reviewed the diff and ran the validation above.