### PR TITLE
feat(cmd): support opening sessions piped directly from stdin

### DIFF
--- a/cmd/mcpsnoop/console_unix.go
+++ b/cmd/mcpsnoop/console_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+func openTTY() (*os.File, error) {
+	return os.OpenFile("/dev/tty", os.O_RDONLY, 0)
+}

--- a/cmd/mcpsnoop/console_windows.go
+++ b/cmd/mcpsnoop/console_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func openTTY() (*os.File, error) {
+	return os.OpenFile("CONIN$", os.O_RDONLY, 0)
+}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/signal"
@@ -352,8 +353,8 @@ func runOpen(args []string) int {
 	fs := flag.NewFlagSet("mcpsnoop open", flag.ExitOnError)
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop open <session.jsonl>\n\n")
-		fmt.Fprintf(os.Stderr, "Open a persisted session log directly in the TUI.\n")
+		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop open <session.jsonl>|-\n\n")
+		fmt.Fprintf(os.Stderr, "Open a persisted session log directly in the TUI. Use - to read from stdin.\n")
 	}
 
 	_ = fs.Parse(args)
@@ -363,19 +364,26 @@ func runOpen(args []string) int {
 		return 2
 	}
 
-	path := fs.Arg(0)
-
-	f, err := os.Open(path)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
-		return 1
+	arg := fs.Arg(0)
+	var r io.Reader
+	var f *os.File
+	if arg == "-" {
+		r = os.Stdin
+	} else {
+		var err error
+		f, err = os.Open(arg)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+			return 1
+		}
+		defer f.Close()
+		r = f
 	}
-	defer f.Close()
+
 	st := store.New(0)
-	err = proxy.Decode(f, func(e proxy.Envelope) {
+	if err := proxy.Decode(r, func(e proxy.Envelope) {
 		st.Ingest(e)
-	})
-	if err != nil {
+	}); err != nil {
 		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 		return 1
 	}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -365,13 +365,12 @@ func runOpen(args []string) int {
 	}
 
 	arg := fs.Arg(0)
+	usedStdin := arg == "-"
 	var r io.Reader
-	var f *os.File
-	if arg == "-" {
+	if usedStdin {
 		r = os.Stdin
 	} else {
-		var err error
-		f, err = os.Open(arg)
+		f, err := os.Open(arg)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 			return 1
@@ -390,9 +389,22 @@ func runOpen(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := tui.RunOpen(ctx, st); err != nil {
-		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
-		return 1
+	if usedStdin {
+		tty, err := openTTY()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+			return 1
+		}
+		defer tty.Close()
+		if err := tui.RunOpenWithInput(ctx, st, tty); err != nil {
+			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+			return 1
+		}
+	} else {
+		if err := tui.RunOpen(ctx, st); err != nil {
+			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+			return 1
+		}
 	}
 
 	return 0

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"io"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -41,6 +42,16 @@ func Run(ctx context.Context, socketPath, sessionsDir string, slow time.Duration
 func RunOpen(ctx context.Context, st *store.Store) error {
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
 
+	_, err := p.Run()
+	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+// RunOpenWithInput starts the TUI using a preloaded store and a custom input reader (e.g., controlling TTY).
+func RunOpenWithInput(ctx context.Context, st *store.Store, in io.Reader) error {
+	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx), tea.WithInput(in))
 	_, err := p.Run()
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {
 		return nil


### PR DESCRIPTION
While utilizing the open command to inspect archived sessions, I noticed that it currently requires a physical file path on disk. Supporting direct piping from stdin via the standard dash (-) argument would significantly improve flexibility for automated scripting and quick post-mortem analyses.

Context and impact:
: The open command only accepts an explicit file path string, forcing users to create temporary files on disk if they are fetching session data from external stream sources or remote logs.

Changes introduced:
: Update the file opening logic in cmd/open.go to intercept the dash (-) argument.
: Dynamically assign an io.Reader to utilize either os.Stdin or a secure os.Open stream based on the input argument.
: Pipe the reader straight into the decoder store without altering the terminal UI loading experience.

Functional benefits:
: Enables seamless composition of CLI commands (e.g., cat dump.json | mcpsnoop open -), eliminates the overhead of tracking temporary files on disk, and speeds up diagnostic workflows.