### PR TITLE
feat: open sessions by id or newest

### DIFF
--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -82,7 +82,7 @@ func main() {
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "export" {
 		os.Exit(runExport(args[1:]))
 	}
-	// `mcpsnoop open <session.jsonl>` opens a session file directly in the TUI.
+	// `mcpsnoop open` opens a session id or file directly in the TUI.
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "open" {
 		os.Exit(runOpen(args[1:]))
 	}
@@ -116,6 +116,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  mcpsnoop [flags] -- <server command> [args...]   run as transparent stdio shim\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop http --target <url> [--listen :7000]     run as transparent HTTP proxy\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop export [-T json|html|text] [-o file|-] [session-id|log.jsonl]\n")
+		fmt.Fprintf(os.Stderr, "  mcpsnoop open [session-id|log.jsonl|-]            open a session in the TUI\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop remote [flags] <user@host>              print SSH tunnel command\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop                                          run the live TUI (collector)\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop demo                                     play a scripted session (no setup)\n\n")
@@ -358,24 +359,33 @@ func runOpen(args []string) int {
 	fs := flag.NewFlagSet("mcpsnoop open", flag.ExitOnError)
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop open <session.jsonl>|-\n\n")
-		fmt.Fprintf(os.Stderr, "Open a persisted session log directly in the TUI. Use - to read from stdin.\n")
+		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop open [session-id|session.jsonl|-]\n\n")
+		fmt.Fprintf(os.Stderr, "If no session is provided, the newest session log is opened.\n")
+		fmt.Fprintf(os.Stderr, "Use - to read from stdin.\n")
 	}
 
 	_ = fs.Parse(args)
 
-	if fs.NArg() != 1 {
-		fs.Usage()
+	if fs.NArg() > 1 {
+		fmt.Fprintln(os.Stderr, "mcpsnoop open: expected at most one session id or log path")
 		return 2
 	}
 
-	arg := fs.Arg(0)
-	usedStdin := arg == "-"
+	var arg string
+	if fs.NArg() == 1 {
+		arg = fs.Arg(0)
+	}
+	inPath, usedStdin, err := resolveOpenSessionPath(arg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
+		return 1
+	}
+
 	var r io.Reader
 	if usedStdin {
 		r = os.Stdin
 	} else {
-		f, err := os.Open(arg)
+		f, err := os.Open(inPath)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 			return 1
@@ -413,4 +423,12 @@ func runOpen(args []string) int {
 	}
 
 	return 0
+}
+
+func resolveOpenSessionPath(arg string) (string, bool, error) {
+	if arg == "-" {
+		return "", true, nil
+	}
+	path, err := exporter.ResolveSessionPath(arg)
+	return path, false, err
 }

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -71,6 +71,52 @@ func TestRedactKeysFlagConfigEnablesCommonSecretsPreset(t *testing.T) {
 	}
 }
 
+func TestResolveOpenSessionPathSupportsSessionIDNewestAndStdin(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", stateDir)
+
+	older := paths.SessionLogPath("older")
+	newer := paths.SessionLogPath("newer")
+	if err := os.WriteFile(older, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newer, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	olderTime := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	newerTime := olderTime.Add(time.Hour)
+	if err := os.Chtimes(older, olderTime, olderTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newer, newerTime, newerTime); err != nil {
+		t.Fatal(err)
+	}
+
+	path, usedStdin, err := resolveOpenSessionPath("newer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usedStdin || path != newer {
+		t.Fatalf("resolveOpenSessionPath(\"newer\") = %q, %v; want %q, false", path, usedStdin, newer)
+	}
+
+	path, usedStdin, err = resolveOpenSessionPath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usedStdin || path != newer {
+		t.Fatalf("resolveOpenSessionPath(\"\") = %q, %v; want newest %q, false", path, usedStdin, newer)
+	}
+
+	path, usedStdin, err = resolveOpenSessionPath("-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !usedStdin || path != "" {
+		t.Fatalf("resolveOpenSessionPath(\"-\") = %q, %v; want empty path, true", path, usedStdin)
+	}
+}
+
 func TestTraceSinkRedactsFileAndLiveSocket(t *testing.T) {
 	stateDir := filepath.Join(os.TempDir(), fmt.Sprintf("mcpsnoop-test-%d", os.Getpid()))
 	if err := os.RemoveAll(stateDir); err != nil {

--- a/docs/POST_MORTEM.md
+++ b/docs/POST_MORTEM.md
@@ -36,12 +36,17 @@ running ones. From there a few keys do the work.
 - Press `ctrl-d` to remove the selected session and its on-disk log, only when
   you mean to.
 
-To open one specific log that is not in the sessions directory, for example a
-`--trace-file` capture or a log a teammate sent you, pass its path to `open`.
+To open one specific log, pass either its session id or a JSONL path to `open`.
+If you omit the session, `open` uses the newest saved log, matching `export`.
 
 ```bash
+mcpsnoop open
+mcpsnoop open server.py-48213
 mcpsnoop open ./session.jsonl
 ```
+
+Passing a path is useful for a `--trace-file` capture outside the sessions
+directory or a log a teammate sent you.
 
 Use `-` to read from stdin, handy for streaming a remote log over SSH without
 copying it down first.


### PR DESCRIPTION
## What and why

Fixes #48.

`mcpsnoop open` now accepts the same saved-session inputs as `mcpsnoop export`: a session id, a JSONL path, or no argument for the newest saved session. Reading from stdin with `-` still works for piped logs. The top-level usage and post-mortem docs were updated for the new forms.

## Validation

- `go test ./cmd/mcpsnoop`
- `PATH="$PATH:$(go env GOPATH)/bin" make check`

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed

AI assistance disclosure: This PR was prepared with AI assistance.
