### PR TITLE
feat: gate captured sessions on selected signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop` | open the live TUI |
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, or otlp |
+| `mcpsnoop check` | fail CI on errors, invalid frames, or warnings |
 | `mcpsnoop open` | open a saved session in the TUI |
 | `mcpsnoop remote <user@host>` | print the SSH tunnel command |
 | `mcpsnoop demo` | play a scripted session |
@@ -218,6 +219,24 @@ mcpsnoop export -T otlp -o trace.json     # import into an OTLP-compatible traci
 Omit `-o` to write to stdout, and omit the session to take the newest. In the
 TUI, press `e` to export the selected session as HTML, or run
 `:export json|html|text|otlp [path]` from command mode.
+
+## Checking sessions in CI
+
+Gate a recorded agent run on errors, stream corruption, or protocol warnings.
+
+```bash
+mcpsnoop check [--fail-on error,invalid,warn] [session-id|log.jsonl|-]
+```
+
+All three signals fail the check by default. Pass a comma-separated subset to
+select only the conditions relevant to a job. Omit the session to check the
+newest capture, or use `-` to read JSONL from stdin.
+
+```bash
+mcpsnoop check build-agent
+mcpsnoop check --fail-on error,invalid artifacts/session.jsonl
+mcpsnoop check --fail-on warn - < trace.jsonl
+```
 
 ## Watching from another machine
 

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+type checkSignal string
+
+const (
+	checkError   checkSignal = "error"
+	checkInvalid checkSignal = "invalid"
+	checkWarn    checkSignal = "warn"
+)
+
+var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn}
+
+type checkSummary struct {
+	sessionID string
+	errors    int
+	invalid   int
+	warnings  int
+}
+
+func newCheckCmd() *cobra.Command {
+	var failOn string
+	cmd := &cobra.Command{
+		Use:   "check [session-id|log.jsonl|-]",
+		Short: "Fail when a captured session contains selected signals",
+		Long:  "Check a captured session for errors, invalid frames, or warnings. With no session, the newest session log is checked. Use - to read from stdin.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			signals, err := parseCheckSignals(failOn)
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
+				return exitCode(2)
+			}
+
+			var arg string
+			if len(args) == 1 {
+				arg = args[0]
+			}
+			st, sessionID, err := loadCheckSession(cmd, arg)
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
+				return exitCode(1)
+			}
+
+			summary := summarizeCheck(st, sessionID)
+			fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d\n",
+				summary.sessionID, summary.errors, summary.invalid, summary.warnings)
+
+			failed := summary.failed(signals)
+			if len(failed) > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "check failed: %s\n", strings.Join(failed, ","))
+				return exitCode(1)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "check passed")
+			return nil
+		},
+	}
+	cmd.Flags().SortFlags = false
+	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on: error, invalid, warn")
+	return cmd
+}
+
+func parseCheckSignals(value string) (map[checkSignal]bool, error) {
+	signals := make(map[checkSignal]bool)
+	for _, part := range strings.Split(value, ",") {
+		signal := checkSignal(strings.TrimSpace(part))
+		switch signal {
+		case checkError, checkInvalid, checkWarn:
+			signals[signal] = true
+		default:
+			return nil, fmt.Errorf("--fail-on must contain error, invalid, or warn, got %q", part)
+		}
+	}
+	return signals, nil
+}
+
+func loadCheckSession(cmd *cobra.Command, arg string) (*store.Store, string, error) {
+	if arg == "-" {
+		return exporter.Load(cmd.InOrStdin(), "stdin")
+	}
+	path, err := exporter.ResolveSessionPath(arg)
+	if err != nil {
+		return nil, "", err
+	}
+	return exporter.LoadFile(path)
+}
+
+func summarizeCheck(st *store.Store, sessionID string) checkSummary {
+	summary := checkSummary{sessionID: sessionID}
+	for _, header := range st.Sessions() {
+		if header.ID == sessionID {
+			summary.errors = header.Errors
+			break
+		}
+	}
+	for _, event := range st.Timeline(sessionID) {
+		if event.Kind == store.EventInvalid {
+			summary.invalid++
+		}
+		if event.Warning != "" {
+			summary.warnings++
+		}
+	}
+	return summary
+}
+
+func (s checkSummary) failed(selected map[checkSignal]bool) []string {
+	counts := map[checkSignal]int{
+		checkError:   s.errors,
+		checkInvalid: s.invalid,
+		checkWarn:    s.warnings,
+	}
+	var failed []string
+	for _, signal := range checkSignalOrder {
+		if selected[signal] && counts[signal] > 0 {
+			failed = append(failed, string(signal))
+		}
+	}
+	return failed
+}

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func TestCheckFailsOnSelectedSessionSignals(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	writeCheckLog(t, paths.SessionLogPath("s1"), checkSignalEnvelopes()...)
+
+	code, stdout, stderr := executeCheck(t, []string{"s1"}, "")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if stdout != "session s1: errors=2 invalid=1 warnings=1\ncheck failed: error,invalid,warn\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckFailsOnlyOnSelectedSignals(t *testing.T) {
+	log := encodeCheckLog(t, checkSignalEnvelopes()...)
+
+	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "invalid", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 because the fixture contains an invalid frame", code)
+	}
+	if stdout != "session s1: errors=2 invalid=1 warnings=1\ncheck failed: invalid\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckIgnoresUnselectedSignals(t *testing.T) {
+	errorOnly := encodeCheckLog(t, checkErrorEnvelopes()...)
+	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "invalid,warn", "-"}, errorOnly)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if stdout != "session s1: errors=2 invalid=0 warnings=0\ncheck passed\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+	)
+
+	code, stdout, stderr := executeCheck(t, []string{"-"}, log)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if stdout != "session s1: errors=0 invalid=0 warnings=0\ncheck passed\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckRejectsUnknownOrEmptyFailOnValues(t *testing.T) {
+	for _, value := range []string{"error,slow", ""} {
+		t.Run(value, func(t *testing.T) {
+			code, stdout, stderr := executeCheck(t, []string{"--fail-on", value, "-"}, "{}\n")
+			if code != 2 {
+				t.Fatalf("exit = %d, want 2", code)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, "mcpsnoop check: --fail-on") {
+				t.Fatalf("stderr = %q, want --fail-on error", stderr)
+			}
+		})
+	}
+}
+
+func TestCheckReportsMalformedInput(t *testing.T) {
+	code, stdout, stderr := executeCheck(t, []string{"-"}, "not-json\n")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "mcpsnoop check: stdin: invalid JSONL envelope") {
+		t.Fatalf("stderr = %q, want malformed-input error", stderr)
+	}
+}
+
+func executeCheck(t *testing.T, args []string, stdin string) (int, string, string) {
+	t.Helper()
+	cmd := newCheckCmd()
+	cmd.SetArgs(args)
+	cmd.SetIn(strings.NewReader(stdin))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		return 0, stdout.String(), stderr.String()
+	}
+	var code exitCode
+	if !errors.As(err, &code) {
+		t.Fatalf("unexpected command error: %v", err)
+	}
+	return int(code), stdout.String(), stderr.String()
+}
+
+func writeCheckLog(t *testing.T, path string, envelopes ...proxy.Envelope) {
+	t.Helper()
+	data := encodeCheckLog(t, envelopes...)
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func encodeCheckLog(t *testing.T, envelopes ...proxy.Envelope) string {
+	t.Helper()
+	var out bytes.Buffer
+	enc := json.NewEncoder(&out)
+	for _, env := range envelopes {
+		if err := enc.Encode(env); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return out.String()
+}
+
+func checkSignalEnvelopes() []proxy.Envelope {
+	envelopes := checkErrorEnvelopes()
+	return append(envelopes,
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 5, TS: time.Unix(5, 0), Direction: proxy.ServerToClient, Text: "not json-rpc"},
+		checkEnvelope(6, proxy.ClientToServer, `{"id":3,"method":"tools/list"}`),
+	)
+}
+
+func checkErrorEnvelopes() []proxy.Envelope {
+	return []proxy.Envelope{
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"missing"}}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"missing"}}`),
+		checkEnvelope(3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"broken"}}`),
+		checkEnvelope(4, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"isError":true,"content":[]}}`),
+	}
+}
+
+func checkEnvelope(seq uint64, direction proxy.Direction, raw string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID:   "s1",
+		ServerLabel: "srv",
+		Seq:         seq,
+		TS:          time.Unix(int64(seq), 0),
+		Direction:   direction,
+		Raw:         json.RawMessage(raw),
+	}
+}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -185,7 +185,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.SetInterspersed(false)
 
 	cmd.SetVersionTemplate("mcpsnoop {{.Version}}\n")
-	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newOpenCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
+	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newOpenCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
 	return cmd
 }
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -160,17 +160,21 @@ func LoadFile(path string) (*store.Store, string, error) {
 		return nil, "", err
 	}
 	defer f.Close()
+	return Load(f, path)
+}
 
+// Load reads a JSONL envelope stream into a store and returns its first session.
+func Load(r io.Reader, source string) (*store.Store, string, error) {
 	st := store.New(0)
 	var firstSession string
-	dec := json.NewDecoder(f)
+	dec := json.NewDecoder(r)
 	for {
 		var env proxy.Envelope
 		if err := dec.Decode(&env); err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return nil, "", fmt.Errorf("%s: invalid JSONL envelope: %w", path, err)
+			return nil, "", fmt.Errorf("%s: invalid JSONL envelope: %w", source, err)
 		}
 		if firstSession == "" {
 			firstSession = env.SessionID
@@ -178,7 +182,7 @@ func LoadFile(path string) (*store.Store, string, error) {
 		st.Ingest(env)
 	}
 	if firstSession == "" {
-		return nil, "", fmt.Errorf("%s: no envelopes found", path)
+		return nil, "", fmt.Errorf("%s: no envelopes found", source)
 	}
 	return st, firstSession, nil
 }


### PR DESCRIPTION
## What and why

Add `mcpsnoop check [--fail-on error,invalid,warn] [session-id|log.jsonl|-]` so recorded MCP runs can gate CI. The command reuses the store's existing classifications, reports error/invalid/warning counts, and exits non-zero only when a selected signal is present. Saved session IDs, paths, the newest capture, and piped JSONL are supported.

Closes #65.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed

## Validation

- `PATH="$PATH:$(go env GOPATH)/bin" GOTOOLCHAIN=go1.26.0 make check`
- built CLI help and stdin warning/failure smokes