### PR TITLE
feat: export sessions as OTLP spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ dir:s2c kind:req                  # server-initiated requests (sampling, roots)
 Turn any captured session into a portable file.
 
 ```bash
-mcpsnoop export -T json|html|text [-o file|-] [session-id|log.jsonl]
+mcpsnoop export -T json|html|text|otlp [-o file|-] [session-id|log.jsonl]
 ```
 
 | Format | What you get |
@@ -166,16 +166,18 @@ mcpsnoop export -T json|html|text [-o file|-] [session-id|log.jsonl]
 | `json` | correlated calls, durations, status, tool-level `isError`, capabilities, and raw frames |
 | `html` | a self-contained browser file with search and collapsible JSON |
 | `text` | a pretty plain-text dump |
+| `otlp` | OTLP JSON with a trace per session and a span per correlated call |
 
 ```bash
 mcpsnoop export -T html -o out.html       # an HTML file to open in a browser
 mcpsnoop export -T text server.py-48213   # a specific session, as text
 mcpsnoop export -T json | jq              # the newest session, piped to jq
+mcpsnoop export -T otlp -o trace.json     # import into an OTLP-compatible tracing backend
 ```
 
 Omit `-o` to write to stdout, and omit the session to take the newest. In the
 TUI, press `e` to export the selected session as HTML, or run
-`:export json|html|text [path]` from command mode.
+`:export json|html|text|otlp [path]` from command mode.
 
 ## Watching from another machine
 

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -101,7 +101,7 @@ func main() {
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "http" {
 		os.Exit(runHTTP(args[1:]))
 	}
-	// `mcpsnoop export` renders a captured JSONL session to json/html/text.
+	// `mcpsnoop export` renders a captured JSONL session to json/html/text/otlp.
 	if args := os.Args[1:]; len(args) > 0 && args[0] == "export" {
 		os.Exit(runExport(args[1:]))
 	}
@@ -140,7 +140,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage:\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop [flags] -- <server command> [args...]   run as transparent stdio shim\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop http --target <url> [--listen :7000]     run as transparent HTTP proxy\n")
-		fmt.Fprintf(os.Stderr, "  mcpsnoop export [-T json|html|text] [-o file|-] [session-id|log.jsonl]\n")
+		fmt.Fprintf(os.Stderr, "  mcpsnoop export [-T json|html|text|otlp] [-o file|-] [session-id|log.jsonl]\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop open [session-id|log.jsonl|-]            open a session in the TUI\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop remote [flags] <user@host>              print SSH tunnel command\n")
 		fmt.Fprintf(os.Stderr, "  mcpsnoop                                          run the live TUI (collector)\n")
@@ -213,11 +213,11 @@ func labelFor(command []string) string {
 func runExport(args []string) int {
 	fs := flag.NewFlagSet("mcpsnoop export", flag.ExitOnError)
 	var (
-		formatFlag = fs.String("T", "json", "output format: json, html, or text")
+		formatFlag = fs.String("T", "json", "output format: json, html, text, or otlp")
 		outFlag    = fs.String("o", "-", "output path, or - for stdout")
 	)
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop export [-T json|html|text] [-o file|-] [session-id|log.jsonl]\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: mcpsnoop export [-T json|html|text|otlp] [-o file|-] [session-id|log.jsonl]\n\n")
 		fmt.Fprintf(os.Stderr, "If no session is provided, the newest session log is exported.\n\n")
 		fmt.Fprintf(os.Stderr, "Flags:\n")
 		fs.PrintDefaults()

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,6 +24,7 @@ const (
 	FormatJSON Format = "json"
 	FormatHTML Format = "html"
 	FormatText Format = "text"
+	FormatOTLP Format = "otlp"
 )
 
 type Options struct {
@@ -97,8 +99,10 @@ func ParseFormat(s string) (Format, error) {
 		return FormatHTML, nil
 	case FormatText:
 		return FormatText, nil
+	case FormatOTLP:
+		return FormatOTLP, nil
 	default:
-		return "", fmt.Errorf("unknown export format %q (want json, html, or text)", s)
+		return "", fmt.Errorf("unknown export format %q (want json, html, text, or otlp)", s)
 	}
 }
 
@@ -246,9 +250,141 @@ func Write(w io.Writer, data SessionExport, opts Options) error {
 		return writeHTML(w, data)
 	case FormatText:
 		return writeText(w, data)
+	case FormatOTLP:
+		return writeOTLP(w, data)
 	default:
 		return fmt.Errorf("unknown export format %q", format)
 	}
+}
+
+// otlpExport follows the OTLP JSON encoding. Each correlated MCP call becomes
+// a span in one trace, making a session importable into tracing backends.
+type otlpExport struct {
+	ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
+}
+
+type otlpResourceSpans struct {
+	Resource   otlpResource     `json:"resource"`
+	ScopeSpans []otlpScopeSpans `json:"scopeSpans"`
+}
+
+type otlpResource struct {
+	Attributes []otlpAttribute `json:"attributes"`
+}
+
+type otlpScopeSpans struct {
+	Scope otlpScope  `json:"scope"`
+	Spans []otlpSpan `json:"spans"`
+}
+
+type otlpScope struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+type otlpSpan struct {
+	TraceID           string          `json:"traceId"`
+	SpanID            string          `json:"spanId"`
+	Name              string          `json:"name"`
+	Kind              string          `json:"kind"`
+	StartTimeUnixNano string          `json:"startTimeUnixNano"`
+	EndTimeUnixNano   string          `json:"endTimeUnixNano"`
+	Attributes        []otlpAttribute `json:"attributes"`
+	Status            otlpStatus      `json:"status"`
+}
+
+type otlpStatus struct {
+	Code string `json:"code"`
+}
+
+type otlpAttribute struct {
+	Key   string       `json:"key"`
+	Value otlpAnyValue `json:"value"`
+}
+
+type otlpAnyValue struct {
+	StringValue *string  `json:"stringValue,omitempty"`
+	BoolValue   *bool    `json:"boolValue,omitempty"`
+	DoubleValue *float64 `json:"doubleValue,omitempty"`
+}
+
+func writeOTLP(w io.Writer, data SessionExport) error {
+	traceID := otlpID(16, "trace", data.Session.ID)
+	spans := make([]otlpSpan, 0, len(data.Calls))
+	for _, call := range data.Calls {
+		end := call.StartedAt
+		if call.EndedAt != nil {
+			end = *call.EndedAt
+		}
+		attrs := []otlpAttribute{
+			otlpString("rpc.system", "mcp"),
+			otlpString("rpc.method", call.Method),
+			otlpString("mcpsnoop.call.id", call.ID),
+			otlpString("mcpsnoop.call.status", call.Status),
+			otlpString("mcpsnoop.call.state", call.State),
+			otlpBool("mcpsnoop.call.is_tool", call.IsTool),
+			otlpBool("mcpsnoop.call.is_error", call.IsError),
+			otlpBool("mcpsnoop.call.tool_error", call.ToolError),
+		}
+		if call.ToolName != "" {
+			attrs = append(attrs, otlpString("mcpsnoop.call.tool_name", call.ToolName))
+		}
+		if call.DurationMS != nil {
+			attrs = append(attrs, otlpDouble("mcpsnoop.call.duration_ms", *call.DurationMS))
+		}
+		status := "STATUS_CODE_OK"
+		if call.State == "pending" {
+			status = "STATUS_CODE_UNSET"
+		}
+		if call.IsError {
+			status = "STATUS_CODE_ERROR"
+		}
+		kind := "SPAN_KIND_CLIENT"
+		if call.Direction == proxy.ServerToClient {
+			kind = "SPAN_KIND_SERVER"
+		}
+		spans = append(spans, otlpSpan{
+			TraceID:           traceID,
+			SpanID:            otlpID(8, "span", data.Session.ID, call.ID, string(call.Direction)),
+			Name:              call.Method,
+			Kind:              kind,
+			StartTimeUnixNano: fmt.Sprint(call.StartedAt.UnixNano()),
+			EndTimeUnixNano:   fmt.Sprint(end.UnixNano()),
+			Attributes:        attrs,
+			Status:            otlpStatus{Code: status},
+		})
+	}
+	payload := otlpExport{ResourceSpans: []otlpResourceSpans{{
+		Resource: otlpResource{Attributes: []otlpAttribute{
+			otlpString("service.name", "mcpsnoop"),
+			otlpString("mcpsnoop.session.id", data.Session.ID),
+			otlpString("mcpsnoop.session.label", data.Session.Label),
+		}},
+		ScopeSpans: []otlpScopeSpans{{Scope: otlpScope{Name: "mcpsnoop"}, Spans: spans}},
+	}}}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}
+
+func otlpID(length int, parts ...string) string {
+	h := sha256.New()
+	for _, part := range parts {
+		_, _ = fmt.Fprint(h, part, "\x00")
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)[:length])
+}
+
+func otlpString(key, value string) otlpAttribute {
+	return otlpAttribute{Key: key, Value: otlpAnyValue{StringValue: &value}}
+}
+
+func otlpBool(key string, value bool) otlpAttribute {
+	return otlpAttribute{Key: key, Value: otlpAnyValue{BoolValue: &value}}
+}
+
+func otlpDouble(key string, value float64) otlpAttribute {
+	return otlpAttribute{Key: key, Value: otlpAnyValue{DoubleValue: &value}}
 }
 
 func ExportFile(inputPath string, w io.Writer, opts Options) error {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -162,3 +162,61 @@ func TestResolveSessionPathNoSessions(t *testing.T) {
 		t.Fatal("ResolveSessionPath(\"\") with no saved sessions should error")
 	}
 }
+
+func TestWriteOTLP(t *testing.T) {
+	st, id, err := LoadFile(sampleLog(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatOTLP}); err != nil {
+		t.Fatal(err)
+	}
+
+	var payload struct {
+		ResourceSpans []struct {
+			ScopeSpans []struct {
+				Spans []struct {
+					TraceID           string `json:"traceId"`
+					SpanID            string `json:"spanId"`
+					Name              string `json:"name"`
+					StartTimeUnixNano string `json:"startTimeUnixNano"`
+					EndTimeUnixNano   string `json:"endTimeUnixNano"`
+					Status            struct {
+						Code string `json:"code"`
+					} `json:"status"`
+					Attributes []struct {
+						Key string `json:"key"`
+					} `json:"attributes"`
+				} `json:"spans"`
+			} `json:"scopeSpans"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid OTLP JSON: %v\n%s", err, buf.String())
+	}
+	if len(payload.ResourceSpans) != 1 || len(payload.ResourceSpans[0].ScopeSpans) != 1 {
+		t.Fatalf("unexpected OTLP hierarchy: %s", buf.String())
+	}
+	spans := payload.ResourceSpans[0].ScopeSpans[0].Spans
+	if len(spans) != 1 {
+		t.Fatalf("spans = %d, want 1", len(spans))
+	}
+	span := spans[0]
+	if span.Name != "tools/call" || len(span.TraceID) != 32 || len(span.SpanID) != 16 || span.StartTimeUnixNano == "" || span.EndTimeUnixNano == "" || span.Status.Code != "STATUS_CODE_OK" {
+		t.Fatalf("bad OTLP span: %+v", span)
+	}
+	keys := make(map[string]bool, len(span.Attributes))
+	for _, attr := range span.Attributes {
+		keys[attr.Key] = true
+	}
+	for _, key := range []string{"rpc.system", "rpc.method", "mcpsnoop.call.duration_ms", "mcpsnoop.call.is_error", "mcpsnoop.call.tool_name"} {
+		if !keys[key] {
+			t.Errorf("OTLP span missing %q", key)
+		}
+	}
+}


### PR DESCRIPTION
## What and why

Add `mcpsnoop export -T otlp` to export correlated calls as OpenTelemetry spans. Each captured session becomes one trace with a span per correlated MCP call, preserving its method, duration, status, and tool-error context. The OTLP JSON can be imported into existing tracing backends such as Jaeger and Grafana. Closes #49.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed