### PR TITLE
feat: add value redaction patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,13 @@ run untrusted ones in a container. It never executes anything you didn't put in
 your client config.
 
 Captured frames can include prompts, tool arguments, credentials, and tool
-results. If payloads can carry secrets, opt in to key-based redaction to scrub
-matching JSON fields from the observed trace copies while the proxied bytes still
-pass through unchanged. It is best effort and only scrubs values under matching
-JSON object keys, so secrets in stderr text, string values under other keys, or
-non-JSON frames pass through.
+results. If payloads can carry secrets, opt in to redaction to scrub the
+observed trace copies while the proxied bytes still pass through unchanged.
+Key-based redaction replaces whole values under matching JSON object keys.
+Value-based redaction applies regular expressions to observed string values,
+stderr text, and non-JSON text frames. Both modes are best effort: regexes can
+miss secrets, overmatch harmless text, or fail to see transformed/encoded
+values.
 
 ```bash
 # built-in preset of common secret keys
@@ -249,8 +251,11 @@ mcpsnoop --redact-secrets -- node build/index.js
 # or name your own keys
 mcpsnoop --redact-key token,api_key,password -- node build/index.js
 
-# preset plus your own keys, in http mode
-mcpsnoop http --target http://localhost:3000/mcp --redact-secrets --redact-key authorization
+# scrub obvious token-shaped values outside known keys
+mcpsnoop --redact-value 'sk-[A-Za-z0-9]+' -- node build/index.js
+
+# combine the layers in http mode
+mcpsnoop http --target http://localhost:3000/mcp --redact-secrets --redact-value 'Bearer\s+\S+'
 ```
 
 For remote workflows, use SSH tunnelling or SSH file transfer so transport auth,

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"syscall"
@@ -66,10 +67,32 @@ func (f *redactKeysFlag) Set(value string) error {
 	return nil
 }
 
-func (f redactKeysFlag) config(commonSecrets bool) proxy.RedactConfig {
+type redactValuesFlag []string
+
+func (f *redactValuesFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	return strings.Join(*f, ",")
+}
+
+func (f *redactValuesFlag) Set(value string) error {
+	pattern := strings.TrimSpace(value)
+	if pattern == "" {
+		return nil
+	}
+	if _, err := regexp.Compile(pattern); err != nil {
+		return fmt.Errorf("invalid redact value regex %q: %w", pattern, err)
+	}
+	*f = append(*f, pattern)
+	return nil
+}
+
+func redactConfig(commonSecrets bool, keys redactKeysFlag, values redactValuesFlag) proxy.RedactConfig {
 	return proxy.RedactConfig{
 		CommonSecrets: commonSecrets,
-		Keys:          []string(f),
+		Keys:          []string(keys),
+		ValuePatterns: []string(values),
 	}
 }
 
@@ -102,6 +125,7 @@ func main() {
 
 	fs := flag.NewFlagSet("mcpsnoop", flag.ExitOnError)
 	var redactKeys redactKeysFlag
+	var redactValues redactValuesFlag
 	var (
 		label         = fs.String("label", "", "server label shown in the TUI (default: command name)")
 		traceFile     = fs.String("trace-file", "", "override the JSONL trace path (default: well-known session log)")
@@ -110,6 +134,7 @@ func main() {
 		showVer       = fs.Bool("version", false, "print version and exit")
 	)
 	fs.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads (repeat or comma-separated)")
+	fs.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text (repeatable)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "mcpsnoop %s — Wireshark for MCP\n\n", appVersion())
 		fmt.Fprintf(os.Stderr, "Usage:\n")
@@ -131,7 +156,7 @@ func main() {
 	}
 
 	if command := fs.Args(); len(command) > 0 {
-		os.Exit(runShim(command, *label, *traceFile, *noTrace, redactKeys.config(*redactSecrets)))
+		os.Exit(runShim(command, *label, *traceFile, *noTrace, redactConfig(*redactSecrets, redactKeys, redactValues)))
 	}
 	os.Exit(runHub())
 }
@@ -299,6 +324,7 @@ func traceSink(sessionID, traceFile string, noTrace bool, redaction proxy.Redact
 func runHTTP(args []string) int {
 	fs := flag.NewFlagSet("mcpsnoop http", flag.ExitOnError)
 	var redactKeys redactKeysFlag
+	var redactValues redactValuesFlag
 	var (
 		target        = fs.String("target", "", "real MCP server endpoint, e.g. http://localhost:3000/mcp (required)")
 		listen        = fs.String("listen", ":7000", "address to listen on")
@@ -307,6 +333,7 @@ func runHTTP(args []string) int {
 		redactSecrets = fs.Bool("redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	)
 	fs.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads (repeat or comma-separated)")
+	fs.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text (repeatable)")
 	_ = fs.Parse(args)
 	if *target == "" {
 		fmt.Fprintln(os.Stderr, "mcpsnoop http: --target is required")
@@ -322,7 +349,7 @@ func runHTTP(args []string) int {
 	}
 	sessionID := fmt.Sprintf("%s-%d", lbl, os.Getpid())
 
-	sink := traceSink(sessionID, "", *noTrace, redactKeys.config(*redactSecrets))
+	sink := traceSink(sessionID, "", *noTrace, redactConfig(*redactSecrets, redactKeys, redactValues))
 	defer sink.Close()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -44,7 +44,7 @@ func TestRedactKeysFlagParsesCommaSeparatedAndRepeatedValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := flag.config(false)
+	cfg := redactConfig(false, flag, nil)
 	if cfg.CommonSecrets {
 		t.Fatal("CommonSecrets = true, want false")
 	}
@@ -62,7 +62,7 @@ func TestRedactKeysFlagConfigEnablesCommonSecretsPreset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := flag.config(true)
+	cfg := redactConfig(true, flag, nil)
 	if !cfg.CommonSecrets {
 		t.Fatal("CommonSecrets = false, want true")
 	}
@@ -127,6 +127,31 @@ func TestResolveOpenSessionPathSupportsSessionIDNewestAndStdin(t *testing.T) {
 	}
 	if !usedStdin || path != "" {
 		t.Fatalf("resolveOpenSessionPath(\"-\") = %q, %v; want empty path, true", path, usedStdin)
+	}
+}
+
+func TestRedactValuesFlagParsesRepeatedRegexes(t *testing.T) {
+	var flag redactValuesFlag
+	if err := flag.Set(`sk-[A-Za-z0-9]+`); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Set(`Bearer\s+\S+`); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := redactConfig(false, nil, flag)
+	if got, want := cfg.ValuePatterns, []string{`sk-[A-Za-z0-9]+`, `Bearer\s+\S+`}; !slices.Equal(got, want) {
+		t.Fatalf("ValuePatterns = %v, want %v", got, want)
+	}
+	if got := flag.String(); got != `sk-[A-Za-z0-9]+,Bearer\s+\S+` {
+		t.Fatalf("String() = %q, want repeated regexes", got)
+	}
+}
+
+func TestRedactValuesFlagRejectsInvalidRegex(t *testing.T) {
+	var flag redactValuesFlag
+	if err := flag.Set(`[`); err == nil {
+		t.Fatal("Set returned nil, want invalid regex error")
 	}
 }
 

--- a/docs/POST_MORTEM.md
+++ b/docs/POST_MORTEM.md
@@ -85,10 +85,14 @@ later start. For a session that reappears automatically, leave `--trace-file`
 off and use the default location.
 
 To keep common secret fields out of saved traces, pass `--redact-secrets` when
-you wrap the server. Add `--redact-key` for project-specific fields.
+you wrap the server. Add `--redact-key` for project-specific fields, and
+`--redact-value` for best-effort regular expression scrubbing inside observed
+string values, stderr text, and non-JSON text frames. Regex redaction can miss
+encoded or transformed secrets and can overmatch harmless text, so review
+anything you plan to share.
 
 ```bash
-mcpsnoop --redact-secrets --redact-key tenant_api_key -- node build/index.js
+mcpsnoop --redact-secrets --redact-key tenant_api_key --redact-value 'sk-[A-Za-z0-9]+' -- node build/index.js
 ```
 
 ## What to include in a bug report

--- a/internal/proxy/redact.go
+++ b/internal/proxy/redact.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
 	"strings"
 )
 
@@ -28,6 +29,10 @@ type RedactConfig struct {
 
 	// Keys are JSON object field names whose values should be replaced.
 	Keys []string
+
+	// ValuePatterns are regular expressions whose matches inside observed
+	// string payloads should be replaced.
+	ValuePatterns []string
 }
 
 // Enabled reports whether cfg has any key-based redaction rule.
@@ -40,12 +45,18 @@ func (cfg RedactConfig) Enabled() bool {
 			return true
 		}
 	}
+	for _, pattern := range cfg.ValuePatterns {
+		if strings.TrimSpace(pattern) != "" {
+			return true
+		}
+	}
 	return false
 }
 
 // Redactor redacts JSON payloads according to a prepared config.
 type Redactor struct {
-	keys map[string]struct{}
+	keys          map[string]struct{}
+	valuePatterns []*regexp.Regexp
 }
 
 // NewRedactor prepares cfg for repeated use.
@@ -55,7 +66,7 @@ func NewRedactor(cfg RedactConfig) Redactor {
 		addRedactKeys(keys, commonSecretRedactKeys)
 	}
 	addRedactKeys(keys, cfg.Keys)
-	return Redactor{keys: keys}
+	return Redactor{keys: keys, valuePatterns: compileRedactPatterns(cfg.ValuePatterns)}
 }
 
 func addRedactKeys(keys map[string]struct{}, candidates []string) {
@@ -67,18 +78,35 @@ func addRedactKeys(keys map[string]struct{}, candidates []string) {
 	}
 }
 
-func (r Redactor) enabled() bool { return len(r.keys) > 0 }
+func compileRedactPatterns(candidates []string) []*regexp.Regexp {
+	var patterns []*regexp.Regexp
+	for _, pattern := range candidates {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		if re, err := regexp.Compile(pattern); err == nil {
+			patterns = append(patterns, re)
+		}
+	}
+	return patterns
+}
+
+func (r Redactor) enabled() bool { return len(r.keys) > 0 || len(r.valuePatterns) > 0 }
 
 // RedactEnvelope returns a copy of env with matching JSON Raw fields scrubbed.
 func (r Redactor) RedactEnvelope(env Envelope) Envelope {
-	if !r.enabled() || len(env.Raw) == 0 {
+	if !r.enabled() {
 		return env
 	}
-	redacted, ok := r.redactRaw(env.Raw)
-	if !ok {
-		return env
+	if len(env.Raw) > 0 {
+		if redacted, ok := r.redactRaw(env.Raw); ok {
+			env.Raw = redacted
+		}
 	}
-	env.Raw = redacted
+	if env.Text != "" && len(r.valuePatterns) > 0 {
+		env.Text = r.redactString(env.Text)
+	}
 	return env
 }
 
@@ -109,6 +137,14 @@ func (r Redactor) redactValue(v any) bool {
 				changed = true
 				continue
 			}
+			if s, ok := child.(string); ok {
+				redacted := r.redactString(s)
+				if redacted != s {
+					x[key] = redacted
+					changed = true
+				}
+				continue
+			}
 			if r.redactValue(child) {
 				changed = true
 			}
@@ -116,7 +152,15 @@ func (r Redactor) redactValue(v any) bool {
 		return changed
 	case []any:
 		changed := false
-		for _, child := range x {
+		for i, child := range x {
+			if s, ok := child.(string); ok {
+				redacted := r.redactString(s)
+				if redacted != s {
+					x[i] = redacted
+					changed = true
+				}
+				continue
+			}
 			if r.redactValue(child) {
 				changed = true
 			}
@@ -125,6 +169,13 @@ func (r Redactor) redactValue(v any) bool {
 	default:
 		return false
 	}
+}
+
+func (r Redactor) redactString(s string) string {
+	for _, re := range r.valuePatterns {
+		s = re.ReplaceAllString(s, redactedValue)
+	}
+	return s
 }
 
 type redactingSink struct {

--- a/internal/proxy/redact_test.go
+++ b/internal/proxy/redact_test.go
@@ -91,6 +91,47 @@ func TestRedactingSinkScrubsCommonSecretPresetAndExplicitKeys(t *testing.T) {
 	}
 }
 
+func TestRedactingSinkScrubsValuePatternMatches(t *testing.T) {
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{
+		ValuePatterns: []string{`sk-[A-Za-z0-9]+`, `Bearer\s+\S+`},
+	})
+
+	redacted.Emit(Envelope{
+		Raw: json.RawMessage(`{
+			"params":{
+				"message":"use sk-abc123 in this text",
+				"headers":["Bearer token-123", "keep visible"],
+				"count":42
+			}
+		}`),
+		Text: "stderr leaked sk-stderr123",
+	})
+
+	got := sink.byDir("")[0]
+	if got.Text != "stderr leaked [REDACTED]" {
+		t.Fatalf("Text = %q, want stderr leaked [REDACTED]", got.Text)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(got.Raw, &obj); err != nil {
+		t.Fatalf("redacted Raw is invalid JSON: %v", err)
+	}
+	params := obj["params"].(map[string]any)
+	if params["message"] != "use [REDACTED] in this text" {
+		t.Fatalf("message = %v, want value pattern redacted", params["message"])
+	}
+	headers := params["headers"].([]any)
+	if headers[0] != redactedValue {
+		t.Fatalf("headers[0] = %v, want redacted", headers[0])
+	}
+	if headers[1] != "keep visible" {
+		t.Fatalf("headers[1] = %v, want visible", headers[1])
+	}
+	if params["count"] != float64(42) {
+		t.Fatalf("count = %v, want unchanged number", params["count"])
+	}
+}
+
 func TestRedactingSinkLeavesPayloadUnchangedWithoutConfig(t *testing.T) {
 	sink := &captureSink{}
 	redacted := NewRedactingSink(sink, RedactConfig{})


### PR DESCRIPTION
feat: add value redaction patterns

## What and why

Adds opt-in value-level redaction for captured MCP traces.
This introduces --redact-value <regex> for both stdio and HTTP proxy modes. It layers on top of the existing key-based redaction and uses the same fan-out sink, so saved JSONL traces and the live TUI stream receive the same scrubbed copy while proxied client/server bytes remain unchanged.
The new redaction mode replaces regex matches in observed JSON string values, stderr text, and best-effort non-JSON payload bytes. Docs call out the expected limitations: regex redaction can miss encoded/transformed secrets and can overmatch harmless text.
Tests cover CLI parsing, invalid regex rejection, JSON string redaction, stderr redaction, non-JSON raw redaction, and existing key/preset behavior.

fixes #46 

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
