### PR TITLE
feat: add common secret redaction preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ JSON object keys, so secrets in stderr text, string values under other keys, or
 non-JSON frames pass through.
 
 ```bash
+mcpsnoop --redact-secrets -- node build/index.js
 mcpsnoop --redact-key token,api_key,password -- node build/index.js
-mcpsnoop http --target http://localhost:3000/mcp --redact-key authorization
+mcpsnoop http --target http://localhost:3000/mcp --redact-secrets --redact-key authorization
 ```
 
 For remote workflows, use SSH tunnelling or SSH file transfer so transport auth,

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -65,8 +65,11 @@ func (f *redactKeysFlag) Set(value string) error {
 	return nil
 }
 
-func (f redactKeysFlag) config() proxy.RedactConfig {
-	return proxy.RedactConfig{Keys: []string(f)}
+func (f redactKeysFlag) config(commonSecrets bool) proxy.RedactConfig {
+	return proxy.RedactConfig{
+		CommonSecrets: commonSecrets,
+		Keys:          []string(f),
+	}
 }
 
 func main() {
@@ -95,10 +98,11 @@ func main() {
 	fs := flag.NewFlagSet("mcpsnoop", flag.ExitOnError)
 	var redactKeys redactKeysFlag
 	var (
-		label     = fs.String("label", "", "server label shown in the TUI (default: command name)")
-		traceFile = fs.String("trace-file", "", "override the JSONL trace path (default: well-known session log)")
-		noTrace   = fs.Bool("no-trace", false, "disable tracing; pure passthrough")
-		showVer   = fs.Bool("version", false, "print version and exit")
+		label         = fs.String("label", "", "server label shown in the TUI (default: command name)")
+		traceFile     = fs.String("trace-file", "", "override the JSONL trace path (default: well-known session log)")
+		noTrace       = fs.Bool("no-trace", false, "disable tracing; pure passthrough")
+		redactSecrets = fs.Bool("redact-secrets", false, "scrub common secret JSON keys in trace payloads")
+		showVer       = fs.Bool("version", false, "print version and exit")
 	)
 	fs.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads (repeat or comma-separated)")
 	fs.Usage = func() {
@@ -120,7 +124,7 @@ func main() {
 	}
 
 	if command := fs.Args(); len(command) > 0 {
-		os.Exit(runShim(command, *label, *traceFile, *noTrace, redactKeys.config()))
+		os.Exit(runShim(command, *label, *traceFile, *noTrace, redactKeys.config(*redactSecrets)))
 	}
 	os.Exit(runHub())
 }
@@ -289,10 +293,11 @@ func runHTTP(args []string) int {
 	fs := flag.NewFlagSet("mcpsnoop http", flag.ExitOnError)
 	var redactKeys redactKeysFlag
 	var (
-		target  = fs.String("target", "", "real MCP server endpoint, e.g. http://localhost:3000/mcp (required)")
-		listen  = fs.String("listen", ":7000", "address to listen on")
-		label   = fs.String("label", "", "server label shown in the TUI (default: target host)")
-		noTrace = fs.Bool("no-trace", false, "disable tracing; pure passthrough")
+		target        = fs.String("target", "", "real MCP server endpoint, e.g. http://localhost:3000/mcp (required)")
+		listen        = fs.String("listen", ":7000", "address to listen on")
+		label         = fs.String("label", "", "server label shown in the TUI (default: target host)")
+		noTrace       = fs.Bool("no-trace", false, "disable tracing; pure passthrough")
+		redactSecrets = fs.Bool("redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	)
 	fs.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads (repeat or comma-separated)")
 	_ = fs.Parse(args)
@@ -310,7 +315,7 @@ func runHTTP(args []string) int {
 	}
 	sessionID := fmt.Sprintf("%s-%d", lbl, os.Getpid())
 
-	sink := traceSink(sessionID, "", *noTrace, redactKeys.config())
+	sink := traceSink(sessionID, "", *noTrace, redactKeys.config(*redactSecrets))
 	defer sink.Close()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -44,11 +44,30 @@ func TestRedactKeysFlagParsesCommaSeparatedAndRepeatedValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := flag.config().Keys, []string{"token", "api_key", "password"}; !slices.Equal(got, want) {
+	cfg := flag.config(false)
+	if cfg.CommonSecrets {
+		t.Fatal("CommonSecrets = true, want false")
+	}
+	if got, want := cfg.Keys, []string{"token", "api_key", "password"}; !slices.Equal(got, want) {
 		t.Fatalf("keys = %v, want %v", got, want)
 	}
 	if got := flag.String(); got != "token,api_key,password" {
 		t.Fatalf("String() = %q, want token,api_key,password", got)
+	}
+}
+
+func TestRedactKeysFlagConfigEnablesCommonSecretsPreset(t *testing.T) {
+	var flag redactKeysFlag
+	if err := flag.Set("custom_secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := flag.config(true)
+	if !cfg.CommonSecrets {
+		t.Fatal("CommonSecrets = false, want true")
+	}
+	if got, want := cfg.Keys, []string{"custom_secret"}; !slices.Equal(got, want) {
+		t.Fatalf("keys = %v, want %v", got, want)
 	}
 }
 

--- a/docs/POST_MORTEM.md
+++ b/docs/POST_MORTEM.md
@@ -65,11 +65,11 @@ lives outside the sessions directory it will not show up in the backfill on a
 later start. For a session that reappears automatically, leave `--trace-file`
 off and use the default location.
 
-To keep common secret fields out of saved traces, pass one or more
-`--redact-key` values when you wrap the server.
+To keep common secret fields out of saved traces, pass `--redact-secrets` when
+you wrap the server. Add `--redact-key` for project-specific fields.
 
 ```bash
-mcpsnoop --redact-key token --redact-key api_key -- node build/index.js
+mcpsnoop --redact-secrets --redact-key tenant_api_key -- node build/index.js
 ```
 
 ## What to include in a bug report

--- a/internal/proxy/redact.go
+++ b/internal/proxy/redact.go
@@ -8,14 +8,33 @@ import (
 
 const redactedValue = "[REDACTED]"
 
+var commonSecretRedactKeys = []string{
+	"token",
+	"api_key",
+	"apikey",
+	"password",
+	"passwd",
+	"secret",
+	"authorization",
+	"access_token",
+	"refresh_token",
+	"client_secret",
+}
+
 // RedactConfig configures best-effort scrubbing for observed trace copies.
 type RedactConfig struct {
+	// CommonSecrets enables a built-in preset of common secret field names.
+	CommonSecrets bool
+
 	// Keys are JSON object field names whose values should be replaced.
 	Keys []string
 }
 
 // Enabled reports whether cfg has any key-based redaction rule.
 func (cfg RedactConfig) Enabled() bool {
+	if cfg.CommonSecrets {
+		return true
+	}
 	for _, key := range cfg.Keys {
 		if strings.TrimSpace(key) != "" {
 			return true
@@ -32,13 +51,20 @@ type Redactor struct {
 // NewRedactor prepares cfg for repeated use.
 func NewRedactor(cfg RedactConfig) Redactor {
 	keys := make(map[string]struct{})
-	for _, key := range cfg.Keys {
+	if cfg.CommonSecrets {
+		addRedactKeys(keys, commonSecretRedactKeys)
+	}
+	addRedactKeys(keys, cfg.Keys)
+	return Redactor{keys: keys}
+}
+
+func addRedactKeys(keys map[string]struct{}, candidates []string) {
+	for _, key := range candidates {
 		key = strings.ToLower(strings.TrimSpace(key))
 		if key != "" {
 			keys[key] = struct{}{}
 		}
 	}
-	return Redactor{keys: keys}
 }
 
 func (r Redactor) enabled() bool { return len(r.keys) > 0 }

--- a/internal/proxy/redact_test.go
+++ b/internal/proxy/redact_test.go
@@ -56,6 +56,41 @@ func TestRedactingSinkScrubsMatchingKeysRecursively(t *testing.T) {
 	}
 }
 
+func TestRedactingSinkScrubsCommonSecretPresetAndExplicitKeys(t *testing.T) {
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{
+		CommonSecrets: true,
+		Keys:          []string{"custom_secret"},
+	})
+
+	redacted.Emit(Envelope{
+		Raw: json.RawMessage(`{
+			"params":{
+				"Authorization":"Bearer secret",
+				"apiKey":"key-123",
+				"client_secret":"client-123",
+				"custom_secret":"custom-123",
+				"keep":"visible"
+			}
+		}`),
+	})
+
+	got := sink.byDir("")[0]
+	var obj map[string]any
+	if err := json.Unmarshal(got.Raw, &obj); err != nil {
+		t.Fatalf("redacted Raw is invalid JSON: %v", err)
+	}
+	params := obj["params"].(map[string]any)
+	for _, key := range []string{"Authorization", "apiKey", "client_secret", "custom_secret"} {
+		if params[key] != redactedValue {
+			t.Fatalf("%s = %v, want redacted", key, params[key])
+		}
+	}
+	if params["keep"] != "visible" {
+		t.Fatalf("keep = %v, want visible", params["keep"])
+	}
+}
+
 func TestRedactingSinkLeavesPayloadUnchangedWithoutConfig(t *testing.T) {
 	sink := &captureSink{}
 	redacted := NewRedactingSink(sink, RedactConfig{})


### PR DESCRIPTION
## Summary

- add a `--redact-secrets` preset for common secret JSON keys
- layer the preset through `RedactConfig` alongside explicit `--redact-key` values
- document the preset in the security and bug-report guidance

Fixes #35

## Validation

- `go test ./internal/proxy`
- `go test ./cmd/mcpsnoop`
- `PATH="$PATH:$(go env GOPATH)/bin" make check`

## AI assistance

Implemented with AI assistance from OpenAI Codex. I reviewed the changes and ran the validation above.