### PR TITLE
feat: show stream footer signal counts

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -94,6 +94,7 @@ type Model struct {
 	streamSessionID string // session whose stream we drilled into
 	streamLabel     string
 	timeline        []store.EventView
+	streamSignals   streamSignalCounts
 	selEvent        int
 	query           string // stream filter
 	total           int
@@ -601,6 +602,7 @@ func (m *Model) refresh() {
 	full := m.store.Timeline(m.streamSessionID)
 	m.total = len(full)
 	m.timeline = m.filterEvents(full)
+	m.streamSignals = countStreamSignals(m.timeline, m.store.SlowThreshold())
 	m.sortStream()
 	// A non-chronological sort means we're inspecting, not tailing.
 	if m.streamSort.col != "" && m.streamSort.col != "time" {
@@ -610,6 +612,30 @@ func (m *Model) refresh() {
 		m.selEvent = len(m.timeline) - 1
 	}
 	m.selEvent = clamp(m.selEvent, 0, max(len(m.timeline)-1, 0))
+}
+
+type streamSignalCounts struct {
+	errors int
+	bad    int
+	warn   int
+	slow   int
+}
+
+func countStreamSignals(events []store.EventView, slowThreshold time.Duration) streamSignalCounts {
+	var c streamSignalCounts
+	for _, e := range events {
+		switch {
+		case e.Kind != store.EventInvalid && e.Warning != "":
+			c.warn++
+		case e.Kind == store.EventInvalid:
+			c.bad++
+		case e.Kind == store.EventResponse && e.Call != nil && e.Call.Failed():
+			c.errors++
+		case e.Kind == store.EventResponse && e.Call != nil && e.Call.Slow(slowThreshold):
+			c.slow++
+		}
+	}
+	return c
 }
 
 func sortSessions(s []store.SessionHeader, st sortState) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -203,6 +203,32 @@ func TestStreamQueryFilter(t *testing.T) {
 	}
 }
 
+func TestStreamFooterShowsSignalCounts(t *testing.T) {
+	st := store.New(100 * time.Millisecond)
+	seed(st)
+	st.Ingest(env(5, proxy.ClientToServer, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"fail"}}`))
+	st.Ingest(env(6, proxy.ServerToClient, `{"jsonrpc":"2.0","id":3,"error":{"code":-32601,"message":"unknown tool"}}`))
+	st.Ingest(env(7, proxy.ServerToClient, `{"note":"stray line"}`))
+	st.Ingest(env(8, proxy.ClientToServer, `{"id":4,"method":"tools/list"}`))
+
+	t0 := time.Now()
+	slowReq := env(9, proxy.ClientToServer, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"slow"}}`)
+	slowReq.TS = t0
+	st.Ingest(slowReq)
+	slowResp := env(10, proxy.ServerToClient, `{"jsonrpc":"2.0","id":5,"result":{"content":[]}}`)
+	slowResp.TS = t0.Add(200 * time.Millisecond)
+	st.Ingest(slowResp)
+
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // into stream
+	out := m.View()
+	for _, want := range []string{"10/10 frames", "1 err", "1 bad", "1 warn", "1 slow"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stream footer missing %q\n%s", want, out)
+		}
+	}
+}
+
 // TestStatusRankInvalid checks that sorting by status surfaces invalid frames,
 // stream corruption ranks above call errors, then protocol warnings.
 func TestStatusRankInvalid(t *testing.T) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -89,7 +89,21 @@ func (m Model) renderStatus() string {
 		count = fmt.Sprintf("%d/%d frames", len(m.timeline), m.total)
 	}
 	left := live + sep + m.styles.dim.Render(count)
-	if e := m.totalErrors(); e > 0 {
+	if m.view == viewStream {
+		c := m.streamSignals
+		if c.errors > 0 {
+			left += sep + m.styles.respErr.Render(fmt.Sprintf("%d err", c.errors))
+		}
+		if c.bad > 0 {
+			left += sep + m.styles.invalid.Render(fmt.Sprintf("%d bad", c.bad))
+		}
+		if c.warn > 0 {
+			left += sep + m.styles.warn.Render(fmt.Sprintf("%d warn", c.warn))
+		}
+		if c.slow > 0 {
+			left += sep + m.styles.slow.Render(fmt.Sprintf("%d slow", c.slow))
+		}
+	} else if e := m.totalErrors(); e > 0 {
 		left += sep + m.styles.respErr.Render(fmt.Sprintf("%d err", e))
 	}
 


### PR DESCRIPTION

## What and why

Fixes #68.

The stream footer now summarizes each non-zero signal type it can show in the frame table: `err`, `bad`, `warn`, and `slow`. This keeps the existing frame count while making session health visible without scrolling through the stream.

The counts are derived in `internal/tui` from the rendered timeline, so the change stays scoped to the TUI footer and does not alter capture, storage, export, or proxy behavior.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed (N/A: compact footer status only)

Validation:

```sh
go test ./internal/tui
PATH="$PATH:$(go env GOPATH)/bin" make check
```

AI assistance was used to prepare this contribution.
