### PR TITLE
feat: narrow trace redaction to selected JSON values

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ label = "filesystem"
 trace-file = "trace.jsonl"
 redact-secrets = true
 redact-key = "token,authorization"
+redact-path = "$.params.arguments.password"
 no-trace = false
 ```
 
@@ -292,10 +293,13 @@ Captured frames can include prompts, tool arguments, credentials, and tool
 results. If payloads can carry secrets, opt in to redaction to scrub the
 observed trace copies while the proxied bytes still pass through unchanged.
 Key-based redaction replaces whole values under matching JSON object keys.
+Path-based redaction replaces only values selected by a JSONPath expression,
+which is useful when a common key name is sensitive in one location but safe in
+another. Repeat `--redact-path` to scrub more than one location.
 Value-based redaction applies regular expressions to observed string values,
-stderr text, and non-JSON text frames. Both modes are best effort. Regexes can
-miss secrets, overmatch harmless text, or fail to see transformed or encoded
-values.
+stderr text, and non-JSON text frames. All redaction modes are best effort.
+Regexes can miss secrets, overmatch harmless text, or fail to see transformed
+or encoded values.
 
 ```bash
 # built-in preset of common secret keys
@@ -303,6 +307,12 @@ mcpsnoop --redact-secrets -- node build/index.js
 
 # or name your own keys
 mcpsnoop --redact-key token,api_key,password -- node build/index.js
+
+# scrub one location without redacting every field named password
+mcpsnoop --redact-path '$.params.arguments.password' -- node build/index.js
+
+# wildcards scrub every matching array element
+mcpsnoop --redact-path '$.params.arguments.accounts[*].password' -- node build/index.js
 
 # scrub obvious token-shaped values outside known keys
 mcpsnoop --redact-value 'sk-[A-Za-z0-9]+' -- node build/index.js

--- a/cmd/mcpsnoop/config.go
+++ b/cmd/mcpsnoop/config.go
@@ -17,6 +17,7 @@ type config struct {
 	NoTrace       bool
 	RedactSecrets bool
 	RedactKeys    []string
+	RedactPaths   redactPathsFlag
 }
 
 func loadConfig() (config, bool, error) {
@@ -122,6 +123,11 @@ func parseConfig(r io.Reader) (config, error) {
 			}
 			cfg.RedactKeys = []string(keys)
 
+		case "redact-path":
+			if err := cfg.RedactPaths.Set(value); err != nil {
+				return config{}, err
+			}
+
 		default:
 			return config{}, fmt.Errorf("unknown config key %q", key)
 		}
@@ -141,6 +147,7 @@ func applyConfig(
 	label, traceFile *string,
 	noTrace, redactSecrets *bool,
 	redactKeys *redactKeysFlag,
+	redactPaths *redactPathsFlag,
 ) {
 	if !ok {
 		return
@@ -164,5 +171,9 @@ func applyConfig(
 
 	if !fs.Changed("redact-key") {
 		*redactKeys = redactKeysFlag(cfg.RedactKeys)
+	}
+
+	if !fs.Changed("redact-path") {
+		*redactPaths = cfg.RedactPaths
 	}
 }

--- a/cmd/mcpsnoop/config_test.go
+++ b/cmd/mcpsnoop/config_test.go
@@ -32,6 +32,10 @@ func TestParseConfigEmpty(t *testing.T) {
 	if len(cfg.RedactKeys) != 0 {
 		t.Fatal("expected no redact keys")
 	}
+
+	if len(cfg.RedactPaths) != 0 {
+		t.Fatal("expected no redact paths")
+	}
 }
 
 func TestParseConfigLabel(t *testing.T) {
@@ -84,6 +88,27 @@ redact-key = "token,api_key"
 	}
 }
 
+func TestParseConfigRedactPaths(t *testing.T) {
+	cfg, err := parseConfig(strings.NewReader(`
+redact-path = "$.params.arguments.password"
+redact-path = "$.result.token"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := cfg.RedactPaths.String(), "$.params.arguments.password,$.result.token"; got != want {
+		t.Fatalf("RedactPaths = %q, want %q", got, want)
+	}
+}
+
+func TestParseConfigRejectsInvalidRedactPath(t *testing.T) {
+	_, err := parseConfig(strings.NewReader(`redact-path = "$.["`))
+	if err == nil {
+		t.Fatal("parseConfig returned nil error")
+	}
+}
+
 func TestParseConfigUnknownKey(t *testing.T) {
 	_, err := parseConfig(strings.NewReader(`
 foo = "bar"
@@ -119,7 +144,9 @@ func TestApplyConfigUsesConfigWhenFlagNotSet(t *testing.T) {
 	noTrace := fs.Bool("no-trace", false, "")
 	redactSecrets := fs.Bool("redact-secrets", false, "")
 	var redactKeys redactKeysFlag
+	var redactPaths redactPathsFlag
 	fs.Var(&redactKeys, "redact-key", "")
+	fs.Var(&redactPaths, "redact-path", "")
 
 	cfg := config{
 		Label:         "filesystem",
@@ -128,8 +155,11 @@ func TestApplyConfigUsesConfigWhenFlagNotSet(t *testing.T) {
 		RedactSecrets: true,
 		RedactKeys:    []string{"token", "api_key"},
 	}
+	if err := cfg.RedactPaths.Set("$.params.arguments.password"); err != nil {
+		t.Fatal(err)
+	}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactPaths)
 
 	if *label != "filesystem" {
 		t.Fatalf("expected label %q, got %q", "filesystem", *label)
@@ -158,6 +188,10 @@ func TestApplyConfigUsesConfigWhenFlagNotSet(t *testing.T) {
 			t.Fatalf("expected %q at index %d, got %q", want[i], i, redactKeys[i])
 		}
 	}
+
+	if got, want := redactPaths.String(), "$.params.arguments.password"; got != want {
+		t.Fatalf("redact paths = %q, want %q", got, want)
+	}
 }
 
 func TestApplyConfigExplicitFlagOverridesConfig(t *testing.T) {
@@ -168,7 +202,9 @@ func TestApplyConfigExplicitFlagOverridesConfig(t *testing.T) {
 	noTrace := fs.Bool("no-trace", false, "")
 	redactSecrets := fs.Bool("redact-secrets", false, "")
 	var redactKeys redactKeysFlag
+	var redactPaths redactPathsFlag
 	fs.Var(&redactKeys, "redact-key", "")
+	fs.Var(&redactPaths, "redact-path", "")
 
 	if err := fs.Parse([]string{"--label=cli"}); err != nil {
 		t.Fatal(err)
@@ -178,7 +214,7 @@ func TestApplyConfigExplicitFlagOverridesConfig(t *testing.T) {
 		Label: "from-config",
 	}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactPaths)
 
 	if *label != "cli" {
 		t.Fatalf("expected CLI value %q, got %q", "cli", *label)
@@ -193,7 +229,9 @@ func TestApplyConfigNoConfigFile(t *testing.T) {
 	noTrace := fs.Bool("no-trace", false, "")
 	redactSecrets := fs.Bool("redact-secrets", false, "")
 	var redactKeys redactKeysFlag
+	var redactPaths redactPathsFlag
 	fs.Var(&redactKeys, "redact-key", "")
+	fs.Var(&redactPaths, "redact-path", "")
 
 	cfg := config{
 		Label:         "filesystem",
@@ -203,7 +241,7 @@ func TestApplyConfigNoConfigFile(t *testing.T) {
 		RedactKeys:    []string{"token"},
 	}
 
-	applyConfig(fs, cfg, false, label, traceFile, noTrace, redactSecrets, &redactKeys)
+	applyConfig(fs, cfg, false, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactPaths)
 
 	if *label != "" {
 		t.Fatal("expected label to remain unchanged")
@@ -234,7 +272,9 @@ func TestApplyConfigExplicitFalseBoolOverridesConfig(t *testing.T) {
 	noTrace := fs.Bool("no-trace", false, "")
 	redactSecrets := fs.Bool("redact-secrets", false, "")
 	var redactKeys redactKeysFlag
+	var redactPaths redactPathsFlag
 	fs.Var(&redactKeys, "redact-key", "")
+	fs.Var(&redactPaths, "redact-path", "")
 
 	if err := fs.Parse([]string{"--no-trace=false"}); err != nil {
 		t.Fatal(err)
@@ -244,7 +284,7 @@ func TestApplyConfigExplicitFalseBoolOverridesConfig(t *testing.T) {
 		NoTrace: true,
 	}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactPaths)
 
 	if *noTrace {
 		t.Fatal("expected explicit --no-trace=false to override config")
@@ -258,17 +298,46 @@ func TestApplyConfigExplicitRedactKeyOverridesConfig(t *testing.T) {
 	noTrace := fs.Bool("no-trace", false, "")
 	redactSecrets := fs.Bool("redact-secrets", false, "")
 	var redactKeys redactKeysFlag
+	var redactPaths redactPathsFlag
 	fs.Var(&redactKeys, "redact-key", "")
+	fs.Var(&redactPaths, "redact-path", "")
 
 	if err := fs.Parse([]string{"--redact-key=cli-key"}); err != nil {
 		t.Fatal(err)
 	}
 	cfg := config{RedactKeys: []string{"config-key"}}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactPaths)
 
 	if len(redactKeys) != 1 || redactKeys[0] != "cli-key" {
 		t.Fatalf("expected explicit redact-key to win, got %v", redactKeys)
+	}
+}
+
+func TestApplyConfigExplicitRedactPathOverridesConfig(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	label := fs.String("label", "", "")
+	traceFile := fs.String("trace-file", "", "")
+	noTrace := fs.Bool("no-trace", false, "")
+	redactSecrets := fs.Bool("redact-secrets", false, "")
+	var redactKeys redactKeysFlag
+	var redactPaths redactPathsFlag
+	fs.Var(&redactKeys, "redact-key", "")
+	fs.Var(&redactPaths, "redact-path", "")
+
+	if err := fs.Parse([]string{"--redact-path=$.cli.password"}); err != nil {
+		t.Fatal(err)
+	}
+	var configPaths redactPathsFlag
+	if err := configPaths.Set("$.config.password"); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config{RedactPaths: configPaths}
+
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactPaths)
+
+	if got, want := redactPaths.String(), "$.cli.password"; got != want {
+		t.Fatalf("redact paths = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -94,11 +94,36 @@ func (f *redactValuesFlag) Set(value string) error {
 
 func (f *redactValuesFlag) Type() string { return "regexp" }
 
-func redactConfig(commonSecrets bool, keys redactKeysFlag, values redactValuesFlag) proxy.RedactConfig {
+type redactPathsFlag []proxy.RedactPath
+
+func (f *redactPathsFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	paths := make([]string, len(*f))
+	for i, path := range *f {
+		paths[i] = path.String()
+	}
+	return strings.Join(paths, ",")
+}
+
+func (f *redactPathsFlag) Set(value string) error {
+	path, err := proxy.ParseRedactPath(value)
+	if err != nil {
+		return fmt.Errorf("invalid redact JSONPath %q: %w", value, err)
+	}
+	*f = append(*f, path)
+	return nil
+}
+
+func (f *redactPathsFlag) Type() string { return "jsonpath" }
+
+func redactConfig(commonSecrets bool, keys redactKeysFlag, values redactValuesFlag, paths redactPathsFlag) proxy.RedactConfig {
 	return proxy.RedactConfig{
 		CommonSecrets: commonSecrets,
 		Keys:          []string(keys),
 		ValuePatterns: []string(values),
+		Paths:         []proxy.RedactPath(paths),
 	}
 }
 
@@ -146,6 +171,7 @@ func newRootCmd() *cobra.Command {
 		noTrace, redactSecrets bool
 		redactKeys             redactKeysFlag
 		redactValues           redactValuesFlag
+		redactPaths            redactPathsFlag
 	)
 	cmd := &cobra.Command{
 		Use:   "mcpsnoop [flags] -- <server command> [args...]",
@@ -169,8 +195,8 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				fmt.Fprintln(os.Stderr, "mcpsnoop:", err)
 				return exitCode(1)
 			}
-			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys)
-			return codeOf(runShimFn(args, label, traceFile, noTrace, redactConfig(redactSecrets, redactKeys, redactValues)))
+			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys, &redactPaths)
+			return codeOf(runShimFn(args, label, traceFile, noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths)))
 		},
 	}
 	flags := cmd.Flags()
@@ -181,6 +207,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
 	flags.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text, repeatable")
+	flags.Var(&redactPaths, "redact-path", "JSONPath selecting values to scrub in saved trace payloads, repeatable")
 	// Stop parsing at the first positional so the wrapped command keeps its flags.
 	flags.SetInterspersed(false)
 
@@ -368,6 +395,7 @@ func newHTTPCmd() *cobra.Command {
 		noTrace, redactSecrets bool
 		redactKeys             redactKeysFlag
 		redactValues           redactValuesFlag
+		redactPaths            redactPathsFlag
 	)
 	cmd := &cobra.Command{
 		Use:   "http --target <url> [--listen :7000]",
@@ -379,7 +407,7 @@ func newHTTPCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "mcpsnoop http:", err)
 				return exitCode(1)
 			}
-			applyConfig(cmd.Flags(), cfg, ok, &label, nil, &noTrace, &redactSecrets, &redactKeys)
+			applyConfig(cmd.Flags(), cfg, ok, &label, nil, &noTrace, &redactSecrets, &redactKeys, &redactPaths)
 			if target == "" {
 				fmt.Fprintln(os.Stderr, "mcpsnoop http: --target is required")
 				return exitCode(2)
@@ -394,7 +422,7 @@ func newHTTPCmd() *cobra.Command {
 			}
 			sessionID := fmt.Sprintf("%s-%d", lbl, os.Getpid())
 
-			sink := traceSink(sessionID, "", noTrace, redactConfig(redactSecrets, redactKeys, redactValues))
+			sink := traceSink(sessionID, "", noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths))
 			defer sink.Close()
 
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -423,6 +451,7 @@ func newHTTPCmd() *cobra.Command {
 	f.BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	f.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
 	f.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text, repeatable")
+	f.Var(&redactPaths, "redact-path", "JSONPath selecting values to scrub in saved trace payloads, repeatable")
 	return cmd
 }
 

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -116,7 +116,7 @@ func TestRedactKeysFlagParsesCommaSeparatedAndRepeatedValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := redactConfig(false, flag, nil)
+	cfg := redactConfig(false, flag, nil, nil)
 	if cfg.CommonSecrets {
 		t.Fatal("CommonSecrets = true, want false")
 	}
@@ -134,7 +134,7 @@ func TestRedactKeysFlagConfigEnablesCommonSecretsPreset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := redactConfig(true, flag, nil)
+	cfg := redactConfig(true, flag, nil, nil)
 	if !cfg.CommonSecrets {
 		t.Fatal("CommonSecrets = false, want true")
 	}
@@ -211,7 +211,7 @@ func TestRedactValuesFlagParsesRepeatedRegexes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := redactConfig(false, nil, flag)
+	cfg := redactConfig(false, nil, flag, nil)
 	if got, want := cfg.ValuePatterns, []string{`sk-[A-Za-z0-9]+`, `Bearer\s+\S+`}; !slices.Equal(got, want) {
 		t.Fatalf("ValuePatterns = %v, want %v", got, want)
 	}
@@ -224,6 +224,31 @@ func TestRedactValuesFlagRejectsInvalidRegex(t *testing.T) {
 	var flag redactValuesFlag
 	if err := flag.Set(`[`); err == nil {
 		t.Fatal("Set returned nil, want invalid regex error")
+	}
+}
+
+func TestRedactPathsFlagParsesRepeatedJSONPaths(t *testing.T) {
+	var flag redactPathsFlag
+	if err := flag.Set("$.params.arguments.password"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Set("$.result.token"); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := flag.String(), "$.params.arguments.password,$.result.token"; got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+	cfg := redactConfig(false, nil, nil, flag)
+	if len(cfg.Paths) != 2 {
+		t.Fatalf("len(Paths) = %d, want 2", len(cfg.Paths))
+	}
+}
+
+func TestRedactPathsFlagRejectsInvalidJSONPath(t *testing.T) {
+	var flag redactPathsFlag
+	if err := flag.Set("$.["); err == nil {
+		t.Fatal("Set returned nil, want invalid JSONPath error")
 	}
 }
 
@@ -260,7 +285,11 @@ func TestTraceSinkRedactsFileAndLiveSocket(t *testing.T) {
 	}()
 
 	traceFile := filepath.Join(t.TempDir(), "session.jsonl")
-	sink := traceSink("s1", traceFile, false, proxy.RedactConfig{Keys: []string{"token"}})
+	path, err := proxy.ParseRedactPath("$.params.token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := traceSink("s1", traceFile, false, proxy.RedactConfig{Paths: []proxy.RedactPath{path}})
 	closed := false
 	t.Cleanup(func() {
 		if !closed {

--- a/docs/POST_MORTEM.md
+++ b/docs/POST_MORTEM.md
@@ -86,13 +86,15 @@ off and use the default location.
 
 To keep common secret fields out of saved traces, pass `--redact-secrets` when
 you wrap the server. Add `--redact-key` for project-specific fields, and
+`--redact-path` to scrub only values at a specific JSONPath, such as
+`$.params.arguments.password`. Add
 `--redact-value` for best-effort regular expression scrubbing inside observed
 string values, stderr text, and non-JSON text frames. Regex redaction can miss
 encoded or transformed secrets and can overmatch harmless text, so review
 anything you plan to share.
 
 ```bash
-mcpsnoop --redact-secrets --redact-key tenant_api_key --redact-value 'sk-[A-Za-z0-9]+' -- node build/index.js
+mcpsnoop --redact-secrets --redact-key tenant_api_key --redact-path '$.params.arguments.password' --redact-value 'sk-[A-Za-z0-9]+' -- node build/index.js
 ```
 
 ## What to include in a bug report

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/ohler55/ojg v1.28.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/ohler55/ojg v1.28.2 h1:HjWBhdvw0o0yrgiVE+qzlK0awPeH1V6S1bLHE7wV4H8=
+github.com/ohler55/ojg v1.28.2/go.mod h1:/Y5dGWkekv9ocnUixuETqiL58f+5pAsUfg5P8e7Pa2o=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/proxy/redact.go
+++ b/internal/proxy/redact.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
+
+	"github.com/ohler55/ojg/jp"
 )
 
 const redactedValue = "[REDACTED]"
@@ -33,9 +35,33 @@ type RedactConfig struct {
 	// ValuePatterns are regular expressions whose matches inside observed
 	// string payloads should be replaced.
 	ValuePatterns []string
+
+	// Paths identify JSON values that should be replaced.
+	Paths []RedactPath
 }
 
-// Enabled reports whether cfg has any key-based redaction rule.
+// RedactPath is a validated JSONPath expression used for trace redaction.
+type RedactPath struct {
+	raw  string
+	expr jp.Expr
+}
+
+// ParseRedactPath validates path for use as a modifying JSONPath expression.
+func ParseRedactPath(path string) (RedactPath, error) {
+	path = strings.TrimSpace(path)
+	expr, err := jp.ParseString(path)
+	if err != nil {
+		return RedactPath{}, err
+	}
+	if _, err := expr.Modify(nil, func(value any) (any, bool) { return value, false }); err != nil {
+		return RedactPath{}, err
+	}
+	return RedactPath{raw: path, expr: expr}, nil
+}
+
+func (p RedactPath) String() string { return p.raw }
+
+// Enabled reports whether cfg has any redaction rule.
 func (cfg RedactConfig) Enabled() bool {
 	if cfg.CommonSecrets {
 		return true
@@ -50,13 +76,14 @@ func (cfg RedactConfig) Enabled() bool {
 			return true
 		}
 	}
-	return false
+	return len(cfg.Paths) > 0
 }
 
 // Redactor redacts JSON payloads according to a prepared config.
 type Redactor struct {
 	keys          map[string]struct{}
 	valuePatterns []*regexp.Regexp
+	paths         []RedactPath
 }
 
 // NewRedactor prepares cfg for repeated use.
@@ -66,7 +93,11 @@ func NewRedactor(cfg RedactConfig) Redactor {
 		addRedactKeys(keys, commonSecretRedactKeys)
 	}
 	addRedactKeys(keys, cfg.Keys)
-	return Redactor{keys: keys, valuePatterns: compileRedactPatterns(cfg.ValuePatterns)}
+	return Redactor{
+		keys:          keys,
+		valuePatterns: compileRedactPatterns(cfg.ValuePatterns),
+		paths:         cfg.Paths,
+	}
 }
 
 func addRedactKeys(keys map[string]struct{}, candidates []string) {
@@ -92,7 +123,9 @@ func compileRedactPatterns(candidates []string) []*regexp.Regexp {
 	return patterns
 }
 
-func (r Redactor) enabled() bool { return len(r.keys) > 0 || len(r.valuePatterns) > 0 }
+func (r Redactor) enabled() bool {
+	return len(r.keys) > 0 || len(r.valuePatterns) > 0 || len(r.paths) > 0
+}
 
 // RedactEnvelope returns a copy of env with matching JSON Raw fields scrubbed.
 func (r Redactor) RedactEnvelope(env Envelope) Envelope {
@@ -117,7 +150,11 @@ func (r Redactor) redactRaw(raw json.RawMessage) (json.RawMessage, bool) {
 	if err := dec.Decode(&v); err != nil {
 		return nil, false
 	}
-	if !r.redactValue(v) {
+	changed := r.redactPaths(&v)
+	if r.redactValue(v) {
+		changed = true
+	}
+	if !changed {
 		return nil, false
 	}
 	b, err := json.Marshal(v)
@@ -125,6 +162,23 @@ func (r Redactor) redactRaw(raw json.RawMessage) (json.RawMessage, bool) {
 		return nil, false
 	}
 	return b, true
+}
+
+func (r Redactor) redactPaths(value *any) bool {
+	changed := false
+	for _, path := range r.paths {
+		pathChanged := false
+		modified, err := path.expr.Modify(*value, func(any) (any, bool) {
+			pathChanged = true
+			return redactedValue, true
+		})
+		if err != nil {
+			continue
+		}
+		*value = modified
+		changed = changed || pathChanged
+	}
+	return changed
 }
 
 func (r Redactor) redactValue(v any) bool {

--- a/internal/proxy/redact_test.go
+++ b/internal/proxy/redact_test.go
@@ -132,6 +132,104 @@ func TestRedactingSinkScrubsValuePatternMatches(t *testing.T) {
 	}
 }
 
+func TestRedactingSinkScrubsOnlyMatchingJSONPath(t *testing.T) {
+	path, err := ParseRedactPath("$.params.arguments.password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{Paths: []RedactPath{path}})
+	raw := json.RawMessage(`{
+		"params":{
+			"password":"keep-param",
+			"arguments":{"password":"secret","nested":{"password":"keep-nested"}}
+		},
+		"password":"keep-root"
+	}`)
+
+	redacted.Emit(Envelope{Raw: raw})
+
+	var obj map[string]any
+	if err := json.Unmarshal(sink.byDir("")[0].Raw, &obj); err != nil {
+		t.Fatal(err)
+	}
+	params := obj["params"].(map[string]any)
+	args := params["arguments"].(map[string]any)
+	if args["password"] != redactedValue {
+		t.Fatalf("arguments.password = %v, want redacted", args["password"])
+	}
+	if params["password"] != "keep-param" || obj["password"] != "keep-root" {
+		t.Fatalf("same-named fields outside the path were changed: %v", obj)
+	}
+	if got := args["nested"].(map[string]any)["password"]; got != "keep-nested" {
+		t.Fatalf("nested password = %v, want unchanged", got)
+	}
+}
+
+func TestRedactingSinkScrubsEveryJSONPathWildcardMatch(t *testing.T) {
+	path, err := ParseRedactPath("$.params.arguments.accounts[*].password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{Paths: []RedactPath{path}})
+
+	redacted.Emit(Envelope{Raw: json.RawMessage(`{
+		"params":{"arguments":{"accounts":[
+			{"password":"first","name":"one"},
+			{"password":"second","name":"two"}
+		]}}
+	}`)})
+
+	var obj map[string]any
+	if err := json.Unmarshal(sink.byDir("")[0].Raw, &obj); err != nil {
+		t.Fatal(err)
+	}
+	accounts := obj["params"].(map[string]any)["arguments"].(map[string]any)["accounts"].([]any)
+	for i, account := range accounts {
+		got := account.(map[string]any)
+		if got["password"] != redactedValue {
+			t.Fatalf("accounts[%d].password = %v, want redacted", i, got["password"])
+		}
+	}
+}
+
+func TestRedactingSinkLeavesRawBytesUnchangedWhenJSONPathDoesNotMatch(t *testing.T) {
+	path, err := ParseRedactPath("$.params.arguments.password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{Paths: []RedactPath{path}})
+	raw := json.RawMessage(`{ "params": { "arguments": { "token": "visible" } } }`)
+
+	redacted.Emit(Envelope{Raw: raw})
+
+	if got := sink.byDir("")[0].Raw; string(got) != string(raw) {
+		t.Fatalf("Raw = %s, want byte-for-byte unchanged %s", got, raw)
+	}
+}
+
+func TestParseRedactPathRejectsInvalidOrNonModifiableExpressions(t *testing.T) {
+	for _, path := range []string{"", "$.[", "$.."} {
+		t.Run(path, func(t *testing.T) {
+			if _, err := ParseRedactPath(path); err == nil {
+				t.Fatalf("ParseRedactPath(%q) returned nil error", path)
+			}
+		})
+	}
+}
+
+func TestRedactConfigEnabledByJSONPath(t *testing.T) {
+	path, err := ParseRedactPath("$")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !(RedactConfig{Paths: []RedactPath{path}}).Enabled() {
+		t.Fatal("RedactConfig.Enabled() = false, want true")
+	}
+}
+
 func TestRedactingSinkLeavesPayloadUnchangedWithoutConfig(t *testing.T) {
 	sink := &captureSink{}
 	redacted := NewRedactingSink(sink, RedactConfig{})


### PR DESCRIPTION
## What and why

Adds repeatable `--redact-path` support for scrubbing only JSON values selected by a JSONPath expression. This avoids blanket-redacting common keys such as `password` when only one location is sensitive.

Paths are validated once at CLI or config parsing, then applied to the decoded trace copy before the existing key and regex layers. Exact paths, wildcard matches, invalid paths, config precedence, unchanged no-match payloads, and durable/live trace fan-out are covered.

Closes #67.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed