### PR TITLE
feat: add remote SSH tunnel helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,18 @@ mcpsnoop
 # create the remote socket directory once
 ssh remote-user@remote-host 'mkdir -p ~/.local/state/mcpsnoop'
 
-# open the tunnel and leave it running
-ssh -N -o StreamLocalBindUnlink=yes \
-  -R /home/remote-user/.local/state/mcpsnoop/hub.sock:$HOME/.local/state/mcpsnoop/hub.sock \
-  remote-user@remote-host
+# print the tunnel command, then run the printed ssh -R line
+mcpsnoop remote remote-user@remote-host
 
 # on the remote host, wrap your server as usual
 mcpsnoop -- node build/index.js
+```
+
+If the remote uses a non-default home or `MCPSNOOP_HOME`, pass it explicitly.
+
+```bash
+mcpsnoop remote --remote-home /Users/remote-user remote-user@remote-host
+mcpsnoop remote --remote-mcpsnoop-home /srv/mcpsnoop remote-user@remote-host
 ```
 
 ### Post-mortem

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -86,6 +86,10 @@ func main() {
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "open" {
 		os.Exit(runOpen(args[1:]))
 	}
+	// `mcpsnoop remote` prints the SSH reverse tunnel command for live remote view.
+	if args := os.Args[1:]; len(args) > 0 && args[0] == "remote" {
+		os.Exit(runRemote(args[1:]))
+	}
 	// `mcpsnoop version` mirrors the --version flag (what most CLIs expect).
 	if args := os.Args[1:]; len(args) == 1 && (args[0] == "version" || args[0] == "-v") {
 		fmt.Println("mcpsnoop", appVersion())
@@ -112,6 +116,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  mcpsnoop [flags] -- <server command> [args...]   run as transparent stdio shim\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop http --target <url> [--listen :7000]     run as transparent HTTP proxy\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop export [-T json|html|text] [-o file|-] [session-id|log.jsonl]\n")
+		fmt.Fprintf(os.Stderr, "  mcpsnoop remote [flags] <user@host>              print SSH tunnel command\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop                                          run the live TUI (collector)\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop demo                                     play a scripted session (no setup)\n\n")
 		fmt.Fprintf(os.Stderr, "Flags:\n")

--- a/cmd/mcpsnoop/remote.go
+++ b/cmd/mcpsnoop/remote.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+)
+
+type remoteTunnelOptions struct {
+	Target             string
+	RemoteHome         string
+	RemoteMCPSnoopHome string
+}
+
+// runRemote prints the SSH reverse tunnel command for live remote viewing. It
+// deliberately does not exec SSH, so users keep full control over credentials,
+// host verification, jump hosts, and local SSH policy.
+func runRemote(args []string) int {
+	fs := flag.NewFlagSet("mcpsnoop remote", flag.ExitOnError)
+	var opts remoteTunnelOptions
+	fs.StringVar(&opts.RemoteHome, "remote-home", "", "remote user's home directory (default: /home/<user> from user@host)")
+	fs.StringVar(&opts.RemoteMCPSnoopHome, "remote-mcpsnoop-home", "", "remote MCPSNOOP_HOME directory (overrides --remote-home)")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop remote [--remote-home /home/user | --remote-mcpsnoop-home /path] <user@host>\n\n")
+		fmt.Fprintf(os.Stderr, "Print the ssh -R command that forwards the remote mcpsnoop socket to this workstation.\n\n")
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	opts.Target = fs.Arg(0)
+
+	cmd, err := remoteSSHCommand(opts)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop remote:", err)
+		return 2
+	}
+	fmt.Println(cmd)
+	return 0
+}
+
+func remoteSSHCommand(opts remoteTunnelOptions) (string, error) {
+	remoteSocket, err := remoteSocketPath(opts)
+	if err != nil {
+		return "", err
+	}
+	localSocket, err := localSocketPath()
+	if err != nil {
+		return "", err
+	}
+	binding := remoteSocket + ":" + localSocket
+	return strings.Join([]string{
+		"ssh",
+		"-N",
+		"-o",
+		"StreamLocalBindUnlink=yes",
+		"-R",
+		shellQuote(binding),
+		shellQuote(opts.Target),
+	}, " "), nil
+}
+
+func remoteSocketPath(opts remoteTunnelOptions) (string, error) {
+	if opts.Target == "" {
+		return "", fmt.Errorf("missing SSH target")
+	}
+	if opts.RemoteHome != "" && opts.RemoteMCPSnoopHome != "" {
+		return "", fmt.Errorf("use either --remote-home or --remote-mcpsnoop-home, not both")
+	}
+	if opts.RemoteMCPSnoopHome != "" {
+		if !path.IsAbs(opts.RemoteMCPSnoopHome) {
+			return "", fmt.Errorf("--remote-mcpsnoop-home must be an absolute path")
+		}
+		return path.Join(opts.RemoteMCPSnoopHome, "hub.sock"), nil
+	}
+
+	remoteHome := opts.RemoteHome
+	if remoteHome == "" {
+		user := sshTargetUser(opts.Target)
+		if user == "" {
+			return "", fmt.Errorf("cannot infer remote home from %q; pass --remote-home or --remote-mcpsnoop-home", opts.Target)
+		}
+		remoteHome = path.Join("/home", user)
+	}
+	if !path.IsAbs(remoteHome) {
+		return "", fmt.Errorf("--remote-home must be an absolute path")
+	}
+	return path.Join(remoteHome, ".local", "state", "mcpsnoop", "hub.sock"), nil
+}
+
+func localSocketPath() (string, error) {
+	socket := paths.SocketPath()
+	if filepath.IsAbs(socket) {
+		return socket, nil
+	}
+	return filepath.Abs(socket)
+}
+
+func sshTargetUser(target string) string {
+	before, _, ok := strings.Cut(target, "@")
+	if !ok || before == "" || strings.ContainsAny(before, "/:") {
+		return ""
+	}
+	return before
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if shellSafe(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+func shellSafe(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			continue
+		}
+		if strings.ContainsRune("@%_+=:,./-", r) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/cmd/mcpsnoop/remote_test.go
+++ b/cmd/mcpsnoop/remote_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoteSSHCommandDefaultsRemoteHomeFromSSHUser(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	t.Setenv("MCPSNOOP_HOME", stateDir)
+
+	got, err := remoteSSHCommand(remoteTunnelOptions{Target: "remote-user@remote-host"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localSocket := filepath.Join(stateDir, "hub.sock")
+	want := "ssh -N -o StreamLocalBindUnlink=yes -R /home/remote-user/.local/state/mcpsnoop/hub.sock:" + localSocket + " remote-user@remote-host"
+	if got != want {
+		t.Fatalf("remoteSSHCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteSSHCommandUsesRemoteMCPSnoopHome(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	t.Setenv("MCPSNOOP_HOME", stateDir)
+
+	got, err := remoteSSHCommand(remoteTunnelOptions{
+		Target:             "prod",
+		RemoteMCPSnoopHome: "/srv/mcpsnoop-state",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localSocket := filepath.Join(stateDir, "hub.sock")
+	want := "ssh -N -o StreamLocalBindUnlink=yes -R /srv/mcpsnoop-state/hub.sock:" + localSocket + " prod"
+	if got != want {
+		t.Fatalf("remoteSSHCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteSSHCommandRequiresRemoteHomeWhenTargetHasNoUser(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+
+	_, err := remoteSSHCommand(remoteTunnelOptions{Target: "prod"})
+	if err == nil {
+		t.Fatal("remoteSSHCommand() error = nil, want error")
+	}
+}
+
+func TestRemoteSSHCommandQuotesSocketBinding(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state dir")
+	t.Setenv("MCPSNOOP_HOME", stateDir)
+
+	got, err := remoteSSHCommand(remoteTunnelOptions{
+		Target:             "remote-user@remote-host",
+		RemoteMCPSnoopHome: "/srv/mcpsnoop state",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localSocket := filepath.Join(stateDir, "hub.sock")
+	want := "ssh -N -o StreamLocalBindUnlink=yes -R '/srv/mcpsnoop state/hub.sock:" + localSocket + "' remote-user@remote-host"
+	if got != want {
+		t.Fatalf("remoteSSHCommand() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What and why

Fixes #36.

Adds `mcpsnoop remote <user@host>` to print the SSH reverse tunnel command for live remote viewing. The helper resolves the local hub socket through the existing `paths.SocketPath()` logic, builds the remote socket path from `/home/<user>` by default, and supports `--remote-home` or `--remote-mcpsnoop-home` for non-default remote layouts.

It only prints the `ssh -R` command and never starts SSH, so users stay in control of credentials, host verification, jump hosts, and local SSH policy.

AI assistance was used to prepare this change.

## Validation

- `go test ./cmd/mcpsnoop`
- `go test ./cmd/mcpsnoop -run 'TestRemoteSSHCommand|TestLabelFor'`
- `MCPSNOOP_HOME=$(mktemp -d) go run ./cmd/mcpsnoop remote remote-user@remote-host`
- `PATH="$PATH:$(go env GOPATH)/bin" make check`

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
