### PR TITLE
feat: summarize per-tool session performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,11 @@ server is written in.
 | `esc` | back | | `:` | command |
 | `j` / `k` | move | | `r` | replay a call |
 | `g` / `G` | top / bottom | | `c` | capabilities |
-| `ctrl-f` / `ctrl-b` | page | | `y` | copy |
+| `ctrl-f` / `ctrl-b` | page | | `s` | tool summary |
+| `p` | pause | | `y` | copy |
 | `shift`+`<key>` | sort by column | | `e` | export |
-| `p` | pause | | `ctrl-d` | delete session |
-| `f` | follow | | `?` | help |
+| `ctrl-d` | delete session | | `f` | follow |
+| `?` | help | | | |
 
 Press `?` in the app for the full list.
 
@@ -205,7 +206,7 @@ mcpsnoop export -T json|html|text|otlp [-o file|-] [session-id|log.jsonl|-]
 
 | Format | What you get |
 |---|---|
-| `json` | correlated calls, durations, status, tool-level `isError`, capabilities, and raw frames |
+| `json` | correlated calls, per-tool counts and p50/p95/p99 latency, slowest calls, capabilities, and raw frames |
 | `html` | a self-contained browser file with search and collapsible JSON |
 | `text` | a pretty plain-text dump |
 | `otlp` | OTLP JSON with a trace per session and a span per correlated call |

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -34,9 +34,33 @@ type Options struct {
 type SessionExport struct {
 	GeneratedAt  time.Time           `json:"generated_at"`
 	Session      SessionSummary      `json:"session"`
+	Summary      ToolSummaryExport   `json:"summary"`
 	Capabilities *CapabilitiesExport `json:"capabilities,omitempty"`
 	Calls        []CallExport        `json:"calls"`
 	Events       []EventExport       `json:"events"`
+}
+
+type ToolSummaryExport struct {
+	Tools        []ToolStatsExport `json:"tools"`
+	SlowestCalls []SlowCallExport  `json:"slowest_calls"`
+}
+
+type ToolStatsExport struct {
+	Name    string  `json:"name"`
+	Calls   int     `json:"calls"`
+	Errors  int     `json:"errors"`
+	Pending int     `json:"pending"`
+	P50MS   float64 `json:"p50_ms"`
+	P95MS   float64 `json:"p95_ms"`
+	P99MS   float64 `json:"p99_ms"`
+}
+
+type SlowCallExport struct {
+	CallIndex  int     `json:"call_index"`
+	ID         string  `json:"id"`
+	ToolName   string  `json:"tool_name"`
+	DurationMS float64 `json:"duration_ms"`
+	IsError    bool    `json:"is_error"`
 }
 
 type SessionSummary struct {
@@ -231,6 +255,9 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 		Calls:  outCalls,
 		Events: outEvents,
 	}
+	if summary, ok := st.ToolSummary(sessionID); ok {
+		out.Summary = exportToolSummary(summary)
+	}
 	if caps, ok := st.Capabilities(sessionID); ok {
 		out.Capabilities = &CapabilitiesExport{
 			ProtocolVersion: caps.ProtocolVersion,
@@ -241,6 +268,30 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 		}
 	}
 	return out, nil
+}
+
+func exportToolSummary(summary store.SessionToolSummary) ToolSummaryExport {
+	out := ToolSummaryExport{
+		Tools:        make([]ToolStatsExport, 0, len(summary.Tools)),
+		SlowestCalls: make([]SlowCallExport, 0, len(summary.Slowest)),
+	}
+	for _, tool := range summary.Tools {
+		out.Tools = append(out.Tools, ToolStatsExport{
+			Name: tool.Name, Calls: tool.Calls, Errors: tool.Errors, Pending: tool.Pending,
+			P50MS: durationMS(tool.P50), P95MS: durationMS(tool.P95), P99MS: durationMS(tool.P99),
+		})
+	}
+	for _, call := range summary.Slowest {
+		out.SlowestCalls = append(out.SlowestCalls, SlowCallExport{
+			CallIndex: call.CallIndex,
+			ID:        call.ID, ToolName: call.ToolName, DurationMS: durationMS(call.Duration), IsError: call.Failed,
+		})
+	}
+	return out
+}
+
+func durationMS(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
 }
 
 func Write(w io.Writer, data SessionExport, opts Options) error {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -62,6 +62,12 @@ func TestBuildCorrelatedExport(t *testing.T) {
 	if len(out.Events) != 2 || out.Events[1].CallIndex == nil || *out.Events[1].CallIndex != 0 {
 		t.Fatalf("bad event correlation: %+v", out.Events)
 	}
+	if len(out.Summary.Tools) != 1 || out.Summary.Tools[0].Name != "echo" || out.Summary.Tools[0].P50MS != 25 {
+		t.Fatalf("bad tool summary: %+v", out.Summary)
+	}
+	if len(out.Summary.SlowestCalls) != 1 || out.Summary.SlowestCalls[0].CallIndex != 0 || out.Summary.SlowestCalls[0].DurationMS != 25 {
+		t.Fatalf("bad slowest calls: %+v", out.Summary.SlowestCalls)
+	}
 }
 
 func TestBuildIncludesValidationWarning(t *testing.T) {
@@ -100,6 +106,13 @@ func TestWriteFormats(t *testing.T) {
 		got := buf.String()
 		if !strings.Contains(got, "echo") {
 			t.Fatalf("%s export missing tool name:\n%s", format, got)
+		}
+		if format == FormatJSON {
+			for _, field := range []string{`"summary"`, `"p50_ms": 25`, `"slowest_calls"`, `"call_index": 0`} {
+				if !strings.Contains(got, field) {
+					t.Fatalf("json export missing %s:\n%s", field, got)
+				}
+			}
 		}
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -172,6 +172,48 @@ func TestToolLevelError(t *testing.T) {
 	}
 }
 
+func TestToolSummaryAggregatesLatencyErrorsAndPendingCalls(t *testing.T) {
+	s := New(0)
+	t0 := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	durations := []time.Duration{10, 20, 30, 40, 100}
+	for i, milliseconds := range durations {
+		id := fmt.Sprintf("%d", i+1)
+		s.Ingest(req(uint64(i*2+1), t0, proxy.ClientToServer, id, "tools/call", `{"name":"echo"}`))
+		body := `"result":{"content":[]}`
+		if i == len(durations)-1 {
+			body = `"error":{"code":-32000,"message":"timeout"}`
+		}
+		s.Ingest(resp(uint64(i*2+2), t0.Add(milliseconds*time.Millisecond), proxy.ServerToClient, id, body))
+	}
+	s.Ingest(req(20, t0, proxy.ClientToServer, "6", "tools/call", `{"name":"search"}`))
+	s.Ingest(req(21, t0, proxy.ClientToServer, "7", "tools/list", ""))
+
+	summary, ok := s.ToolSummary("s1")
+	if !ok {
+		t.Fatal("ToolSummary should find the session")
+	}
+	if len(summary.Tools) != 2 {
+		t.Fatalf("tools = %d, want 2: %+v", len(summary.Tools), summary.Tools)
+	}
+	echo := summary.Tools[0]
+	if echo.Name != "echo" || echo.Calls != 5 || echo.Errors != 1 || echo.Pending != 0 {
+		t.Fatalf("echo summary = %+v", echo)
+	}
+	if echo.P50 != 30*time.Millisecond || echo.P95 != 100*time.Millisecond || echo.P99 != 100*time.Millisecond {
+		t.Fatalf("echo percentiles = %s/%s/%s, want 30ms/100ms/100ms", echo.P50, echo.P95, echo.P99)
+	}
+	search := summary.Tools[1]
+	if search.Name != "search" || search.Calls != 1 || search.Pending != 1 || search.P50 != 0 {
+		t.Fatalf("search summary = %+v", search)
+	}
+	if len(summary.Slowest) != 5 || summary.Slowest[0].ToolName != "echo" || summary.Slowest[0].Duration != 100*time.Millisecond || !summary.Slowest[0].Failed {
+		t.Fatalf("slowest calls = %+v", summary.Slowest)
+	}
+	if _, ok := s.ToolSummary("missing"); ok {
+		t.Fatal("ToolSummary should report an unknown session")
+	}
+}
+
 func TestServerToClientRequest(t *testing.T) {
 	// Server-initiated request (e.g. sampling) must correlate with the client's
 	// response travelling the other way.

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -1,7 +1,10 @@
 package store
 
 import (
+	"cmp"
 	"encoding/json"
+	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -78,6 +81,33 @@ type CapsView struct {
 	ServerInfo      json.RawMessage
 	Client          json.RawMessage
 	Server          json.RawMessage
+}
+
+// ToolStats summarizes calls to one MCP tool within a session.
+type ToolStats struct {
+	Name    string
+	Calls   int
+	Errors  int
+	Pending int
+	P50     time.Duration
+	P95     time.Duration
+	P99     time.Duration
+}
+
+// SlowToolCall identifies one of a session's slowest completed tool calls.
+type SlowToolCall struct {
+	CallIndex int
+	ID        string
+	ToolName  string
+	Duration  time.Duration
+	Failed    bool
+	Start     time.Time
+}
+
+// SessionToolSummary is the aggregate tool activity for one session.
+type SessionToolSummary struct {
+	Tools   []ToolStats
+	Slowest []SlowToolCall
 }
 
 // view builds the snapshot for an event. Caller holds at least the read lock.
@@ -266,4 +296,81 @@ func (s *Store) Calls(sessionID string) []CallView {
 		}
 	}
 	return out
+}
+
+// ToolSummary returns per-tool latency and error statistics plus the five
+// slowest completed tool calls. Pending calls are counted but have no latency.
+func (s *Store) ToolSummary(sessionID string) (SessionToolSummary, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return SessionToolSummary{}, false
+	}
+
+	type aggregate struct {
+		stats     ToolStats
+		durations []time.Duration
+	}
+	byName := make(map[string]*aggregate)
+	var slowest []SlowToolCall
+	callIndex := 0
+	for _, ev := range sess.events {
+		if ev.kind != EventRequest || ev.call == nil {
+			continue
+		}
+		c := ev.call
+		index := callIndex
+		callIndex++
+		if !c.isTool {
+			continue
+		}
+		agg := byName[c.toolName]
+		if agg == nil {
+			agg = &aggregate{stats: ToolStats{Name: c.toolName}}
+			byName[c.toolName] = agg
+		}
+		agg.stats.Calls++
+		if c.state == Pending {
+			agg.stats.Pending++
+			continue
+		}
+		if c.err != nil || c.toolErr {
+			agg.stats.Errors++
+		}
+		duration := c.end.Sub(c.start)
+		agg.durations = append(agg.durations, duration)
+		slowest = append(slowest, SlowToolCall{
+			CallIndex: index, ID: c.id, ToolName: c.toolName,
+			Duration: duration, Failed: c.err != nil || c.toolErr, Start: c.start,
+		})
+	}
+
+	tools := make([]ToolStats, 0, len(byName))
+	for _, agg := range byName {
+		slices.Sort(agg.durations)
+		agg.stats.P50 = nearestRank(agg.durations, 0.50)
+		agg.stats.P95 = nearestRank(agg.durations, 0.95)
+		agg.stats.P99 = nearestRank(agg.durations, 0.99)
+		tools = append(tools, agg.stats)
+	}
+	slices.SortFunc(tools, func(a, b ToolStats) int { return cmp.Compare(a.Name, b.Name) })
+	slices.SortStableFunc(slowest, func(a, b SlowToolCall) int {
+		if c := cmp.Compare(b.Duration, a.Duration); c != 0 {
+			return c
+		}
+		return a.Start.Compare(b.Start)
+	})
+	if len(slowest) > 5 {
+		slowest = slowest[:5]
+	}
+	return SessionToolSummary{Tools: tools, Slowest: slowest}, true
+}
+
+func nearestRank(sorted []time.Duration, percentile float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
+	return sorted[max(index, 0)]
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -19,13 +19,14 @@ type keyMap struct {
 	Command key.Binding
 	Help    key.Binding
 
-	Replay key.Binding
-	Caps   key.Binding
-	Pause  key.Binding
-	Follow key.Binding
-	Copy   key.Binding
-	Export key.Binding
-	Delete key.Binding
+	Replay  key.Binding
+	Caps    key.Binding
+	Summary key.Binding
+	Pause   key.Binding
+	Follow  key.Binding
+	Copy    key.Binding
+	Export  key.Binding
+	Delete  key.Binding
 
 	Quit key.Binding
 }
@@ -45,13 +46,14 @@ func defaultKeys() keyMap {
 		Command: key.NewBinding(key.WithKeys(":"), key.WithHelp(":", "command")),
 		Help:    key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 
-		Replay: key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "replay")),
-		Caps:   key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
-		Pause:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
-		Follow: key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
-		Copy:   key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
-		Export: key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
-		Delete: key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
+		Replay:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "replay")),
+		Caps:    key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
+		Summary: key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
+		Pause:   key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
+		Follow:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
+		Copy:    key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
+		Export:  key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
+		Delete:  key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
 
 		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp(":q", "quit")),
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -57,6 +57,7 @@ const (
 	overlayNone overlayMode = iota
 	overlayInspector
 	overlayCaps
+	overlaySummary
 	overlayReplay
 )
 
@@ -292,7 +293,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Copy):
 			m.copyCurrent()
 		case key.Matches(msg, m.keys.Enter, m.keys.Back, m.keys.Quit),
-			key.Matches(msg, m.keys.Caps):
+			key.Matches(msg, m.keys.Caps, m.keys.Summary):
 			m.closeOverlay()
 		default:
 			var cmd tea.Cmd
@@ -344,6 +345,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Caps):
 		if m.currentSessionID() != "" {
 			m.openOverlay(overlayCaps, m.capsContent())
+		}
+	case key.Matches(msg, m.keys.Summary):
+		if m.currentSessionID() != "" {
+			m.openOverlay(overlaySummary, m.summaryContent())
 		}
 	case key.Matches(msg, m.keys.Replay):
 		if cmd := m.startReplay(); cmd != nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -603,6 +603,32 @@ func TestSwitchSessionWithBrackets(t *testing.T) {
 	}
 }
 
+func TestToolSummaryOverlay(t *testing.T) {
+	st := store.New(0)
+	seed(st)
+	m := ready(t, st)
+
+	m = typeRunes(t, m, "s")
+	if m.overlay != overlaySummary {
+		t.Fatal("s should open the tool summary")
+	}
+	out := m.View()
+	for _, want := range []string{"TOOL SUMMARY", "echo", "CALLS", "ERRORS", "P50", "SLOWEST CALLS"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing %q\n%s", want, out)
+		}
+	}
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.overlay != overlayNone {
+		t.Fatal("esc should close the summary")
+	}
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = typeRunes(t, m, "s")
+	if m.view != viewStream || m.overlay != overlaySummary {
+		t.Fatal("s should also open the summary from the stream")
+	}
+}
+
 func TestSortSessions(t *testing.T) {
 	st := store.New(0)
 	st.Ingest(sessionEnv("s1", "gamma"))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -762,6 +762,7 @@ func (m Model) renderHelp() string {
 	frameActions := helpGroup{"FRAME ACTIONS", [][2]string{
 		{"r", "replay the selected tool call"},
 		{"c", "show negotiated capabilities"},
+		{"s", "show per-tool latency and error summary"},
 		{"p", "pause or resume the stream"},
 		{"f", "toggle follow"},
 	}}
@@ -1101,6 +1102,47 @@ func (m Model) capsContent() string {
 		b.WriteString("\n\n" + strings.Join(sections, "\n\n"))
 	}
 	return b.String()
+}
+
+func (m Model) summaryContent() string {
+	sid := m.currentSessionID()
+	label := m.streamLabel
+	if m.view == viewSessions && len(m.sessions) > 0 {
+		label = m.sessions[m.selSession].Label
+	}
+	var b strings.Builder
+	b.WriteString(m.styles.panelTitle.Render(" TOOL SUMMARY · "+label) + "\n\n")
+	summary, ok := m.store.ToolSummary(sid)
+	if !ok || len(summary.Tools) == 0 {
+		b.WriteString(m.styles.dim.Render(" no tool calls observed yet for this session"))
+		return b.String()
+	}
+	b.WriteString(" TOOL                 CALLS  ERRORS  PENDING       P50       P95       P99\n")
+	for _, tool := range summary.Tools {
+		b.WriteString(fmt.Sprintf(" %s %5d  %6d  %7d  %8s  %8s  %8s\n",
+			cellL(tool.Name, 20), tool.Calls, tool.Errors, tool.Pending,
+			formatLatency(tool.P50), formatLatency(tool.P95), formatLatency(tool.P99)))
+	}
+	b.WriteString("\n" + m.styles.tableHead.Render(" SLOWEST CALLS") + "\n")
+	if len(summary.Slowest) == 0 {
+		b.WriteString(m.styles.dim.Render(" no completed tool calls"))
+		return b.String()
+	}
+	for _, call := range summary.Slowest {
+		status := "ok"
+		if call.Failed {
+			status = "error"
+		}
+		b.WriteString(fmt.Sprintf(" %8s  %-5s  %s id=%s\n", formatLatency(call.Duration), status, cellL(call.ToolName, 20), call.ID))
+	}
+	return b.String()
+}
+
+func formatLatency(duration time.Duration) string {
+	if duration == 0 {
+		return "-"
+	}
+	return duration.Round(time.Microsecond).String()
 }
 
 func infoLine(raw json.RawMessage) string {


### PR DESCRIPTION
## What and why

Adds an `s` summary view for a selected session with per-tool call, error, and pending counts; p50, p95, and p99 latency; and the five slowest completed calls. Pending calls stay visible in counts without affecting latency percentiles.

JSON exports carry the same store-backed summary, so interactive and automated analysis use identical aggregation semantics.

Closes #45.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed