### PR TITLE
feat: stream completed calls to OTLP collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,28 @@ Omit `-o` to write to stdout, and omit the session to take the newest, or pass
 `-` to read JSONL from stdin. In the TUI, press `e` to export the selected
 session as HTML, or run `:export json|html|text|otlp [path]` from command mode.
 
+### Stream completed calls to an OTLP collector
+
+Send spans while the proxy is running by pointing it at an OTLP/HTTP JSON
+traces endpoint. Repeat `--otlp-header` for collector authentication or tenant
+headers.
+
+```bash
+mcpsnoop \
+  --otlp-endpoint http://localhost:4318/v1/traces \
+  --otlp-header "Authorization=Bearer $OTLP_TOKEN" \
+  -- node build/index.js
+
+mcpsnoop http \
+  --target http://localhost:3000/mcp \
+  --otlp-endpoint http://localhost:4318/v1/traces
+```
+
+Delivery is best-effort and never blocks proxied MCP traffic. If the collector
+is unavailable, mcpsnoop retries in the background and drops new trace frames
+when its bounded queue is full. The normal JSONL session log remains the durable
+record.
+
 ## Checking sessions in CI
 
 Gate a recorded agent run on errors, stream corruption, protocol warnings, slow

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -14,18 +14,21 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/otlpsink"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
@@ -118,6 +121,69 @@ func (f *redactPathsFlag) Set(value string) error {
 
 func (f *redactPathsFlag) Type() string { return "jsonpath" }
 
+type otlpHeadersFlag http.Header
+
+func (f *otlpHeadersFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	var headers []string
+	for name, values := range http.Header(*f) {
+		for _, value := range values {
+			headers = append(headers, name+"="+value)
+		}
+	}
+	sort.Strings(headers)
+	return strings.Join(headers, ",")
+}
+
+func (f *otlpHeadersFlag) Set(value string) error {
+	name, headerValue, ok := strings.Cut(value, "=")
+	name = strings.TrimSpace(name)
+	headerValue = strings.TrimSpace(headerValue)
+	if !ok || !validHeaderName(name) || strings.ContainsAny(headerValue, "\r\n") {
+		return fmt.Errorf("invalid OTLP header %q, want Name=Value", value)
+	}
+	if *f == nil {
+		*f = make(otlpHeadersFlag)
+	}
+	http.Header(*f).Add(name, headerValue)
+	return nil
+}
+
+func (f *otlpHeadersFlag) Type() string { return "header" }
+
+func validHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') && !strings.ContainsRune("!#$%&'*+-.^_`|~", r) {
+			return false
+		}
+	}
+	return true
+}
+
+type traceOptions struct {
+	OTLPEndpoint string
+	OTLPHeaders  http.Header
+}
+
+func parseTraceOptions(endpoint string, headers otlpHeadersFlag) (traceOptions, error) {
+	if endpoint == "" {
+		if len(headers) != 0 {
+			return traceOptions{}, errors.New("--otlp-header requires --otlp-endpoint")
+		}
+		return traceOptions{}, nil
+	}
+	u, err := url.ParseRequestURI(endpoint)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return traceOptions{}, fmt.Errorf("invalid OTLP endpoint %q, want an http(s) URL", endpoint)
+	}
+	return traceOptions{OTLPEndpoint: endpoint, OTLPHeaders: http.Header(headers)}, nil
+}
+
 func redactConfig(commonSecrets bool, keys redactKeysFlag, values redactValuesFlag, paths redactPathsFlag) proxy.RedactConfig {
 	return proxy.RedactConfig{
 		CommonSecrets: commonSecrets,
@@ -169,10 +235,12 @@ func execute(args []string) int {
 func newRootCmd() *cobra.Command {
 	var (
 		label, traceFile       string
+		otlpEndpoint           string
 		noTrace, redactSecrets bool
 		redactKeys             redactKeysFlag
 		redactValues           redactValuesFlag
 		redactPaths            redactPathsFlag
+		otlpHeaders            otlpHeadersFlag
 	)
 	cmd := &cobra.Command{
 		Use:   "mcpsnoop [flags] -- <server command> [args...]",
@@ -197,13 +265,19 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				return exitCode(1)
 			}
 			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys, &redactPaths)
-			return codeOf(runShimFn(args, label, traceFile, noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths)))
+			trace, err := parseTraceOptions(otlpEndpoint, otlpHeaders)
+			if err != nil {
+				return err
+			}
+			return codeOf(runShimFn(args, label, traceFile, noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths), trace))
 		},
 	}
 	flags := cmd.Flags()
 	flags.SortFlags = false
 	flags.StringVar(&label, "label", "", "server label shown in the TUI, defaults to the command name")
 	flags.StringVar(&traceFile, "trace-file", "", "override the JSONL trace path, defaults to the well-known session log")
+	flags.StringVar(&otlpEndpoint, "otlp-endpoint", "", "stream completed calls to an OTLP/HTTP JSON traces endpoint")
+	flags.Var(&otlpHeaders, "otlp-header", "HTTP header for OTLP delivery as Name=Value, repeatable")
 	flags.BoolVar(&noTrace, "no-trace", false, "disable tracing, pure passthrough")
 	flags.BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
@@ -348,13 +422,13 @@ func newExportCmd() *cobra.Command {
 
 // runShim runs the transparent stdio proxy. It writes the durable session log
 // AND streams live to the hub. Neither has to be running first.
-func runShim(command []string, label, traceFile string, noTrace bool, redaction proxy.RedactConfig) int {
+func runShim(command []string, label, traceFile string, noTrace bool, redaction proxy.RedactConfig, trace traceOptions) int {
 	if label == "" {
 		label = labelFor(command)
 	}
 	sessionID := fmt.Sprintf("%s-%d", label, os.Getpid())
 
-	sink := traceSink(sessionID, traceFile, noTrace, redaction)
+	sink := traceSink(sessionID, traceFile, noTrace, redaction, trace)
 	defer sink.Close()
 	if !noTrace {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: tracing %q (session %s)\n", strings.Join(command, " "), sessionID)
@@ -380,7 +454,7 @@ func runShim(command []string, label, traceFile string, noTrace bool, redaction 
 
 // traceSink builds the shared sink, a durable per-session JSONL log plus a
 // best-effort live stream to the hub. Returns a no-op sink when disabled.
-func traceSink(sessionID, traceFile string, noTrace bool, redaction proxy.RedactConfig) proxy.Sink {
+func traceSink(sessionID, traceFile string, noTrace bool, redaction proxy.RedactConfig, trace traceOptions) proxy.Sink {
 	if noTrace {
 		return proxy.NopSink()
 	}
@@ -394,6 +468,12 @@ func traceSink(sessionID, traceFile string, noTrace bool, redaction proxy.Redact
 		sinks = append(sinks, proxy.NewAsyncSink(f, 0))
 	}
 	sinks = append(sinks, proxy.NewSocketSink(paths.SocketPath(), 0))
+	if trace.OTLPEndpoint != "" {
+		sinks = append(sinks, otlpsink.New(otlpsink.Config{
+			Endpoint: trace.OTLPEndpoint,
+			Headers:  trace.OTLPHeaders,
+		}))
+	}
 	sink := proxy.Sink(proxy.NewMultiSink(sinks...))
 	if redaction.Enabled() {
 		sink = proxy.NewRedactingSink(sink, redaction)
@@ -405,10 +485,12 @@ func traceSink(sessionID, traceFile string, noTrace bool, redaction proxy.Redact
 func newHTTPCmd() *cobra.Command {
 	var (
 		target, listen, label  string
+		otlpEndpoint           string
 		noTrace, redactSecrets bool
 		redactKeys             redactKeysFlag
 		redactValues           redactValuesFlag
 		redactPaths            redactPathsFlag
+		otlpHeaders            otlpHeadersFlag
 	)
 	cmd := &cobra.Command{
 		Use:   "http --target <url> [--listen :7000]",
@@ -425,6 +507,10 @@ func newHTTPCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "mcpsnoop http: --target is required")
 				return exitCode(2)
 			}
+			trace, err := parseTraceOptions(otlpEndpoint, otlpHeaders)
+			if err != nil {
+				return err
+			}
 			lbl := label
 			if lbl == "" {
 				if u, err := url.Parse(target); err == nil && u.Host != "" {
@@ -435,7 +521,7 @@ func newHTTPCmd() *cobra.Command {
 			}
 			sessionID := fmt.Sprintf("%s-%d", lbl, os.Getpid())
 
-			sink := traceSink(sessionID, "", noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths))
+			sink := traceSink(sessionID, "", noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths), trace)
 			defer sink.Close()
 
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -460,6 +546,8 @@ func newHTTPCmd() *cobra.Command {
 	f.StringVar(&target, "target", "", "real MCP server endpoint, for example http://localhost:3000/mcp (required)")
 	f.StringVar(&listen, "listen", ":7000", "address to listen on")
 	f.StringVar(&label, "label", "", "server label shown in the TUI, defaults to the target host")
+	f.StringVar(&otlpEndpoint, "otlp-endpoint", "", "stream completed calls to an OTLP/HTTP JSON traces endpoint")
+	f.Var(&otlpHeaders, "otlp-header", "HTTP header for OTLP delivery as Name=Value, repeatable")
 	f.BoolVar(&noTrace, "no-trace", false, "disable tracing, pure passthrough")
 	f.BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	f.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -39,7 +41,7 @@ func TestLabelFor(t *testing.T) {
 // command without spawning a process, and returns a restore func.
 func stubShim(capture *[]string) func() {
 	orig := runShimFn
-	runShimFn = func(command []string, _, _ string, _ bool, _ proxy.RedactConfig) int {
+	runShimFn = func(command []string, _, _ string, _ bool, _ proxy.RedactConfig, _ traceOptions) int {
 		*capture = command
 		return 0
 	}
@@ -93,7 +95,7 @@ func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	defer func() { runHubFn = origHub }()
 
 	origShim := runShimFn
-	runShimFn = func([]string, string, string, bool, proxy.RedactConfig) int {
+	runShimFn = func([]string, string, string, bool, proxy.RedactConfig, traceOptions) int {
 		t.Fatal("shim ran for bare mcpsnoop, want hub")
 		return 0
 	}
@@ -252,6 +254,124 @@ func TestRedactPathsFlagRejectsInvalidJSONPath(t *testing.T) {
 	}
 }
 
+func TestOTLPHeadersFlagParsesRepeatedValues(t *testing.T) {
+	var flag otlpHeadersFlag
+	for _, value := range []string{
+		"Authorization=Bearer test-token",
+		"X-Tenant=team-a",
+		"X-Tenant=team-b",
+	} {
+		if err := flag.Set(value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	header := http.Header(flag)
+	if got := header.Get("Authorization"); got != "Bearer test-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := header.Values("X-Tenant"); !slices.Equal(got, []string{"team-a", "team-b"}) {
+		t.Fatalf("X-Tenant = %v", got)
+	}
+}
+
+func TestOTLPHeadersFlagRejectsMalformedValues(t *testing.T) {
+	for _, value := range []string{"Authorization", "=token", "Bad Header=value", "X-Test=one\ntwo"} {
+		var flag otlpHeadersFlag
+		if err := flag.Set(value); err == nil {
+			t.Fatalf("Set(%q) returned nil", value)
+		}
+	}
+}
+
+func TestParseTraceOptionsValidatesEndpointAndHeaderDependency(t *testing.T) {
+	for _, endpoint := range []string{"collector:4318/v1/traces", "ftp://collector/v1/traces", "http:///v1/traces"} {
+		if _, err := parseTraceOptions(endpoint, nil); err == nil {
+			t.Fatalf("parseTraceOptions(%q) returned nil error", endpoint)
+		}
+	}
+	if _, err := parseTraceOptions("", otlpHeadersFlag{"Authorization": {"Bearer token"}}); err == nil {
+		t.Fatal("header without endpoint returned nil error")
+	}
+	got, err := parseTraceOptions("https://collector.example/v1/traces", otlpHeadersFlag{"Authorization": {"Bearer token"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.OTLPEndpoint != "https://collector.example/v1/traces" || got.OTLPHeaders.Get("Authorization") != "Bearer token" {
+		t.Fatalf("trace options = %+v", got)
+	}
+}
+
+func TestProxyCommandsExposeLiveOTLPFlags(t *testing.T) {
+	root := newRootCmd()
+	for _, name := range []string{"otlp-endpoint", "otlp-header"} {
+		if root.Flags().Lookup(name) == nil {
+			t.Fatalf("root command is missing --%s", name)
+		}
+	}
+	httpCmd, _, err := root.Find([]string{"http"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"otlp-endpoint", "otlp-header"} {
+		if httpCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("http command is missing --%s", name)
+		}
+	}
+}
+
+func TestTraceSinkStreamsCompletedCallToOTLP(t *testing.T) {
+	received := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		var payload struct {
+			ResourceSpans []struct {
+				ScopeSpans []struct {
+					Spans []json.RawMessage `json:"spans"`
+				} `json:"scopeSpans"`
+			} `json:"resourceSpans"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		} else if len(payload.ResourceSpans) != 1 || len(payload.ResourceSpans[0].ScopeSpans) != 1 || len(payload.ResourceSpans[0].ScopeSpans[0].Spans) != 1 {
+			t.Errorf("unexpected OTLP payload: %+v", payload)
+		}
+		received <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	traceFile := filepath.Join(t.TempDir(), "session.jsonl")
+	sink := traceSink("s1", traceFile, false, proxy.RedactConfig{}, traceOptions{
+		OTLPEndpoint: server.URL,
+		OTLPHeaders:  http.Header{"Authorization": {"Bearer test-token"}},
+	})
+	defer sink.Close()
+	started := time.Unix(1_700_000_000, 0)
+	sink.Emit(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "inventory", Seq: 1, TS: started,
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lookup"}}`),
+	})
+	sink.Emit(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "inventory", Seq: 2, TS: started.Add(20 * time.Millisecond),
+		Direction: proxy.ServerToClient,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`),
+	})
+
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for live OTLP delivery")
+	}
+	if data, err := os.ReadFile(traceFile); err != nil {
+		t.Fatal(err)
+	} else if len(data) == 0 {
+		t.Fatal("durable trace file is empty")
+	}
+}
+
 func TestTraceSinkRedactsFileAndLiveSocket(t *testing.T) {
 	stateDir := filepath.Join(os.TempDir(), fmt.Sprintf("mcpsnoop-test-%d", os.Getpid()))
 	if err := os.RemoveAll(stateDir); err != nil {
@@ -289,7 +409,7 @@ func TestTraceSinkRedactsFileAndLiveSocket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sink := traceSink("s1", traceFile, false, proxy.RedactConfig{Paths: []proxy.RedactPath{path}})
+	sink := traceSink("s1", traceFile, false, proxy.RedactConfig{Paths: []proxy.RedactPath{path}}, traceOptions{})
 	closed := false
 	t.Cleanup(func() {
 		if !closed {

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -258,7 +258,7 @@ func Write(w io.Writer, data SessionExport, opts Options) error {
 	case FormatText:
 		return writeText(w, data)
 	case FormatOTLP:
-		return writeOTLP(w, data)
+		return WriteOTLP(w, data)
 	default:
 		return fmt.Errorf("unknown export format %q", format)
 	}
@@ -315,7 +315,8 @@ type otlpAnyValue struct {
 	DoubleValue *float64 `json:"doubleValue,omitempty"`
 }
 
-func writeOTLP(w io.Writer, data SessionExport) error {
+// WriteOTLP writes data using the OTLP JSON encoding.
+func WriteOTLP(w io.Writer, data SessionExport) error {
 	traceID := otlpID(16, "trace", data.Session.ID)
 	spans := make([]otlpSpan, 0, len(data.Calls))
 	for _, call := range data.Calls {

--- a/internal/otlpsink/sink.go
+++ b/internal/otlpsink/sink.go
@@ -1,0 +1,252 @@
+// Package otlpsink streams completed MCP calls to an OTLP/HTTP collector.
+package otlpsink
+
+import (
+	"bytes"
+	"container/list"
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+// Config controls live OTLP delivery.
+type Config struct {
+	Endpoint   string
+	Headers    http.Header
+	Buffer     int
+	Client     *http.Client
+	MinBackoff time.Duration
+	MaxBackoff time.Duration
+}
+
+// Sink correlates observed envelopes and delivers each completed call as one
+// OTLP span. Network work stays in a single background goroutine.
+type Sink struct {
+	endpoint string
+	headers  http.Header
+	client   *http.Client
+	ch       chan proxy.Envelope
+	cancel   context.CancelFunc
+	done     chan struct{}
+	once     sync.Once
+	dropped  atomic.Uint64
+	minRetry time.Duration
+	maxRetry time.Duration
+	limit    int
+}
+
+// New starts a live OTLP sink. The queue is bounded and Emit drops on overflow.
+func New(cfg Config) *Sink {
+	if cfg.Buffer <= 0 {
+		cfg.Buffer = 4096
+	}
+	if cfg.Client == nil {
+		cfg.Client = &http.Client{Timeout: 10 * time.Second}
+	}
+	if cfg.MinBackoff <= 0 {
+		cfg.MinBackoff = 200 * time.Millisecond
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 2 * time.Second
+	}
+	if cfg.MaxBackoff < cfg.MinBackoff {
+		cfg.MaxBackoff = cfg.MinBackoff
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Sink{
+		endpoint: cfg.Endpoint,
+		headers:  cfg.Headers.Clone(),
+		client:   cfg.Client,
+		ch:       make(chan proxy.Envelope, cfg.Buffer),
+		cancel:   cancel,
+		done:     make(chan struct{}),
+		minRetry: cfg.MinBackoff,
+		maxRetry: cfg.MaxBackoff,
+		limit:    cfg.Buffer,
+	}
+	go s.run(ctx)
+	return s
+}
+
+func (s *Sink) run(ctx context.Context) {
+	defer close(s.done)
+	pending := make(map[callKey]pendingCall)
+	order := list.New()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case env, ok := <-s.ch:
+			if !ok {
+				return
+			}
+			msg, ok := proxy.ParseRPC(env.Raw)
+			if !ok {
+				continue
+			}
+			if msg.IsRequest() && len(msg.ID) > 0 {
+				s.remember(pending, order, requestKey(env, msg), env)
+				continue
+			}
+			if !msg.IsResponse() {
+				continue
+			}
+			key, ok := responseKey(env, msg)
+			if !ok {
+				continue
+			}
+			request, ok := pending[key]
+			if !ok {
+				continue
+			}
+			delete(pending, key)
+			order.Remove(request.element)
+			payload, ok := payloadFor(request.envelope, env)
+			if !ok {
+				continue
+			}
+			if !s.deliver(ctx, payload) {
+				return
+			}
+		}
+	}
+}
+
+type callKey struct {
+	session   string
+	direction proxy.Direction
+	id        string
+}
+
+type pendingCall struct {
+	envelope proxy.Envelope
+	element  *list.Element
+}
+
+func requestKey(env proxy.Envelope, msg proxy.RPCMessage) callKey {
+	return callKey{session: env.SessionID, direction: env.Direction, id: string(msg.ID)}
+}
+
+func responseKey(env proxy.Envelope, msg proxy.RPCMessage) (callKey, bool) {
+	var requestDirection proxy.Direction
+	switch env.Direction {
+	case proxy.ClientToServer:
+		requestDirection = proxy.ServerToClient
+	case proxy.ServerToClient:
+		requestDirection = proxy.ClientToServer
+	default:
+		return callKey{}, false
+	}
+	return callKey{session: env.SessionID, direction: requestDirection, id: string(msg.ID)}, true
+}
+
+func (s *Sink) remember(pending map[callKey]pendingCall, order *list.List, key callKey, env proxy.Envelope) {
+	if previous, ok := pending[key]; ok {
+		previous.envelope = env
+		pending[key] = previous
+		order.MoveToBack(previous.element)
+		return
+	}
+	if len(pending) >= s.limit {
+		oldest := order.Front()
+		delete(pending, oldest.Value.(callKey))
+		order.Remove(oldest)
+		s.dropped.Add(1)
+	}
+	element := order.PushBack(key)
+	pending[key] = pendingCall{envelope: env, element: element}
+}
+
+func payloadFor(request, response proxy.Envelope) ([]byte, bool) {
+	st := store.New(0)
+	st.Ingest(request)
+	event := st.Ingest(response)
+	if event.Call == nil || !event.Call.Done() {
+		return nil, false
+	}
+	data, err := exporter.Build(st, request.SessionID)
+	if err != nil {
+		return nil, false
+	}
+	if len(data.Calls) != 1 {
+		return nil, false
+	}
+	var payload bytes.Buffer
+	if err := exporter.WriteOTLP(&payload, data); err != nil {
+		return nil, false
+	}
+	return payload.Bytes(), true
+}
+
+func (s *Sink) deliver(ctx context.Context, payload []byte) bool {
+	backoff := s.minRetry
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(payload))
+		if err == nil {
+			for name, values := range s.headers {
+				for _, value := range values {
+					req.Header.Add(name, value)
+				}
+			}
+			req.Header.Set("Content-Type", "application/json")
+			var resp *http.Response
+			resp, err = s.client.Do(req)
+			if err == nil {
+				_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+				_ = resp.Body.Close()
+				if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+					return true
+				}
+			}
+		}
+		if !sleep(ctx, backoff) {
+			return false
+		}
+		backoff = min(backoff*2, s.maxRetry)
+	}
+}
+
+// Emit queues env without waiting for correlation or network delivery.
+func (s *Sink) Emit(env proxy.Envelope) {
+	select {
+	case s.ch <- env:
+	default:
+		s.dropped.Add(1)
+	}
+}
+
+// Dropped reports how many envelopes were dropped because the queue was full.
+func (s *Sink) Dropped() uint64 { return s.dropped.Load() }
+
+// Close stops delivery promptly, including an in-flight HTTP request.
+func (s *Sink) Close() error {
+	s.once.Do(func() { close(s.ch) })
+	timer := time.NewTimer(500 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-s.done:
+		s.cancel()
+	case <-timer.C:
+		s.cancel()
+		<-s.done
+	}
+	return nil
+}
+
+func sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/otlpsink/sink_test.go
+++ b/internal/otlpsink/sink_test.go
@@ -1,0 +1,251 @@
+package otlpsink
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func callEnvelopes(session string, id int, started time.Time) (proxy.Envelope, proxy.Envelope) {
+	request := proxy.Envelope{
+		SessionID:   session,
+		ServerLabel: "inventory",
+		Seq:         uint64(id*2 - 1),
+		TS:          started,
+		Direction:   proxy.ClientToServer,
+		Raw:         json.RawMessage(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"lookup"}}`),
+	}
+	response := proxy.Envelope{
+		SessionID:   session,
+		ServerLabel: "inventory",
+		Seq:         uint64(id * 2),
+		TS:          started.Add(25 * time.Millisecond),
+		Direction:   proxy.ServerToClient,
+		Raw:         json.RawMessage(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"result":{"content":[]}}`),
+	}
+	return request, response
+}
+
+func TestSinkPostsCompletedCallAsOTLP(t *testing.T) {
+	received := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode OTLP payload: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		received <- payload
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink := New(Config{
+		Endpoint: server.URL,
+		Headers:  http.Header{"Authorization": {"Bearer test-token"}},
+	})
+	defer sink.Close()
+
+	request, response := callEnvelopes("session-1", 1, time.Unix(1_700_000_000, 0))
+	sink.Emit(request)
+	sink.Emit(response)
+
+	select {
+	case payload := <-received:
+		resourceSpans := payload["resourceSpans"].([]any)
+		scopeSpans := resourceSpans[0].(map[string]any)["scopeSpans"].([]any)
+		spans := scopeSpans[0].(map[string]any)["spans"].([]any)
+		if len(spans) != 1 {
+			t.Fatalf("posted %d spans, want 1", len(spans))
+		}
+		span := spans[0].(map[string]any)
+		if span["name"] != "tools/call" {
+			t.Fatalf("span name = %v, want tools/call", span["name"])
+		}
+		if span["endTimeUnixNano"] == span["startTimeUnixNano"] {
+			t.Fatal("completed span has zero duration")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OTLP payload")
+	}
+}
+
+func TestSinkPostsDuplicateResponseOnlyOnce(t *testing.T) {
+	var posts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink := New(Config{Endpoint: server.URL})
+	request, response := callEnvelopes("session-1", 1, time.Now())
+	sink.Emit(request)
+	sink.Emit(response)
+	sink.Emit(response)
+	deadline := time.Now().Add(time.Second)
+	for posts.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("posts = %d, want one span for one completed call", got)
+	}
+}
+
+func TestSinkCloseDrainsQueuedCompletedCall(t *testing.T) {
+	var posts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink := New(Config{Endpoint: server.URL})
+	request, response := callEnvelopes("session-1", 1, time.Now())
+	sink.Emit(request)
+	sink.Emit(response)
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("posts after Close = %d, want queued completed call drained", got)
+	}
+}
+
+func TestSinkCorrelatesServerInitiatedCall(t *testing.T) {
+	var posts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink := New(Config{Endpoint: server.URL})
+	request, response := callEnvelopes("session-1", 1, time.Now())
+	request.Direction = proxy.ServerToClient
+	response.Direction = proxy.ClientToServer
+	sink.Emit(request)
+	sink.Emit(response)
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("posts = %d, want one server-initiated span", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestSinkRecoversAfterTransportFailureAndBoundsQueue(t *testing.T) {
+	received := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var attempts atomic.Int32
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if attempts.Add(1) == 1 {
+			close(started)
+			select {
+			case <-release:
+				return nil, io.ErrUnexpectedEOF
+			case <-r.Context().Done():
+				return nil, r.Context().Err()
+			}
+		}
+		return http.DefaultTransport.RoundTrip(r)
+	})
+	sink := New(Config{
+		Endpoint:   server.URL,
+		Buffer:     2,
+		Client:     &http.Client{Transport: transport},
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 5 * time.Millisecond,
+	})
+	defer sink.Close()
+
+	request, response := callEnvelopes("session-1", 1, time.Now())
+	sink.Emit(request)
+	sink.Emit(response)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first delivery attempt")
+	}
+
+	for i := 2; i < 20; i++ {
+		request, response := callEnvelopes("session-1", i%9+1, time.Now())
+		sink.Emit(request)
+		sink.Emit(response)
+	}
+	if sink.Dropped() == 0 {
+		t.Fatal("queue never dropped while delivery was blocked")
+	}
+	close(release)
+
+	select {
+	case <-received:
+		if attempts.Load() < 2 {
+			t.Fatalf("delivery attempts = %d, want retry", attempts.Load())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delivery after transport recovery")
+	}
+}
+
+func TestSinkCloseCancelsBlockedDelivery(t *testing.T) {
+	started := make(chan struct{})
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		close(started)
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})
+	sink := New(Config{
+		Endpoint: "http://collector.invalid/v1/traces",
+		Client:   &http.Client{Transport: transport},
+	})
+	request, response := callEnvelopes("session-1", 1, time.Now())
+	sink.Emit(request)
+	sink.Emit(response)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked delivery")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- sink.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked on unavailable collector")
+	}
+}


### PR DESCRIPTION
## What and why

Adds optional live OTLP/HTTP JSON delivery for completed MCP calls in both stdio and HTTP proxy modes. The sink retries collector failures in a background worker, bounds queued and pending frames, drops instead of blocking proxied traffic, and reuses the existing OTLP exporter. Repeatable headers support collector authentication and tenancy.

Closes #64.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed