### PR TITLE
feat: add config file support for repeated shim flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,27 @@ mcpsnoop
 No flags, no socket paths, no startup order to remember. The shim and the UI find
 each other on their own, and the UI backfills past sessions from disk.
 
+### Config file
+
+If you reuse the same shim flags across a project, put them in a
+`.mcpsnoop.toml` file in the current working directory.
+
+```toml
+label = "filesystem"
+trace-file = "trace.jsonl"
+redact-secrets = true
+redact-key = "token,authorization"
+no-trace = false
+```
+
+The config file supports `label`, `trace-file`, `redact-secrets`,
+`redact-key`, and `no-trace`.
+
+The file is only looked up in the current working directory. Parent
+directories are not searched.
+
+Explicit command-line flags override values from the config file.
+
 For a streamable-HTTP server, run mcpsnoop as a reverse proxy.
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,10 @@ mcpsnoop runs the server command you wrap and captures MCP payloads that may
 include credentials, so treat saved traces as sensitive and see the redaction
 options in the README before you share one.
 
+mcpsnoop also reads `.mcpsnoop.toml` from the current working directory. Only
+use it in directories you trust, since a config file can change tracing
+behavior (for example, `no-trace`) or override the trace output path.
+
 ## Supported versions
 
 Security fixes land only on the latest release, so please update to the newest

--- a/cmd/mcpsnoop/config.go
+++ b/cmd/mcpsnoop/config.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type config struct {
+	Label         string
+	TraceFile     string
+	NoTrace       bool
+	RedactSecrets bool
+	RedactKeys    []string
+}
+
+func loadConfig() (config, bool, error) {
+	const configFile = ".mcpsnoop.toml"
+
+	f, err := os.Open(configFile)
+	if os.IsNotExist(err) {
+		return config{}, false, nil
+	}
+	if err != nil {
+		return config{}, false, err
+	}
+	defer f.Close()
+
+	cfg, err := parseConfig(f)
+	if err != nil {
+		return config{}, false, err
+	}
+
+	return cfg, true, nil
+}
+
+func parseConfig(r io.Reader) (config, error) {
+	var cfg config
+
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return config{}, fmt.Errorf("invalid config line: %q", line)
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.Trim(strings.TrimSpace(parts[1]), `"`)
+
+		switch key {
+		case "label":
+			cfg.Label = value
+
+		case "trace-file":
+			cfg.TraceFile = value
+
+		case "no-trace":
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return config{}, fmt.Errorf("invalid value for %q: %w", key, err)
+			}
+			cfg.NoTrace = b
+
+		case "redact-secrets":
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return config{}, fmt.Errorf("invalid value for %q: %w", key, err)
+			}
+			cfg.RedactSecrets = b
+
+		case "redact-key":
+			var keys redactKeysFlag
+			if err := keys.Set(value); err != nil {
+				return config{}, err
+			}
+			cfg.RedactKeys = []string(keys)
+
+		default:
+			return config{}, fmt.Errorf("unknown config key %q", key)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return config{}, err
+	}
+
+	return cfg, nil
+}
+
+func applyConfig(
+	fs *flag.FlagSet,
+	cfg config,
+	ok bool,
+	label, traceFile *string,
+	noTrace, redactSecrets *bool,
+	redactKeys *redactKeysFlag,
+) {
+	if !ok {
+		return
+	}
+
+	visited := map[string]bool{}
+
+	fs.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+
+	if !visited["label"] {
+		*label = cfg.Label
+	}
+
+	if !visited["trace-file"] {
+		*traceFile = cfg.TraceFile
+	}
+
+	if !visited["no-trace"] {
+		*noTrace = cfg.NoTrace
+	}
+
+	if !visited["redact-secrets"] {
+		*redactSecrets = cfg.RedactSecrets
+	}
+
+	if !visited["redact-key"] {
+		*redactKeys = redactKeysFlag(cfg.RedactKeys)
+	}
+}

--- a/cmd/mcpsnoop/config.go
+++ b/cmd/mcpsnoop/config.go
@@ -38,6 +38,37 @@ func loadConfig() (config, bool, error) {
 	return cfg, true, nil
 }
 
+func parseValue(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+
+	if strings.HasPrefix(value, "[") {
+		return "", fmt.Errorf("array values are not supported")
+	}
+
+	if strings.HasPrefix(value, `"`) {
+		rest := value[1:]
+		quote := strings.Index(rest, `"`)
+
+		if quote == -1 {
+			return "", fmt.Errorf("unterminated quoted value")
+		}
+
+		end := quote + 1
+
+		if strings.TrimSpace(value[end+1:]) != "" {
+			return "", fmt.Errorf("unexpected content after quoted value")
+		}
+
+		return value[1:end], nil
+	}
+
+	if i := strings.Index(value, "#"); i >= 0 {
+		return "", fmt.Errorf("unexpected content after value")
+	}
+
+	return value, nil
+}
+
 func parseConfig(r io.Reader) (config, error) {
 	var cfg config
 
@@ -56,7 +87,11 @@ func parseConfig(r io.Reader) (config, error) {
 		}
 
 		key := strings.TrimSpace(parts[0])
-		value := strings.Trim(strings.TrimSpace(parts[1]), `"`)
+
+		value, err := parseValue(parts[1])
+		if err != nil {
+			return config{}, fmt.Errorf("invalid value for %q: %w", key, err)
+		}
 
 		switch key {
 		case "label":
@@ -120,7 +155,7 @@ func applyConfig(
 		*label = cfg.Label
 	}
 
-	if !visited["trace-file"] {
+	if traceFile != nil && !visited["trace-file"] {
 		*traceFile = cfg.TraceFile
 	}
 

--- a/cmd/mcpsnoop/config_test.go
+++ b/cmd/mcpsnoop/config_test.go
@@ -270,3 +270,43 @@ func TestApplyConfigExplicitRedactKeyOverridesConfig(t *testing.T) {
 		t.Fatalf("expected explicit redact-key to win, got %v", redactKeys)
 	}
 }
+
+func TestParseConfigRejectsArraySyntax(t *testing.T) {
+	_, err := parseConfig(strings.NewReader(`
+redact-key = ["token", "authorization"]
+`))
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseConfigRejectsTrailingContentAfterQuote(t *testing.T) {
+	_, err := parseConfig(strings.NewReader(`
+label = "fs" # my server
+`))
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseConfigRejectsUnterminatedQuotedValue(t *testing.T) {
+	_, err := parseConfig(strings.NewReader(`
+label = "fs
+`))
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseConfigRejectsTrailingCommentOnUnquotedValue(t *testing.T) {
+	_, err := parseConfig(strings.NewReader(`
+redact-key = token,api_key # note
+`))
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/mcpsnoop/config_test.go
+++ b/cmd/mcpsnoop/config_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestParseConfigEmpty(t *testing.T) {
+	cfg, err := parseConfig(strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Label != "" {
+		t.Fatal("expected empty label")
+	}
+
+	if cfg.TraceFile != "" {
+		t.Fatal("expected empty trace file")
+	}
+
+	if cfg.NoTrace {
+		t.Fatal("expected no-trace=false")
+	}
+
+	if cfg.RedactSecrets {
+		t.Fatal("expected redact-secrets=false")
+	}
+
+	if len(cfg.RedactKeys) != 0 {
+		t.Fatal("expected no redact keys")
+	}
+}
+
+func TestParseConfigLabel(t *testing.T) {
+	cfg, err := parseConfig(strings.NewReader(`label = "filesystem"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Label != "filesystem" {
+		t.Fatalf("expected label %q, got %q", "filesystem", cfg.Label)
+	}
+}
+
+func TestParseConfigBoolValues(t *testing.T) {
+	cfg, err := parseConfig(strings.NewReader(`
+no-trace = true
+redact-secrets = true
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cfg.NoTrace {
+		t.Fatal("expected no-trace=true")
+	}
+
+	if !cfg.RedactSecrets {
+		t.Fatal("expected redact-secrets=true")
+	}
+}
+
+func TestParseConfigRedactKeys(t *testing.T) {
+	cfg, err := parseConfig(strings.NewReader(`
+redact-key = "token,api_key"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"token", "api_key"}
+
+	if len(cfg.RedactKeys) != len(want) {
+		t.Fatalf("expected %d keys, got %d", len(want), len(cfg.RedactKeys))
+	}
+
+	for i := range want {
+		if cfg.RedactKeys[i] != want[i] {
+			t.Fatalf("expected %q at index %d, got %q", want[i], i, cfg.RedactKeys[i])
+		}
+	}
+}
+
+func TestParseConfigUnknownKey(t *testing.T) {
+	_, err := parseConfig(strings.NewReader(`
+foo = "bar"
+`))
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseConfigInvalidBool(t *testing.T) {
+	_, err := parseConfig(strings.NewReader(`
+no-trace = maybe
+`))
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseConfigMissingEquals(t *testing.T) {
+	_, err := parseConfig(strings.NewReader("just some text"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestApplyConfigUsesConfigWhenFlagNotSet(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	label := fs.String("label", "", "")
+	traceFile := fs.String("trace-file", "", "")
+	noTrace := fs.Bool("no-trace", false, "")
+	redactSecrets := fs.Bool("redact-secrets", false, "")
+	var redactKeys redactKeysFlag
+	fs.Var(&redactKeys, "redact-key", "")
+
+	cfg := config{
+		Label:         "filesystem",
+		TraceFile:     "trace.jsonl",
+		NoTrace:       true,
+		RedactSecrets: true,
+		RedactKeys:    []string{"token", "api_key"},
+	}
+
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+
+	if *label != "filesystem" {
+		t.Fatalf("expected label %q, got %q", "filesystem", *label)
+	}
+
+	if *traceFile != "trace.jsonl" {
+		t.Fatalf("expected trace-file %q, got %q", "trace.jsonl", *traceFile)
+	}
+
+	if !*noTrace {
+		t.Fatal("expected no-trace=true")
+	}
+
+	if !*redactSecrets {
+		t.Fatal("expected redact-secrets=true")
+	}
+
+	want := []string{"token", "api_key"}
+
+	if len(redactKeys) != len(want) {
+		t.Fatalf("expected %d redact keys, got %d", len(want), len(redactKeys))
+	}
+
+	for i := range want {
+		if redactKeys[i] != want[i] {
+			t.Fatalf("expected %q at index %d, got %q", want[i], i, redactKeys[i])
+		}
+	}
+}
+
+func TestApplyConfigExplicitFlagOverridesConfig(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	label := fs.String("label", "", "")
+	traceFile := fs.String("trace-file", "", "")
+	noTrace := fs.Bool("no-trace", false, "")
+	redactSecrets := fs.Bool("redact-secrets", false, "")
+	var redactKeys redactKeysFlag
+	fs.Var(&redactKeys, "redact-key", "")
+
+	if err := fs.Parse([]string{"--label=cli"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config{
+		Label: "from-config",
+	}
+
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+
+	if *label != "cli" {
+		t.Fatalf("expected CLI value %q, got %q", "cli", *label)
+	}
+}
+
+func TestApplyConfigNoConfigFile(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	label := fs.String("label", "", "")
+	traceFile := fs.String("trace-file", "", "")
+	noTrace := fs.Bool("no-trace", false, "")
+	redactSecrets := fs.Bool("redact-secrets", false, "")
+	var redactKeys redactKeysFlag
+	fs.Var(&redactKeys, "redact-key", "")
+
+	cfg := config{
+		Label:         "filesystem",
+		TraceFile:     "trace.jsonl",
+		NoTrace:       true,
+		RedactSecrets: true,
+		RedactKeys:    []string{"token"},
+	}
+
+	applyConfig(fs, cfg, false, label, traceFile, noTrace, redactSecrets, &redactKeys)
+
+	if *label != "" {
+		t.Fatal("expected label to remain unchanged")
+	}
+
+	if *traceFile != "" {
+		t.Fatal("expected trace-file to remain unchanged")
+	}
+
+	if *noTrace {
+		t.Fatal("expected no-trace=false")
+	}
+
+	if *redactSecrets {
+		t.Fatal("expected redact-secrets=false")
+	}
+
+	if len(redactKeys) != 0 {
+		t.Fatal("expected no redact keys")
+	}
+}
+
+func TestApplyConfigExplicitFalseBoolOverridesConfig(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	label := fs.String("label", "", "")
+	traceFile := fs.String("trace-file", "", "")
+	noTrace := fs.Bool("no-trace", false, "")
+	redactSecrets := fs.Bool("redact-secrets", false, "")
+	var redactKeys redactKeysFlag
+	fs.Var(&redactKeys, "redact-key", "")
+
+	if err := fs.Parse([]string{"--no-trace=false"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config{
+		NoTrace: true,
+	}
+
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+
+	if *noTrace {
+		t.Fatal("expected explicit --no-trace=false to override config")
+	}
+}
+
+func TestApplyConfigExplicitRedactKeyOverridesConfig(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	label := fs.String("label", "", "")
+	traceFile := fs.String("trace-file", "", "")
+	noTrace := fs.Bool("no-trace", false, "")
+	redactSecrets := fs.Bool("redact-secrets", false, "")
+	var redactKeys redactKeysFlag
+	fs.Var(&redactKeys, "redact-key", "")
+
+	if err := fs.Parse([]string{"--redact-key=cli-key"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config{RedactKeys: []string{"config-key"}}
+
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+
+	if len(redactKeys) != 1 || redactKeys[0] != "cli-key" {
+		t.Fatalf("expected explicit redact-key to win, got %v", redactKeys)
+	}
+}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -149,6 +149,22 @@ func main() {
 		fs.PrintDefaults()
 	}
 	_ = fs.Parse(os.Args[1:])
+	cfg, ok, err := loadConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop:", err)
+		os.Exit(1)
+	}
+
+	applyConfig(
+		fs,
+		cfg,
+		ok,
+		label,
+		traceFile,
+		noTrace,
+		redactSecrets,
+		&redactKeys,
+	)
 
 	if *showVer {
 		fmt.Println("mcpsnoop", appVersion())

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -149,22 +149,6 @@ func main() {
 		fs.PrintDefaults()
 	}
 	_ = fs.Parse(os.Args[1:])
-	cfg, ok, err := loadConfig()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "mcpsnoop:", err)
-		os.Exit(1)
-	}
-
-	applyConfig(
-		fs,
-		cfg,
-		ok,
-		label,
-		traceFile,
-		noTrace,
-		redactSecrets,
-		&redactKeys,
-	)
 
 	if *showVer {
 		fmt.Println("mcpsnoop", appVersion())
@@ -172,7 +156,30 @@ func main() {
 	}
 
 	if command := fs.Args(); len(command) > 0 {
-		os.Exit(runShim(command, *label, *traceFile, *noTrace, redactConfig(*redactSecrets, redactKeys, redactValues)))
+		cfg, ok, err := loadConfig()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "mcpsnoop:", err)
+			os.Exit(1)
+		}
+
+		applyConfig(
+			fs,
+			cfg,
+			ok,
+			label,
+			traceFile,
+			noTrace,
+			redactSecrets,
+			&redactKeys,
+		)
+
+		os.Exit(runShim(
+			command,
+			*label,
+			*traceFile,
+			*noTrace,
+			redactConfig(*redactSecrets, redactKeys, redactValues),
+		))
 	}
 	os.Exit(runHub())
 }
@@ -351,6 +358,22 @@ func runHTTP(args []string) int {
 	fs.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads (repeat or comma-separated)")
 	fs.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text (repeatable)")
 	_ = fs.Parse(args)
+	cfg, ok, err := loadConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpsnoop http:", err)
+		return 1
+	}
+
+	applyConfig(
+		fs,
+		cfg,
+		ok,
+		label,
+		nil,
+		noTrace,
+		redactSecrets,
+		&redactKeys,
+	)
 	if *target == "" {
 		fmt.Fprintln(os.Stderr, "mcpsnoop http: --target is required")
 		return 2


### PR DESCRIPTION
## Summary

Adds optional `.mcpsnoop.toml` support for repeated shim flags.

Supported options:

- `label`
- `trace-file`
- `redact-secrets`
- `redact-key`
- `no-trace`

Precedence is:

```
CLI flags > config file > built-in defaults
```

The config file is looked up only in the current working directory.

## Implementation

- add config loading and parsing
- merge config values after `flag.Parse`
- preserve CLI flag precedence
- add unit tests for parsing and merge behavior
- document the feature in the README

## Notes

This intentionally covers the repeated shim flags discussed in the issue.

Closes #37