### PR TITLE
feat: diff captured sessions for regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, or otlp |
 | `mcpsnoop check` | fail CI on errors, invalid frames, warnings, slow, or hung calls |
+| `mcpsnoop diff` | compare tools and calls across two captured sessions |
 | `mcpsnoop open` | open a saved session in the TUI |
 | `mcpsnoop remote <user@host>` | print the SSH tunnel command |
 | `mcpsnoop demo` | play a scripted session |
@@ -243,6 +244,21 @@ Delivery is best-effort and never blocks proxied MCP traffic. If the collector
 is unavailable, mcpsnoop retries in the background and drops new trace frames
 when its bounded queue is full. The normal JSONL session log remains the durable
 record.
+
+## Comparing sessions
+
+Compare two saved sessions by id or JSONL path.
+
+```bash
+mcpsnoop diff before-session after-session
+mcpsnoop diff old.jsonl new.jsonl
+```
+
+The report shows tools that were added or removed, `inputSchema` changes,
+matching tool calls whose status changed, and notable duration shifts. Calls are
+matched by tool name and arguments, so reordered calls still compare correctly.
+By default, duration changes must differ by at least 100 ms and 2x; use
+`--duration-threshold` and `--duration-ratio` to adjust those cutoffs.
 
 ## Checking sessions in CI
 

--- a/cmd/mcpsnoop/diff.go
+++ b/cmd/mcpsnoop/diff.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/sessiondiff"
+)
+
+func newDiffCmd() *cobra.Command {
+	var durationThreshold time.Duration
+	var durationRatio float64
+	cmd := &cobra.Command{
+		Use:   "diff <session-id|log.jsonl> <session-id|log.jsonl>",
+		Short: "Compare tools and calls across two captured sessions",
+		Long:  "Compare two captured sessions for added or removed tools, input schema changes, call status changes, and notable duration shifts.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if durationThreshold < 0 {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop diff: --duration-threshold must not be negative")
+				return exitCode(2)
+			}
+			if durationRatio < 1 || math.IsNaN(durationRatio) || math.IsInf(durationRatio, 0) {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop diff: --duration-ratio must be finite and at least 1")
+				return exitCode(2)
+			}
+
+			before, err := loadDiffSession(args[0])
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop diff:", err)
+				return exitCode(1)
+			}
+			after, err := loadDiffSession(args[1])
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop diff:", err)
+				return exitCode(1)
+			}
+
+			report := sessiondiff.Compare(before, after, sessiondiff.Options{
+				DurationThreshold: durationThreshold,
+				DurationRatio:     durationRatio,
+			})
+			if err := sessiondiff.WriteText(cmd.OutOrStdout(), report); err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop diff:", err)
+				return exitCode(1)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().SortFlags = false
+	cmd.Flags().DurationVar(&durationThreshold, "duration-threshold", sessiondiff.DefaultDurationThreshold, "minimum absolute duration change to report")
+	cmd.Flags().Float64Var(&durationRatio, "duration-ratio", sessiondiff.DefaultDurationRatio, "minimum slowdown or speedup ratio to report")
+	return cmd
+}
+
+func loadDiffSession(arg string) (exporter.SessionExport, error) {
+	path, err := exporter.ResolveSessionPath(arg)
+	if err != nil {
+		return exporter.SessionExport{}, err
+	}
+	st, sessionID, err := exporter.LoadFile(path)
+	if err != nil {
+		return exporter.SessionExport{}, err
+	}
+	return exporter.Build(st, sessionID)
+}

--- a/cmd/mcpsnoop/diff_test.go
+++ b/cmd/mcpsnoop/diff_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func TestDiffCommandComparesTwoLogPaths(t *testing.T) {
+	dir := t.TempDir()
+	before := filepath.Join(dir, "before.jsonl")
+	after := filepath.Join(dir, "after.jsonl")
+	writeDiffLog(t, before,
+		diffEnvelope("before", 1, time.Unix(1, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		diffEnvelope("before", 2, time.Unix(2, 0), proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","inputSchema":{"type":"object"}}]}}`),
+		diffEnvelope("before", 3, time.Unix(3, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"query":"ruff"}}}`),
+		diffEnvelope("before", 4, time.Unix(3, 0).Add(100*time.Millisecond), proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
+	)
+	writeDiffLog(t, after,
+		diffEnvelope("after", 1, time.Unix(1, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		diffEnvelope("after", 2, time.Unix(2, 0), proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","inputSchema":{"type":"object","required":["query"]}}]}}`),
+		diffEnvelope("after", 3, time.Unix(3, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"query":"ruff"}}}`),
+		diffEnvelope("after", 4, time.Unix(3, 0).Add(350*time.Millisecond), proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"isError":true,"content":[]}}`),
+	)
+
+	code, stdout, stderr := executeDiff(t, []string{"--duration-threshold", "100ms", "--duration-ratio", "2", before, after})
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	for _, want := range []string{
+		"mcpsnoop diff before -> after",
+		"schema changed: search",
+		`status changed: search {"query":"ruff"} ok -> error`,
+		`slower: search {"query":"ruff"} 100ms -> 350ms`,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want %q", stdout, want)
+		}
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestDiffCommandRejectsInvalidDurationRatio(t *testing.T) {
+	for _, ratio := range []string{"0.5", "NaN", "+Inf"} {
+		t.Run(ratio, func(t *testing.T) {
+			code, _, stderr := executeDiff(t, []string{"--duration-ratio", ratio, "a", "b"})
+			if code != 2 {
+				t.Fatalf("exit = %d, want 2", code)
+			}
+			if !strings.Contains(stderr, "--duration-ratio must be finite and at least 1") {
+				t.Fatalf("stderr = %q", stderr)
+			}
+		})
+	}
+}
+
+func executeDiff(t *testing.T, args []string) (int, string, string) {
+	t.Helper()
+	cmd := newDiffCmd()
+	cmd.SetArgs(args)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		return 0, stdout.String(), stderr.String()
+	}
+	var code exitCode
+	if !errors.As(err, &code) {
+		t.Fatalf("unexpected command error: %v", err)
+	}
+	return int(code), stdout.String(), stderr.String()
+}
+
+func writeDiffLog(t *testing.T, path string, envelopes ...proxy.Envelope) {
+	t.Helper()
+	var out bytes.Buffer
+	enc := json.NewEncoder(&out)
+	for _, envelope := range envelopes {
+		if err := enc.Encode(envelope); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(path, out.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func diffEnvelope(sessionID string, seq uint64, ts time.Time, direction proxy.Direction, raw string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID:   sessionID,
+		ServerLabel: sessionID,
+		Seq:         seq,
+		TS:          ts,
+		Direction:   direction,
+		Raw:         json.RawMessage(raw),
+	}
+}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -287,7 +287,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.SetInterspersed(false)
 
 	cmd.SetVersionTemplate("mcpsnoop {{.Version}}\n")
-	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newOpenCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
+	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newDiffCmd(), newOpenCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
 	return cmd
 }
 

--- a/internal/sessiondiff/diff.go
+++ b/internal/sessiondiff/diff.go
@@ -1,0 +1,294 @@
+// Package sessiondiff compares two exported MCP sessions.
+package sessiondiff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+)
+
+const (
+	DefaultDurationThreshold = 100 * time.Millisecond
+	DefaultDurationRatio     = 2.0
+)
+
+type Options struct {
+	DurationThreshold time.Duration
+	DurationRatio     float64
+}
+
+type Report struct {
+	BeforeSession   string
+	AfterSession    string
+	AddedTools      []string
+	RemovedTools    []string
+	ChangedSchemas  []string
+	CallChanges     []CallChange
+	DurationChanges []DurationChange
+}
+
+type CallChange struct {
+	ToolName  string
+	Arguments string
+	Before    string
+	After     string
+}
+
+type DurationChange struct {
+	ToolName  string
+	Arguments string
+	Before    time.Duration
+	After     time.Duration
+}
+
+func (r Report) Empty() bool {
+	return len(r.AddedTools) == 0 &&
+		len(r.RemovedTools) == 0 &&
+		len(r.ChangedSchemas) == 0 &&
+		len(r.CallChanges) == 0 &&
+		len(r.DurationChanges) == 0
+}
+
+func Compare(before, after exporter.SessionExport, opts Options) Report {
+	if opts.DurationThreshold < 0 {
+		opts.DurationThreshold = DefaultDurationThreshold
+	}
+	if opts.DurationRatio < 1 || math.IsNaN(opts.DurationRatio) || math.IsInf(opts.DurationRatio, 0) {
+		opts.DurationRatio = DefaultDurationRatio
+	}
+
+	report := Report{
+		BeforeSession: before.Session.ID,
+		AfterSession:  after.Session.ID,
+	}
+	beforeTools := listedTools(before)
+	afterTools := listedTools(after)
+	for name, beforeSchema := range beforeTools {
+		afterSchema, ok := afterTools[name]
+		switch {
+		case !ok:
+			report.RemovedTools = append(report.RemovedTools, name)
+		case beforeSchema != afterSchema:
+			report.ChangedSchemas = append(report.ChangedSchemas, name)
+		}
+	}
+	for name := range afterTools {
+		if _, ok := beforeTools[name]; !ok {
+			report.AddedTools = append(report.AddedTools, name)
+		}
+	}
+	slices.Sort(report.AddedTools)
+	slices.Sort(report.RemovedTools)
+	slices.Sort(report.ChangedSchemas)
+
+	beforeCalls := callsBySignature(before)
+	afterCalls := callsBySignature(after)
+	var signatures []string
+	for signature := range beforeCalls {
+		if _, ok := afterCalls[signature]; ok {
+			signatures = append(signatures, signature)
+		}
+	}
+	slices.Sort(signatures)
+	for _, signature := range signatures {
+		beforeMatches := beforeCalls[signature]
+		afterMatches := afterCalls[signature]
+		for i := range min(len(beforeMatches), len(afterMatches)) {
+			beforeCall := beforeMatches[i]
+			afterCall := afterMatches[i]
+			if beforeCall.status != afterCall.status {
+				report.CallChanges = append(report.CallChanges, CallChange{
+					ToolName: beforeCall.toolName, Arguments: beforeCall.arguments,
+					Before: beforeCall.status, After: afterCall.status,
+				})
+			}
+			if beforeCall.duration == nil || afterCall.duration == nil {
+				continue
+			}
+			if notableDurationChange(*beforeCall.duration, *afterCall.duration, opts) {
+				report.DurationChanges = append(report.DurationChanges, DurationChange{
+					ToolName: beforeCall.toolName, Arguments: beforeCall.arguments,
+					Before: *beforeCall.duration, After: *afterCall.duration,
+				})
+			}
+		}
+	}
+	return report
+}
+
+func WriteText(w io.Writer, report Report) error {
+	if _, err := fmt.Fprintf(w, "mcpsnoop diff %s -> %s\n", report.BeforeSession, report.AfterSession); err != nil {
+		return err
+	}
+	if report.Empty() {
+		_, err := fmt.Fprintln(w, "no differences found")
+		return err
+	}
+	if len(report.AddedTools)+len(report.RemovedTools)+len(report.ChangedSchemas) > 0 {
+		if _, err := fmt.Fprintln(w, "tools:"); err != nil {
+			return err
+		}
+		for _, name := range report.AddedTools {
+			if _, err := fmt.Fprintf(w, "  added: %s\n", name); err != nil {
+				return err
+			}
+		}
+		for _, name := range report.RemovedTools {
+			if _, err := fmt.Fprintf(w, "  removed: %s\n", name); err != nil {
+				return err
+			}
+		}
+		for _, name := range report.ChangedSchemas {
+			if _, err := fmt.Fprintf(w, "  schema changed: %s\n", name); err != nil {
+				return err
+			}
+		}
+	}
+	if len(report.CallChanges) > 0 {
+		if _, err := fmt.Fprintln(w, "calls:"); err != nil {
+			return err
+		}
+		for _, change := range report.CallChanges {
+			if _, err := fmt.Fprintf(w, "  status changed: %s %s %s -> %s\n",
+				change.ToolName, change.Arguments, change.Before, change.After); err != nil {
+				return err
+			}
+		}
+	}
+	if len(report.DurationChanges) > 0 {
+		if _, err := fmt.Fprintln(w, "durations:"); err != nil {
+			return err
+		}
+		for _, change := range report.DurationChanges {
+			direction := "slower"
+			if change.After < change.Before {
+				direction = "faster"
+			}
+			if _, err := fmt.Fprintf(w, "  %s: %s %s %s -> %s\n",
+				direction, change.ToolName, change.Arguments, change.Before, change.After); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func listedTools(session exporter.SessionExport) map[string]string {
+	tools := make(map[string]string)
+	for _, call := range session.Calls {
+		if call.Method != "tools/list" {
+			continue
+		}
+		var result struct {
+			Tools []struct {
+				Name        string          `json:"name"`
+				InputSchema json.RawMessage `json:"inputSchema"`
+			} `json:"tools"`
+		}
+		if json.Unmarshal(call.Result, &result) != nil {
+			continue
+		}
+		if !hasCursor(call.Params) {
+			clear(tools)
+		}
+		for _, tool := range result.Tools {
+			if tool.Name == "" {
+				continue
+			}
+			if _, exists := tools[tool.Name]; exists {
+				continue
+			}
+			tools[tool.Name] = canonicalJSON(tool.InputSchema)
+		}
+	}
+	return tools
+}
+
+func hasCursor(params json.RawMessage) bool {
+	var request struct {
+		Cursor string `json:"cursor"`
+	}
+	return json.Unmarshal(params, &request) == nil && request.Cursor != ""
+}
+
+type comparableCall struct {
+	toolName  string
+	arguments string
+	status    string
+	duration  *time.Duration
+}
+
+func callsBySignature(session exporter.SessionExport) map[string][]comparableCall {
+	calls := make(map[string][]comparableCall)
+	for _, call := range session.Calls {
+		if !call.IsTool || call.ToolName == "" {
+			continue
+		}
+		arguments := callArguments(call.Params)
+		signature := call.ToolName + "\x00" + arguments
+		comparable := comparableCall{
+			toolName: call.ToolName, arguments: arguments, status: call.Status,
+		}
+		if call.DurationMS != nil {
+			duration := time.Duration(*call.DurationMS * float64(time.Millisecond))
+			comparable.duration = &duration
+		}
+		calls[signature] = append(calls[signature], comparable)
+	}
+	return calls
+}
+
+func callArguments(params json.RawMessage) string {
+	var request struct {
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if json.Unmarshal(params, &request) != nil || len(request.Arguments) == 0 {
+		return "{}"
+	}
+	return canonicalJSON(request.Arguments)
+}
+
+func canonicalJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "null"
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if decoder.Decode(&value) != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return strings.TrimSpace(string(raw))
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	return string(canonical)
+}
+
+func notableDurationChange(before, after time.Duration, opts Options) bool {
+	difference := after - before
+	if difference < 0 {
+		difference = -difference
+	}
+	if difference == 0 {
+		return false
+	}
+	if difference < opts.DurationThreshold {
+		return false
+	}
+	shorter, longer := before, after
+	if shorter > longer {
+		shorter, longer = longer, shorter
+	}
+	if shorter <= 0 {
+		return longer > 0
+	}
+	return float64(longer)/float64(shorter) >= opts.DurationRatio
+}

--- a/internal/sessiondiff/diff_test.go
+++ b/internal/sessiondiff/diff_test.go
@@ -1,0 +1,130 @@
+package sessiondiff
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+)
+
+func TestCompareReportsToolCallAndDurationChanges(t *testing.T) {
+	beforeDuration := 100.0
+	afterDuration := 350.0
+	before := exporter.SessionExport{
+		Session: exporter.SessionSummary{ID: "before"},
+		Calls: []exporter.CallExport{
+			listCall(`{"tools":[{"name":"search","inputSchema":{"type":"object","properties":{"query":{"type":"string"}}}},{"name":"old","inputSchema":{}}]}`),
+			toolCall("search", `{"name":"search","arguments":{"limit":5,"query":"ruff"}}`, "ok", &beforeDuration),
+		},
+	}
+	after := exporter.SessionExport{
+		Session: exporter.SessionSummary{ID: "after"},
+		Calls: []exporter.CallExport{
+			listCall(`{"tools":[{"name":"search","inputSchema":{"properties":{"query":{"minLength":1,"type":"string"}},"type":"object"}},{"name":"summarize","inputSchema":{}}]}`),
+			toolCall("search", `{"arguments":{"query":"ruff","limit":5},"name":"search"}`, "error", &afterDuration),
+		},
+	}
+
+	report := Compare(before, after, Options{
+		DurationThreshold: 100 * time.Millisecond,
+		DurationRatio:     2,
+	})
+
+	if !slices.Equal(report.AddedTools, []string{"summarize"}) {
+		t.Fatalf("added tools = %v", report.AddedTools)
+	}
+	if !slices.Equal(report.RemovedTools, []string{"old"}) {
+		t.Fatalf("removed tools = %v", report.RemovedTools)
+	}
+	if !slices.Equal(report.ChangedSchemas, []string{"search"}) {
+		t.Fatalf("changed schemas = %v", report.ChangedSchemas)
+	}
+	if len(report.CallChanges) != 1 {
+		t.Fatalf("call changes = %+v", report.CallChanges)
+	}
+	if got := report.CallChanges[0]; got.ToolName != "search" || got.Arguments != `{"limit":5,"query":"ruff"}` || got.Before != "ok" || got.After != "error" {
+		t.Fatalf("call change = %+v", got)
+	}
+	if len(report.DurationChanges) != 1 {
+		t.Fatalf("duration changes = %+v", report.DurationChanges)
+	}
+	if got := report.DurationChanges[0]; got.Before != 100*time.Millisecond || got.After != 350*time.Millisecond {
+		t.Fatalf("duration change = %+v", got)
+	}
+}
+
+func TestCompareUsesLatestCompleteToolListing(t *testing.T) {
+	before := exporter.SessionExport{
+		Session: exporter.SessionSummary{ID: "before"},
+		Calls: []exporter.CallExport{
+			listCall(`{"tools":[{"name":"withdrawn","inputSchema":{}}]}`),
+			listCall(`{"tools":[{"name":"page-one","inputSchema":{}}]}`),
+			{
+				Method: "tools/list",
+				Params: json.RawMessage(`{"cursor":"next"}`),
+				Result: json.RawMessage(`{"tools":[{"name":"page-two","inputSchema":{}}]}`),
+			},
+		},
+	}
+	after := exporter.SessionExport{
+		Session: exporter.SessionSummary{ID: "after"},
+		Calls: []exporter.CallExport{
+			listCall(`{"tools":[{"name":"page-one","inputSchema":{}},{"name":"page-two","inputSchema":{}}]}`),
+		},
+	}
+
+	report := Compare(before, after, Options{})
+	if len(report.AddedTools) != 0 || len(report.RemovedTools) != 0 || len(report.ChangedSchemas) != 0 {
+		t.Fatalf("tool changes = added %v, removed %v, schemas %v", report.AddedTools, report.RemovedTools, report.ChangedSchemas)
+	}
+}
+
+func TestWriteTextReportsNoDifferences(t *testing.T) {
+	report := Compare(
+		exporter.SessionExport{Session: exporter.SessionSummary{ID: "a"}},
+		exporter.SessionExport{Session: exporter.SessionSummary{ID: "b"}},
+		Options{},
+	)
+	var out strings.Builder
+	if err := WriteText(&out, report); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := out.String(), "mcpsnoop diff a -> b\nno differences found\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalJSONPreservesLargeIntegers(t *testing.T) {
+	left := canonicalJSON(json.RawMessage(`{"id":9007199254740992}`))
+	right := canonicalJSON(json.RawMessage(`{"id":9007199254740993}`))
+	if left == right {
+		t.Fatalf("distinct integers canonicalized to the same value: %s", left)
+	}
+}
+
+func TestNotableDurationChangeRequiresAChange(t *testing.T) {
+	if notableDurationChange(100*time.Millisecond, 100*time.Millisecond, Options{DurationRatio: 1}) {
+		t.Fatal("identical durations reported as a change")
+	}
+	if !notableDurationChange(100*time.Millisecond, 101*time.Millisecond, Options{DurationRatio: 1}) {
+		t.Fatal("non-zero duration change was not reported with open thresholds")
+	}
+}
+
+func listCall(result string) exporter.CallExport {
+	return exporter.CallExport{Method: "tools/list", Result: json.RawMessage(result)}
+}
+
+func toolCall(name, params, status string, durationMS *float64) exporter.CallExport {
+	return exporter.CallExport{
+		Method:     "tools/call",
+		Status:     status,
+		IsTool:     true,
+		ToolName:   name,
+		Params:     json.RawMessage(params),
+		DurationMS: durationMS,
+	}
+}


### PR DESCRIPTION
## What and why

Adds `mcpsnoop diff <before> <after>` for comparing saved session ids or JSONL logs. It reports tool additions/removals, `inputSchema` drift, matching call status changes, and duration shifts above configurable absolute and ratio thresholds. Calls are matched by canonical arguments, so JSON key and call ordering do not create false differences.

Closes #63.

## Validation

- `make check` — passed (gofmt, vet, Staticcheck, race tests)
- built `mcpsnoop diff --help` smoke — passed

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed