### PR TITLE
feat: add JSON-RPC validation warnings

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -83,6 +83,7 @@ type EventExport struct {
 	Kind      string          `json:"kind"`
 	Method    string          `json:"method,omitempty"`
 	ID        string          `json:"id,omitempty"`
+	Warning   string          `json:"warning,omitempty"`
 	CallIndex *int            `json:"call_index,omitempty"`
 	Raw       json.RawMessage `json:"raw,omitempty"`
 	Text      string          `json:"text,omitempty"`
@@ -302,6 +303,7 @@ func exportEvent(ev store.EventView, callIndex map[string]int) EventExport {
 		Kind:      eventKind(ev.Kind),
 		Method:    ev.Method,
 		ID:        ev.ID,
+		Warning:   ev.Warning,
 		Raw:       ev.Raw,
 		Text:      ev.Text,
 	}
@@ -330,6 +332,9 @@ func writeText(w io.Writer, data SessionExport) error {
 		}
 		if ev.ID != "" {
 			title += " id=" + ev.ID
+		}
+		if ev.Warning != "" {
+			title += " warning=" + ev.Warning
 		}
 		if ev.CallIndex != nil {
 			c := data.Calls[*ev.CallIndex]

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -64,6 +64,25 @@ func TestBuildCorrelatedExport(t *testing.T) {
 	}
 }
 
+func TestBuildIncludesValidationWarning(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "warning.jsonl")
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: time.Now(),
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"id":1,"method":"tools/list"}`),
+	})
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Events) != 1 || out.Events[0].Warning != "missing jsonrpc=2.0" {
+		t.Fatalf("warning not exported: %+v", out.Events)
+	}
+}
+
 func TestWriteFormats(t *testing.T) {
 	st, id, err := LoadFile(sampleLog(t))
 	if err != nil {

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -35,6 +35,7 @@ main { padding:18px 24px 40px; max-width:1180px; margin:0 auto; }
 .status { text-transform:uppercase; font-size:12px; font-weight:700; color:var(--muted); }
 .status.ok { color:var(--resp); }
 .status.error { color:var(--err); }
+.status.warn { color:var(--slow); }
 .status.slow { color:var(--slow); }
 .status.pending { color:var(--slow); }
 .status.bad { color:var(--invalid); }
@@ -150,8 +151,9 @@ const eventMatches = (ev, tokens) => {
 const toneOf = (ev, call) => {
   if (ev.kind === "stderr") return "stderr";
   if (ev.kind === "notification") return "notif";
-  if (ev.kind === "request") return "req";
   if (ev.kind === "invalid") return "invalid";
+  if (ev.warning) return "slow";
+  if (ev.kind === "request") return "req";
   if (ev.kind === "response") {
     if (call && call.status === "error") return "error";
     if (call && call.duration_ms != null && call.duration_ms > SLOW_MS) return "slow";
@@ -161,6 +163,7 @@ const toneOf = (ev, call) => {
 };
 const statusOf = (ev, call) => {
   if (ev.kind === "invalid") return "bad";
+  if (ev.warning) return "warn";
   if (!call) return "";
   if (ev.kind === "response") {
     if (call.status === "error") return "error";
@@ -174,6 +177,7 @@ const renderEvent = (ev) => {
   const tone = toneOf(ev, call);
   const st = statusOf(ev, call);
   const raw = ev.text || textOf(ev.raw);
+  const warning = ev.warning ? "<details open><summary>Warning</summary><pre>" + esc(ev.warning) + "</pre></details>" : "";
   const callBlock = call ? "<details><summary>Correlated call</summary><pre>" + esc(JSON.stringify(call, null, 2)) + "</pre></details>" : "";
   return "<article class=\"event tone-" + tone + "\">" +
     "<div class=\"head\">" +
@@ -183,6 +187,7 @@ const renderEvent = (ev) => {
       "<div class=\"status " + esc(st) + "\">" + esc(st) + "</div>" +
       "<div class=\"time\">" + esc(fmtTime(ev.timestamp)) + "</div>" +
     "</div>" +
+    warning +
     "<details open><summary>Frame</summary><pre>" + esc(raw) + "</pre></details>" +
     callBlock +
   "</article>";

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -89,15 +89,16 @@ type call struct {
 
 // event is the mutable internal timeline entry.
 type event struct {
-	seq    uint64
-	ts     time.Time
-	dir    proxy.Direction
-	kind   EventKind
-	method string
-	id     string
-	raw    json.RawMessage
-	text   string
-	call   *call // set for request/response events
+	seq     uint64
+	ts      time.Time
+	dir     proxy.Direction
+	kind    EventKind
+	method  string
+	id      string
+	raw     json.RawMessage
+	text    string
+	warning string
+	call    *call // set for request/response events
 }
 
 // capabilities holds what the handshake negotiated.
@@ -197,7 +198,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 	case msg.Method == "" && msg.IsResponse():
 		ev.kind = EventResponse
 		ev.id = string(msg.ID)
+		ev.warning = validationWarning(msg)
 		ev.call = sess.completeCall(ev.id, e.Direction, e.TS, msg)
+		if ev.call == nil {
+			ev.warning = appendWarning(ev.warning, "response id has no matching request")
+		}
 		sess.responses++
 		if msg.Error != nil || (ev.call != nil && ev.call.toolErr) {
 			sess.errors++
@@ -206,6 +211,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.kind = EventRequest
 		ev.method = msg.Method
 		ev.id = string(msg.ID)
+		ev.warning = validationWarning(msg)
 		ev.call = sess.openCall(ev.id, msg, e)
 		sess.requests++
 		sess.pending++
@@ -215,9 +221,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 	case msg.Method != "":
 		ev.kind = EventNotification
 		ev.method = msg.Method
+		ev.warning = validationWarning(msg)
 		sess.notifications++
 	default:
 		ev.kind = EventOther
+		ev.warning = validationWarning(msg)
 	}
 
 	sess.events = append(sess.events, ev)
@@ -337,6 +345,35 @@ func isToolError(result json.RawMessage) bool {
 		IsError bool `json:"isError"`
 	}
 	return json.Unmarshal(result, &r) == nil && r.IsError
+}
+
+func validationWarning(msg proxy.RPCMessage) string {
+	var warning string
+	switch {
+	case msg.JSONRPC == "":
+		warning = appendWarning(warning, "missing jsonrpc=2.0")
+	case msg.JSONRPC != "2.0":
+		warning = appendWarning(warning, "jsonrpc must be 2.0")
+	}
+	if msg.Method == "" && len(msg.ID) > 0 {
+		if len(msg.Result) == 0 && msg.Error == nil {
+			warning = appendWarning(warning, "response has neither result nor error")
+		}
+		if len(msg.Result) > 0 && msg.Error != nil {
+			warning = appendWarning(warning, "response has both result and error")
+		}
+	}
+	return warning
+}
+
+func appendWarning(existing, next string) string {
+	if next == "" {
+		return existing
+	}
+	if existing == "" {
+		return next
+	}
+	return existing + "; " + next
 }
 
 func opposite(d proxy.Direction) proxy.Direction {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -168,6 +168,29 @@ func TestInvalidProtocolFrame(t *testing.T) {
 	}
 }
 
+func TestValidationWarnings(t *testing.T) {
+	s := New(0)
+	t0 := time.Now()
+
+	ev := s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"id":1,"method":"tools/list"}`)})
+	if ev.Kind != EventRequest || ev.Warning != "missing jsonrpc=2.0" {
+		t.Fatalf("missing jsonrpc warning = kind %d warning %q", ev.Kind, ev.Warning)
+	}
+
+	ev = s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0,
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":99,"result":{}}`)})
+	if ev.Kind != EventResponse || ev.Call != nil || ev.Warning != "response id has no matching request" {
+		t.Fatalf("unmatched response warning = kind %d call %+v warning %q", ev.Kind, ev.Call, ev.Warning)
+	}
+
+	ev = s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: t0,
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":100}`)})
+	if ev.Kind != EventOther || ev.Warning != "response has neither result nor error" {
+		t.Fatalf("malformed response warning = kind %d warning %q", ev.Kind, ev.Warning)
+	}
+}
+
 // TestConcurrentIngest exercises the lock under -race: many goroutines ingest
 // while another reads snapshots.
 func TestConcurrentIngest(t *testing.T) {

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -44,15 +44,16 @@ func (c CallView) Slow(threshold time.Duration) bool {
 
 // EventView is an immutable snapshot of one timeline entry.
 type EventView struct {
-	Seq    uint64
-	TS     time.Time
-	Dir    proxy.Direction
-	Kind   EventKind
-	Method string
-	ID     string
-	Raw    json.RawMessage
-	Text   string
-	Call   *CallView // set for request/response events
+	Seq     uint64
+	TS      time.Time
+	Dir     proxy.Direction
+	Kind    EventKind
+	Method  string
+	ID      string
+	Raw     json.RawMessage
+	Text    string
+	Warning string
+	Call    *CallView // set for request/response events
 }
 
 // SessionHeader is a lightweight per-session summary for the left panel.
@@ -81,14 +82,15 @@ type CapsView struct {
 // view builds the snapshot for an event. Caller holds at least the read lock.
 func (e *event) view(_ *session) EventView {
 	v := EventView{
-		Seq:    e.seq,
-		TS:     e.ts,
-		Dir:    e.dir,
-		Kind:   e.kind,
-		Method: e.method,
-		ID:     e.id,
-		Raw:    e.raw,
-		Text:   e.text,
+		Seq:     e.seq,
+		TS:      e.ts,
+		Dir:     e.dir,
+		Kind:    e.kind,
+		Method:  e.method,
+		ID:      e.id,
+		Raw:     e.raw,
+		Text:    e.text,
+		Warning: e.warning,
 	}
 	if e.call != nil {
 		cv := e.call.view()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -676,14 +676,18 @@ func callDur(e store.EventView) int64 {
 
 func statusRank(e store.EventView) int {
 	if e.Kind == store.EventInvalid {
-		return 4 // stream corruption sorts above call errors when sorting by status
+		return 5 // stream corruption sorts above call errors when sorting by status
+	}
+	if e.Call != nil && e.Call.Failed() {
+		return 4
+	}
+	if e.Warning != "" {
+		return 3
 	}
 	if e.Call == nil {
 		return 0
 	}
 	switch {
-	case e.Call.Err != nil:
-		return 3
 	case e.Call.State == store.Pending:
 		return 1
 	default:
@@ -755,6 +759,7 @@ func eventSubstr(e store.EventView, q string) bool {
 	if strings.Contains(strings.ToLower(e.Method), q) ||
 		strings.Contains(strings.ToLower(e.ID), q) ||
 		strings.Contains(strings.ToLower(e.Text), q) ||
+		strings.Contains(strings.ToLower(e.Warning), q) ||
 		strings.Contains(strings.ToLower(string(e.Raw)), q) {
 		return true
 	}
@@ -798,6 +803,9 @@ func (m *Model) matchStatus(e store.EventView, v string) bool {
 	if v == "bad" || v == "invalid" {
 		// Invalid frames are not calls, so match them before the Call check.
 		return e.Kind == store.EventInvalid
+	}
+	if v == "warn" || v == "warning" {
+		return e.Warning != ""
 	}
 	if e.Call == nil {
 		return false

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -151,6 +151,8 @@ func TestStreamQueryFilter(t *testing.T) {
 	st.Ingest(env(6, proxy.ServerToClient, `{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"not found"}],"isError":true}}`))
 	// a stray non-JSON-RPC frame on the protocol channel (stdout corruption)
 	st.Ingest(env(7, proxy.ServerToClient, `{"note":"stray line"}`))
+	// a best-effort JSON-RPC validation warning: method but no jsonrpc marker.
+	st.Ingest(env(8, proxy.ClientToServer, `{"id":4,"method":"tools/list"}`))
 
 	m := ready(t, st)
 	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // into stream
@@ -194,16 +196,22 @@ func TestStreamQueryFilter(t *testing.T) {
 			t.Fatalf("%s returned a non-invalid frame: %+v", q, fb.timeline[0])
 		}
 	}
+
+	fw := apply("status:warn")
+	if len(fw.timeline) != 1 || fw.timeline[0].Warning == "" {
+		t.Fatalf("status:warn should match exactly the warning frame, got %+v", fw.timeline)
+	}
 }
 
 // TestStatusRankInvalid checks that sorting by status surfaces invalid frames:
-// stream corruption ranks above call errors, which rank above call-less frames.
+// stream corruption ranks above call errors, then protocol warnings.
 func TestStatusRankInvalid(t *testing.T) {
 	invalid := statusRank(store.EventView{Kind: store.EventInvalid})
 	errored := statusRank(store.EventView{Kind: store.EventResponse, Call: &store.CallView{Err: &proxy.RPCError{}}})
+	warned := statusRank(store.EventView{Kind: store.EventRequest, Warning: "missing jsonrpc=2.0"})
 	none := statusRank(store.EventView{Kind: store.EventStderr})
-	if !(invalid > errored && errored > none) {
-		t.Fatalf("statusRank order wrong: invalid=%d error=%d none=%d (want invalid>error>none)", invalid, errored, none)
+	if !(invalid > errored && errored > warned && warned > none) {
+		t.Fatalf("statusRank order wrong: invalid=%d error=%d warning=%d none=%d", invalid, errored, warned, none)
 	}
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -15,6 +15,7 @@ var (
 	colResp    = lipgloss.Color("114") // soft green — successful response
 	colErr     = lipgloss.Color("203") // red — error
 	colSlow    = lipgloss.Color("215") // warm amber — slow call
+	colWarn    = lipgloss.Color("179") // soft gold — best-effort protocol warning
 	colNotif   = lipgloss.Color("146") // muted lavender — notification
 	colStderr  = lipgloss.Color("245") // muted gray — server stderr (a side channel, not an error)
 	colInvalid = lipgloss.Color("205") // magenta — non-JSON-RPC on the protocol channel (stream corruption)
@@ -43,6 +44,7 @@ type styles struct {
 	resp     lipgloss.Style
 	respErr  lipgloss.Style
 	slow     lipgloss.Style
+	warn     lipgloss.Style
 	invalid  lipgloss.Style
 	notif    lipgloss.Style
 	stderr   lipgloss.Style
@@ -73,6 +75,7 @@ func newStyles() styles {
 		resp:     lipgloss.NewStyle().Foreground(colResp),
 		respErr:  lipgloss.NewStyle().Foreground(colErr).Bold(true),
 		slow:     lipgloss.NewStyle().Foreground(colSlow),
+		warn:     lipgloss.NewStyle().Foreground(colWarn).Bold(true),
 		invalid:  lipgloss.NewStyle().Foreground(colInvalid).Bold(true),
 		notif:    lipgloss.NewStyle().Foreground(colNotif),
 		stderr:   lipgloss.NewStyle().Foreground(colStderr),

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -375,6 +375,14 @@ func (m Model) streamCells(e store.EventView) streamCell {
 		c.dir, c.method = "?", "frame"
 		c.detail = string(e.Raw)
 	}
+	if e.Kind != store.EventInvalid && e.Warning != "" {
+		c.status = "WARN"
+		if c.detail == "" {
+			c.detail = e.Warning
+		} else {
+			c.detail = e.Warning + "; " + c.detail
+		}
+	}
 	return c
 }
 
@@ -408,6 +416,9 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 	if e.Kind == store.EventInvalid {
 		return m.styles.invalid
 	}
+	if e.Warning != "" {
+		return m.styles.warn
+	}
 	if e.Call != nil {
 		switch {
 		case e.Call.State == store.Pending:
@@ -424,6 +435,9 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 }
 
 func (m Model) kindColor(e store.EventView) lipgloss.Color {
+	if e.Kind != store.EventInvalid && e.Warning != "" {
+		return colWarn
+	}
 	switch e.Kind {
 	case store.EventStderr:
 		return colStderr
@@ -470,7 +484,7 @@ func (m Model) renderHelp(h int) string {
 		{"STREAM FILTER QUERY (/)", [][2]string{
 			{"<text>", "substring over method / tool / id / payload"},
 			{"tool:echo", "by tool name"},
-			{"status:err|slow|ok|pending|bad", "by outcome"},
+			{"status:err|warn|slow|ok|pending|bad", "by outcome"},
 			{"kind:req|resp|notify|stderr|invalid", "by message type"},
 			{"dir:c2s|s2c", "by direction (who sent it — orthogonal to kind)"},
 			{"method:tools/call  id:7", "by method / id (tokens are ANDed)"},
@@ -527,6 +541,9 @@ func (m Model) inspectorContent() string {
 	var b strings.Builder
 	b.WriteString(m.styles.panelTitle.Render(" FRAME") + "\n")
 	b.WriteString(fmt.Sprintf(" seq=%d  dir=%s  time=%s\n", e.Seq, e.Dir, e.TS.Format("15:04:05.000")))
+	if e.Warning != "" {
+		b.WriteString(" warning=" + e.Warning + "\n")
+	}
 	if e.Call != nil {
 		c := e.Call
 		b.WriteString(fmt.Sprintf(" method=%s  id=%s  state=%s  dur=%s\n",


### PR DESCRIPTION
## What and why

Fixes #47.

This adds a small best-effort validator slice on top of the observed JSON-RPC/MCP stream without touching forwarded bytes. The store now annotates frames when they are missing `jsonrpc: "2.0"`, when responses have neither `result` nor `error`, when responses have both `result` and `error`, or when a response id does not match an observed request.

The TUI surfaces these frames with a `WARN` status and warning-colored row/detail text, `status:warn` filtering, and inspector warning details. Exported JSON/text/HTML sessions preserve the same warning field so saved traces keep the validation context.

## Validation

- `go test ./internal/store ./internal/tui ./internal/exporter`
- `go test ./cmd/mcpsnoop`
- `PATH="$PATH:$(go env GOPATH)/bin" make check`

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed

AI assistance disclosure: This PR was prepared with AI assistance.
