### PR TITLE
feat: detect MCP tool definition drift with TOFU baselines

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, or otlp |
 | `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, or hung calls |
+| `mcpsnoop baseline` | inspect, accept, or reset trusted tool definitions |
 | `mcpsnoop diff` | compare tools and calls across two captured sessions |
 | `mcpsnoop open` | open a saved session in the TUI |
 | `mcpsnoop remote <user@host>` | print the SSH tunnel command |
@@ -112,6 +113,7 @@ Run `mcpsnoop help` for the full list, or `mcpsnoop help <command>` for the flag
 | Flags hung calls and stream errors | no | yes |
 | Flags stray output that corrupts the stream | no | yes |
 | Flags malformed JSON-RPC frames | no | yes |
+| Detects tool definition drift after approval | no | yes |
 | Interactive terminal UI | no | yes |
 | Zero-config, no flags or ordering | no | yes |
 | Capability inspector | partial | yes |
@@ -254,9 +256,9 @@ mcpsnoop diff before-session after-session
 mcpsnoop diff old.jsonl new.jsonl
 ```
 
-The report shows tools that were added or removed, `inputSchema` changes,
-matching tool calls whose status changed, and notable duration shifts. Calls are
-matched by tool name and arguments, so reordered calls still compare correctly.
+The report shows tools that were added or removed, description and `inputSchema`
+changes, matching tool calls whose status changed, and notable duration shifts. Calls
+are matched by tool name and arguments, so reordered calls still compare correctly.
 By default, duration changes must differ by at least 100 ms and 2x; use
 `--duration-threshold` and `--duration-ratio` to adjust those cutoffs.
 
@@ -284,6 +286,26 @@ mcpsnoop check build-agent
 mcpsnoop check --fail-on error,invalid artifacts/session.jsonl
 mcpsnoop check --fail-on mismatch gateway-run.jsonl
 ```
+
+### Detect tool definition drift
+
+The first complete `tools/list` observed for a server label becomes its trusted
+baseline. Later sessions compare tool descriptions and input schemas with that
+baseline, including tools that were added or removed. The sessions table and
+tool summary flag drift without blocking or changing MCP traffic.
+
+Use a stable, unique `--label` for each server whose command name or target host
+would otherwise collide. Baselines are stored under the normal mcpsnoop state
+directory, so `MCPSNOOP_HOME` and `XDG_STATE_HOME` apply.
+
+```bash
+mcpsnoop check --fail-on drift session.jsonl
+mcpsnoop baseline session.jsonl
+mcpsnoop baseline --accept session.jsonl  # trust a legitimate definition change
+mcpsnoop baseline --reset session.jsonl   # trust the next complete tools/list
+```
+
+`drift` is opt-in for `check`; the default `error,invalid,warn` gate is unchanged.
 
 ## Watching from another machine
 

--- a/cmd/mcpsnoop/baseline.go
+++ b/cmd/mcpsnoop/baseline.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+	"github.com/kerlenton/mcpsnoop/internal/toolbaseline"
+)
+
+func newBaselineCmd() *cobra.Command {
+	var accept, reset bool
+	cmd := &cobra.Command{
+		Use:   "baseline [session-id|log.jsonl|-]",
+		Short: "Inspect or update the trusted tool-definition baseline",
+		Long:  "Compare a captured session's complete tools/list definition set with its server-label baseline. Use --accept after a legitimate change, or --reset to remove the baseline so the next observation becomes trusted.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if accept && reset {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop baseline: --accept and --reset are mutually exclusive")
+				return exitCode(2)
+			}
+			var arg string
+			if len(args) == 1 {
+				arg = args[0]
+			}
+			st, sessionID, err := loadCheckSession(cmd, arg)
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop baseline:", err)
+				return exitCode(1)
+			}
+			manager := toolbaseline.New(paths.ToolBaselinesDir())
+			switch {
+			case accept:
+				server, err := toolbaseline.AcceptSession(manager, st, sessionID)
+				if err != nil {
+					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop baseline:", err)
+					return exitCode(1)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "accepted baseline for %s\n", server)
+				return nil
+			case reset:
+				server, err := toolbaseline.ResetSession(manager, st, sessionID)
+				if err != nil {
+					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop baseline:", err)
+					return exitCode(1)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "reset baseline for %s\n", server)
+				return nil
+			default:
+				report, created, err := toolbaseline.ObserveSession(manager, st, sessionID)
+				if err != nil {
+					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop baseline:", err)
+					return exitCode(1)
+				}
+				if created {
+					fmt.Fprintln(cmd.OutOrStdout(), "created first-seen tool baseline")
+					return nil
+				}
+				if report.Empty() {
+					fmt.Fprintln(cmd.OutOrStdout(), "no tool definition drift")
+					return nil
+				}
+				writeToolDrift(cmd.OutOrStdout(), report)
+				return exitCode(1)
+			}
+		},
+	}
+	cmd.Flags().SortFlags = false
+	cmd.Flags().BoolVar(&accept, "accept", false, "replace the baseline with this session's complete tool definitions")
+	cmd.Flags().BoolVar(&reset, "reset", false, "remove the baseline for this session's server label")
+	return cmd
+}
+
+func writeToolDrift(w io.Writer, report store.ToolDrift) {
+	fmt.Fprintln(w, "definition drift:")
+	for _, change := range []struct {
+		label string
+		names []string
+	}{
+		{"added", report.AddedTools},
+		{"removed", report.RemovedTools},
+		{"description changed", report.ChangedDescriptions},
+		{"schema changed", report.ChangedSchemas},
+	} {
+		if len(change.names) > 0 {
+			fmt.Fprintf(w, "  %s: %s\n", change.label, strings.Join(change.names, ", "))
+		}
+	}
+}

--- a/cmd/mcpsnoop/baseline_test.go
+++ b/cmd/mcpsnoop/baseline_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func TestBaselineCommandAcceptsShowsAndResetsDefinitionDrift(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	initial := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"old","inputSchema":{}}]}}`),
+	)
+	code, stdout, stderr := executeBaseline(t, []string{"--accept", "-"}, initial)
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "accepted baseline for srv") {
+		t.Fatalf("accept = code %d, stdout %q, stderr %q", code, stdout, stderr)
+	}
+
+	changed := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"new","inputSchema":{}}]}}`),
+	)
+	code, stdout, stderr = executeBaseline(t, []string{"-"}, changed)
+	if code != 1 || stderr != "" || !strings.Contains(stdout, "description changed: search") {
+		t.Fatalf("show = code %d, stdout %q, stderr %q", code, stdout, stderr)
+	}
+
+	code, stdout, stderr = executeBaseline(t, []string{"--reset", "-"}, changed)
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "reset baseline for srv") {
+		t.Fatalf("reset = code %d, stdout %q, stderr %q", code, stdout, stderr)
+	}
+}
+
+func executeBaseline(t *testing.T, args []string, stdin string) (int, string, string) {
+	t.Helper()
+	cmd := newBaselineCmd()
+	cmd.SetArgs(args)
+	cmd.SetIn(strings.NewReader(stdin))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		return 0, stdout.String(), stderr.String()
+	}
+	var code exitCode
+	if !errors.As(err, &code) {
+		t.Fatalf("unexpected command error: %v", err)
+	}
+	return int(code), stdout.String(), stderr.String()
+}

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -7,7 +7,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/store"
+	"github.com/kerlenton/mcpsnoop/internal/toolbaseline"
 )
 
 type checkSignal string
@@ -18,9 +20,10 @@ const (
 	checkWarn     checkSignal = "warn"
 	checkMismatch checkSignal = "mismatch"
 	checkPending  checkSignal = "pending"
+	checkDrift    checkSignal = "drift"
 )
 
-var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending}
+var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift}
 
 type checkSummary struct {
 	sessionID  string
@@ -29,6 +32,7 @@ type checkSummary struct {
 	warnings   int
 	mismatches int
 	pending    int
+	drift      store.ToolDrift
 }
 
 func newCheckCmd() *cobra.Command {
@@ -36,7 +40,7 @@ func newCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check [session-id|log.jsonl|-]",
 		Short: "Fail when a captured session contains selected signals",
-		Long:  "Check a captured session for errors, invalid frames, warnings, routing-header mismatches, or calls that never got a response. With no session, the newest session log is checked. Use - to read from stdin.",
+		Long:  "Check a captured session for errors, invalid frames, warnings, routing-header mismatches, calls that never got a response, or tool definitions that drifted from their trust-on-first-use baseline. With no session, the newest session log is checked. Use - to read from stdin.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			signals, err := parseCheckSignals(failOn)
@@ -55,10 +59,18 @@ func newCheckCmd() *cobra.Command {
 				return exitCode(1)
 			}
 
+			summaries, err := summarizeCheck(st, toolbaseline.New(paths.ToolBaselinesDir()))
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
+				return exitCode(1)
+			}
 			anyFailed := false
-			for _, summary := range summarizeCheck(st) {
+			for _, summary := range summaries {
 				fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d\n",
 					summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending)
+				if !summary.drift.Empty() {
+					writeToolDrift(cmd.OutOrStdout(), summary.drift)
+				}
 				if failed := summary.failed(signals); len(failed) > 0 {
 					fmt.Fprintf(cmd.OutOrStdout(), "check failed: %s\n", strings.Join(failed, ","))
 					anyFailed = true
@@ -72,7 +84,7 @@ func newCheckCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().SortFlags = false
-	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending")
+	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift")
 	return cmd
 }
 
@@ -81,10 +93,10 @@ func parseCheckSignals(value string) (map[checkSignal]bool, error) {
 	for _, part := range strings.Split(value, ",") {
 		signal := checkSignal(strings.TrimSpace(part))
 		switch signal {
-		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending:
+		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift:
 			signals[signal] = true
 		default:
-			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, or pending, got %q", part)
+			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, or drift, got %q", part)
 		}
 	}
 	return signals, nil
@@ -104,10 +116,17 @@ func loadCheckSession(cmd *cobra.Command, arg string) (*store.Store, string, err
 // summarizeCheck counts each signal for every session in the store, so a
 // concatenated multi-session capture is gated as a whole rather than only its
 // first session.
-func summarizeCheck(st *store.Store) []checkSummary {
+func summarizeCheck(st *store.Store, baselines *toolbaseline.Manager) ([]checkSummary, error) {
 	var summaries []checkSummary
 	for _, header := range st.Sessions() {
 		summary := checkSummary{sessionID: header.ID, errors: header.Errors, pending: header.Pending}
+		if _, ok := st.ToolDefinitions(header.ID); ok {
+			report, _, err := toolbaseline.ObserveSession(baselines, st, header.ID)
+			if err != nil {
+				return nil, err
+			}
+			summary.drift = report
+		}
 		for _, event := range st.Timeline(header.ID) {
 			if event.Kind == store.EventInvalid {
 				summary.invalid++
@@ -121,7 +140,7 @@ func summarizeCheck(st *store.Store) []checkSummary {
 		}
 		summaries = append(summaries, summary)
 	}
-	return summaries
+	return summaries, nil
 }
 
 func (s checkSummary) failed(selected map[checkSignal]bool) []string {
@@ -131,6 +150,7 @@ func (s checkSummary) failed(selected map[checkSignal]bool) []string {
 		checkWarn:     s.warnings,
 		checkMismatch: s.mismatches,
 		checkPending:  s.pending,
+		checkDrift:    s.drift.Count(),
 	}
 	var failed []string
 	for _, signal := range checkSignalOrder {

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -30,6 +30,7 @@ func TestCheckFailsOnSelectedSessionSignals(t *testing.T) {
 }
 
 func TestCheckFailsOnlyOnSelectedSignals(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	log := encodeCheckLog(t, checkSignalEnvelopes()...)
 
 	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "invalid", "-"}, log)
@@ -45,6 +46,7 @@ func TestCheckFailsOnlyOnSelectedSignals(t *testing.T) {
 }
 
 func TestCheckIgnoresUnselectedSignals(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	errorOnly := encodeCheckLog(t, checkErrorEnvelopes()...)
 	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "invalid,warn", "-"}, errorOnly)
 	if code != 0 {
@@ -59,6 +61,7 @@ func TestCheckIgnoresUnselectedSignals(t *testing.T) {
 }
 
 func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	log := encodeCheckLog(t,
 		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
 		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
@@ -77,6 +80,7 @@ func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
 }
 
 func TestCheckRejectsUnknownOrEmptyFailOnValues(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	for _, value := range []string{"error,bogus", ""} {
 		t.Run(value, func(t *testing.T) {
 			code, stdout, stderr := executeCheck(t, []string{"--fail-on", value, "-"}, "{}\n")
@@ -94,6 +98,7 @@ func TestCheckRejectsUnknownOrEmptyFailOnValues(t *testing.T) {
 }
 
 func TestCheckReportsMalformedInput(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	code, stdout, stderr := executeCheck(t, []string{"-"}, "not-json\n")
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
@@ -107,6 +112,7 @@ func TestCheckReportsMalformedInput(t *testing.T) {
 }
 
 func TestCheckGatesEverySessionNotJustTheFirst(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	env := func(session string, seq uint64, dir proxy.Direction, raw string) proxy.Envelope {
 		return proxy.Envelope{SessionID: session, ServerLabel: "srv", Seq: seq, TS: time.Unix(int64(seq), 0), Direction: dir, Raw: json.RawMessage(raw)}
 	}
@@ -130,6 +136,7 @@ func TestCheckGatesEverySessionNotJustTheFirst(t *testing.T) {
 }
 
 func TestCheckFailsOnHungCall(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	// A request with no response is a hung call that only the pending signal sees.
 	log := encodeCheckLog(t,
 		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hang"}}`),
@@ -154,6 +161,7 @@ func TestCheckFailsOnHungCall(t *testing.T) {
 }
 
 func TestCheckFailsOnRoutingMismatch(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	// The Mcp-Name header claims a safe tool while the body calls another one: a
 	// routing mismatch (tool shadowing) that a compliant gateway would reject.
 	shadow := checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dangerous"}}`)
@@ -182,6 +190,37 @@ func TestCheckFailsOnRoutingMismatch(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "mismatches=0") || !strings.Contains(stdout, "check passed") {
 		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestCheckFailsOnToolDefinitionDriftWhenSelected(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	baseline := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"Search docs","inputSchema":{"type":"object"}}]}}`),
+	)
+	code, _, stderr := executeCheck(t, []string{"--fail-on", "drift", "-"}, baseline)
+	if code != 0 || stderr != "" {
+		t.Fatalf("baseline check = code %d, stderr %q", code, stderr)
+	}
+
+	changed := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"Search private docs","inputSchema":{"type":"object"}}]}}`),
+	)
+	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "drift", "-"}, changed)
+	if code != 1 || stderr != "" {
+		t.Fatalf("drift check = code %d, stderr %q", code, stderr)
+	}
+	for _, want := range []string{"definition drift:", "description changed: search", "check failed: drift"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q\n%s", want, stdout)
+		}
+	}
+
+	code, stdout, stderr = executeCheck(t, []string{"-"}, changed)
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "description changed: search") {
+		t.Fatalf("default check = code %d, stdout %q, stderr %q", code, stdout, stderr)
 	}
 }
 

--- a/cmd/mcpsnoop/diff_test.go
+++ b/cmd/mcpsnoop/diff_test.go
@@ -19,13 +19,13 @@ func TestDiffCommandComparesTwoLogPaths(t *testing.T) {
 	after := filepath.Join(dir, "after.jsonl")
 	writeDiffLog(t, before,
 		diffEnvelope("before", 1, time.Unix(1, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
-		diffEnvelope("before", 2, time.Unix(2, 0), proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","inputSchema":{"type":"object"}}]}}`),
+		diffEnvelope("before", 2, time.Unix(2, 0), proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"Search docs","inputSchema":{"type":"object"}}]}}`),
 		diffEnvelope("before", 3, time.Unix(3, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"query":"ruff"}}}`),
 		diffEnvelope("before", 4, time.Unix(3, 0).Add(100*time.Millisecond), proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
 	)
 	writeDiffLog(t, after,
 		diffEnvelope("after", 1, time.Unix(1, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
-		diffEnvelope("after", 2, time.Unix(2, 0), proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","inputSchema":{"type":"object","required":["query"]}}]}}`),
+		diffEnvelope("after", 2, time.Unix(2, 0), proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"Search private docs","inputSchema":{"type":"object","required":["query"]}}]}}`),
 		diffEnvelope("after", 3, time.Unix(3, 0), proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"query":"ruff"}}}`),
 		diffEnvelope("after", 4, time.Unix(3, 0).Add(350*time.Millisecond), proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"isError":true,"content":[]}}`),
 	)
@@ -36,6 +36,7 @@ func TestDiffCommandComparesTwoLogPaths(t *testing.T) {
 	}
 	for _, want := range []string{
 		"mcpsnoop diff before -> after",
+		"description changed: search",
 		"schema changed: search",
 		`status changed: search {"query":"ruff"} ok -> error`,
 		`slower: search {"query":"ruff"} 100ms -> 350ms`,

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -287,7 +287,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.SetInterspersed(false)
 
 	cmd.SetVersionTemplate("mcpsnoop {{.Version}}\n")
-	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newDiffCmd(), newOpenCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
+	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newBaselineCmd(), newDiffCmd(), newOpenCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
 	return cmd
 }
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -54,6 +54,13 @@ func ExportsDir() string {
 	return d
 }
 
+// ToolBaselinesDir holds trust-on-first-use tool definitions per server label.
+func ToolBaselinesDir() string {
+	d := filepath.Join(Base(), "tool-baselines")
+	_ = os.MkdirAll(d, 0o700)
+	return d
+}
+
 // SessionLogPath returns the JSONL trace path for a given session id.
 func SessionLogPath(sessionID string) string {
 	return filepath.Join(SessionsDir(), sessionID+".jsonl")

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,26 @@
+package paths
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestToolBaselinesDirUsesConfiguredStateRoot(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", root)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	if got, want := ToolBaselinesDir(), filepath.Join(root, "tool-baselines"); got != want {
+		t.Fatalf("ToolBaselinesDir() = %q, want %q", got, want)
+	}
+}
+
+func TestToolBaselinesDirUsesXDGStateHome(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", "")
+	t.Setenv("XDG_STATE_HOME", root)
+
+	if got, want := ToolBaselinesDir(), filepath.Join(root, "mcpsnoop", "tool-baselines"); got != want {
+		t.Fatalf("ToolBaselinesDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/sessiondiff/diff.go
+++ b/internal/sessiondiff/diff.go
@@ -25,13 +25,29 @@ type Options struct {
 }
 
 type Report struct {
-	BeforeSession   string
-	AfterSession    string
-	AddedTools      []string
-	RemovedTools    []string
-	ChangedSchemas  []string
-	CallChanges     []CallChange
-	DurationChanges []DurationChange
+	BeforeSession       string
+	AfterSession        string
+	AddedTools          []string
+	RemovedTools        []string
+	ChangedDescriptions []string
+	ChangedSchemas      []string
+	CallChanges         []CallChange
+	DurationChanges     []DurationChange
+}
+
+// ToolDefinition is the behavior-affecting contract advertised for one MCP tool.
+type ToolDefinition struct {
+	Name        string
+	Description string
+	InputSchema json.RawMessage
+}
+
+// ToolChanges contains definition differences between two complete tool lists.
+type ToolChanges struct {
+	AddedTools          []string
+	RemovedTools        []string
+	ChangedDescriptions []string
+	ChangedSchemas      []string
 }
 
 type CallChange struct {
@@ -51,6 +67,7 @@ type DurationChange struct {
 func (r Report) Empty() bool {
 	return len(r.AddedTools) == 0 &&
 		len(r.RemovedTools) == 0 &&
+		len(r.ChangedDescriptions) == 0 &&
 		len(r.ChangedSchemas) == 0 &&
 		len(r.CallChanges) == 0 &&
 		len(r.DurationChanges) == 0
@@ -61,7 +78,7 @@ func (r Report) Empty() bool {
 // change), a call whose status got worse, or a call that got notably slower.
 // Improvements, added tools, fixed calls, and speedups do not count.
 func (r Report) HasRegression() bool {
-	if len(r.RemovedTools) > 0 || len(r.ChangedSchemas) > 0 {
+	if len(r.RemovedTools) > 0 || len(r.ChangedDescriptions) > 0 || len(r.ChangedSchemas) > 0 {
 		return true
 	}
 	for _, change := range r.CallChanges {
@@ -102,25 +119,11 @@ func Compare(before, after exporter.SessionExport, opts Options) Report {
 		BeforeSession: before.Session.ID,
 		AfterSession:  after.Session.ID,
 	}
-	beforeTools := listedTools(before)
-	afterTools := listedTools(after)
-	for name, beforeSchema := range beforeTools {
-		afterSchema, ok := afterTools[name]
-		switch {
-		case !ok:
-			report.RemovedTools = append(report.RemovedTools, name)
-		case beforeSchema != afterSchema:
-			report.ChangedSchemas = append(report.ChangedSchemas, name)
-		}
-	}
-	for name := range afterTools {
-		if _, ok := beforeTools[name]; !ok {
-			report.AddedTools = append(report.AddedTools, name)
-		}
-	}
-	slices.Sort(report.AddedTools)
-	slices.Sort(report.RemovedTools)
-	slices.Sort(report.ChangedSchemas)
+	toolChanges := CompareToolDefinitions(listedTools(before), listedTools(after))
+	report.AddedTools = toolChanges.AddedTools
+	report.RemovedTools = toolChanges.RemovedTools
+	report.ChangedDescriptions = toolChanges.ChangedDescriptions
+	report.ChangedSchemas = toolChanges.ChangedSchemas
 
 	beforeCalls := callsBySignature(before)
 	afterCalls := callsBySignature(after)
@@ -165,7 +168,7 @@ func WriteText(w io.Writer, report Report) error {
 		_, err := fmt.Fprintln(w, "no differences found")
 		return err
 	}
-	if len(report.AddedTools)+len(report.RemovedTools)+len(report.ChangedSchemas) > 0 {
+	if len(report.AddedTools)+len(report.RemovedTools)+len(report.ChangedDescriptions)+len(report.ChangedSchemas) > 0 {
 		if _, err := fmt.Fprintln(w, "tools:"); err != nil {
 			return err
 		}
@@ -176,6 +179,11 @@ func WriteText(w io.Writer, report Report) error {
 		}
 		for _, name := range report.RemovedTools {
 			if _, err := fmt.Fprintf(w, "  removed: %s\n", name); err != nil {
+				return err
+			}
+		}
+		for _, name := range report.ChangedDescriptions {
+			if _, err := fmt.Fprintf(w, "  description changed: %s\n", name); err != nil {
 				return err
 			}
 		}
@@ -214,8 +222,54 @@ func WriteText(w io.Writer, report Report) error {
 	return nil
 }
 
-func listedTools(session exporter.SessionExport) map[string]string {
-	tools := make(map[string]string)
+// CompareToolDefinitions reports behavior-affecting differences between two
+// complete tool lists. Schema JSON is canonicalized before comparison.
+func CompareToolDefinitions(before, after []ToolDefinition) ToolChanges {
+	beforeTools := toolDefinitionsByName(before)
+	afterTools := toolDefinitionsByName(after)
+	var changes ToolChanges
+	for name, trusted := range beforeTools {
+		observed, ok := afterTools[name]
+		switch {
+		case !ok:
+			changes.RemovedTools = append(changes.RemovedTools, name)
+		default:
+			if trusted.Description != observed.Description {
+				changes.ChangedDescriptions = append(changes.ChangedDescriptions, name)
+			}
+			if canonicalJSON(trusted.InputSchema) != canonicalJSON(observed.InputSchema) {
+				changes.ChangedSchemas = append(changes.ChangedSchemas, name)
+			}
+		}
+	}
+	for name := range afterTools {
+		if _, ok := beforeTools[name]; !ok {
+			changes.AddedTools = append(changes.AddedTools, name)
+		}
+	}
+	slices.Sort(changes.AddedTools)
+	slices.Sort(changes.RemovedTools)
+	slices.Sort(changes.ChangedDescriptions)
+	slices.Sort(changes.ChangedSchemas)
+	return changes
+}
+
+func toolDefinitionsByName(definitions []ToolDefinition) map[string]ToolDefinition {
+	tools := make(map[string]ToolDefinition, len(definitions))
+	for _, definition := range definitions {
+		if definition.Name == "" {
+			continue
+		}
+		if _, exists := tools[definition.Name]; exists {
+			continue
+		}
+		tools[definition.Name] = definition
+	}
+	return tools
+}
+
+func listedTools(session exporter.SessionExport) []ToolDefinition {
+	tools := make(map[string]ToolDefinition)
 	for _, call := range session.Calls {
 		if call.Method != "tools/list" {
 			continue
@@ -223,6 +277,7 @@ func listedTools(session exporter.SessionExport) map[string]string {
 		var result struct {
 			Tools []struct {
 				Name        string          `json:"name"`
+				Description string          `json:"description"`
 				InputSchema json.RawMessage `json:"inputSchema"`
 			} `json:"tools"`
 		}
@@ -239,10 +294,19 @@ func listedTools(session exporter.SessionExport) map[string]string {
 			if _, exists := tools[tool.Name]; exists {
 				continue
 			}
-			tools[tool.Name] = canonicalJSON(tool.InputSchema)
+			tools[tool.Name] = ToolDefinition{
+				Name:        tool.Name,
+				Description: tool.Description,
+				InputSchema: append(json.RawMessage(nil), tool.InputSchema...),
+			}
 		}
 	}
-	return tools
+	definitions := make([]ToolDefinition, 0, len(tools))
+	for _, definition := range tools {
+		definitions = append(definitions, definition)
+	}
+	slices.SortFunc(definitions, func(a, b ToolDefinition) int { return strings.Compare(a.Name, b.Name) })
+	return definitions
 }
 
 func hasCursor(params json.RawMessage) bool {

--- a/internal/sessiondiff/diff_test.go
+++ b/internal/sessiondiff/diff_test.go
@@ -16,14 +16,14 @@ func TestCompareReportsToolCallAndDurationChanges(t *testing.T) {
 	before := exporter.SessionExport{
 		Session: exporter.SessionSummary{ID: "before"},
 		Calls: []exporter.CallExport{
-			listCall(`{"tools":[{"name":"search","inputSchema":{"type":"object","properties":{"query":{"type":"string"}}}},{"name":"old","inputSchema":{}}]}`),
+			listCall(`{"tools":[{"name":"search","description":"Search docs","inputSchema":{"type":"object","properties":{"query":{"type":"string"}}}},{"name":"old","inputSchema":{}}]}`),
 			toolCall("search", `{"name":"search","arguments":{"limit":5,"query":"ruff"}}`, "ok", &beforeDuration),
 		},
 	}
 	after := exporter.SessionExport{
 		Session: exporter.SessionSummary{ID: "after"},
 		Calls: []exporter.CallExport{
-			listCall(`{"tools":[{"name":"search","inputSchema":{"properties":{"query":{"minLength":1,"type":"string"}},"type":"object"}},{"name":"summarize","inputSchema":{}}]}`),
+			listCall(`{"tools":[{"name":"search","description":"Search private docs","inputSchema":{"properties":{"query":{"minLength":1,"type":"string"}},"type":"object"}},{"name":"summarize","inputSchema":{}}]}`),
 			toolCall("search", `{"arguments":{"query":"ruff","limit":5},"name":"search"}`, "error", &afterDuration),
 		},
 	}
@@ -39,6 +39,9 @@ func TestCompareReportsToolCallAndDurationChanges(t *testing.T) {
 	if !slices.Equal(report.RemovedTools, []string{"old"}) {
 		t.Fatalf("removed tools = %v", report.RemovedTools)
 	}
+	if !slices.Equal(report.ChangedDescriptions, []string{"search"}) {
+		t.Fatalf("changed descriptions = %v", report.ChangedDescriptions)
+	}
 	if !slices.Equal(report.ChangedSchemas, []string{"search"}) {
 		t.Fatalf("changed schemas = %v", report.ChangedSchemas)
 	}
@@ -53,6 +56,22 @@ func TestCompareReportsToolCallAndDurationChanges(t *testing.T) {
 	}
 	if got := report.DurationChanges[0]; got.Before != 100*time.Millisecond || got.After != 350*time.Millisecond {
 		t.Fatalf("duration change = %+v", got)
+	}
+}
+
+func TestCompareToolDefinitionsDetectsDescriptionOnlyChanges(t *testing.T) {
+	before := []ToolDefinition{{
+		Name: "search", Description: "Search docs",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}}}`),
+	}}
+	after := []ToolDefinition{{
+		Name: "search", Description: "Search private docs",
+		InputSchema: json.RawMessage(`{"properties":{"q":{"type":"string"}},"type":"object"}`),
+	}}
+
+	changes := CompareToolDefinitions(before, after)
+	if !slices.Equal(changes.ChangedDescriptions, []string{"search"}) || len(changes.ChangedSchemas) != 0 {
+		t.Fatalf("tool changes = %+v", changes)
 	}
 }
 
@@ -106,6 +125,7 @@ func TestHasRegression(t *testing.T) {
 		{"empty", Report{}, false},
 		{"added tool only", Report{AddedTools: []string{"x"}}, false},
 		{"removed tool", Report{RemovedTools: []string{"x"}}, true},
+		{"description changed", Report{ChangedDescriptions: []string{"x"}}, true},
 		{"schema changed", Report{ChangedSchemas: []string{"x"}}, true},
 		{"status worse", Report{CallChanges: []CallChange{{Before: "ok", After: "error"}}}, true},
 		{"status better", Report{CallChanges: []CallChange{{Before: "error", After: "ok"}}}, false},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -124,8 +124,12 @@ type session struct {
 	last  time.Time
 	caps  capabilities
 
-	advertisedTools []string
-	advertisedSet   map[string]struct{}
+	advertisedTools  []string
+	advertisedSet    map[string]struct{}
+	toolDefinitions  map[string]ToolDefinition
+	toolListComplete bool
+	toolDrift        ToolDrift
+	toolDriftSet     bool
 
 	command []string
 	cwd     string
@@ -300,11 +304,12 @@ func (s *Store) sessionFor(e proxy.Envelope) *session {
 	sess, ok := s.sessions[e.SessionID]
 	if !ok {
 		sess = &session{
-			id:            e.SessionID,
-			label:         e.ServerLabel,
-			first:         e.TS,
-			advertisedSet: make(map[string]struct{}),
-			calls:         make(map[callKey]*call),
+			id:              e.SessionID,
+			label:           e.ServerLabel,
+			first:           e.TS,
+			advertisedSet:   make(map[string]struct{}),
+			toolDefinitions: make(map[string]ToolDefinition),
+			calls:           make(map[callKey]*call),
 		}
 		s.sessions[e.SessionID] = sess
 		s.order = append(s.order, e.SessionID)
@@ -516,8 +521,11 @@ func (c *capabilities) applyResponseMeta(result json.RawMessage) {
 func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 	var r struct {
 		Tools []struct {
-			Name string `json:"name"`
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			InputSchema json.RawMessage `json:"inputSchema"`
 		} `json:"tools"`
+		NextCursor string `json:"nextCursor"`
 	}
 
 	if json.Unmarshal(result, &r) != nil {
@@ -526,6 +534,7 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 
 	if !hasListCursor(reqParams) {
 		clear(sess.advertisedSet)
+		clear(sess.toolDefinitions)
 		sess.advertisedTools = nil
 	}
 
@@ -539,7 +548,13 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 
 		sess.advertisedSet[tool.Name] = struct{}{}
 		sess.advertisedTools = append(sess.advertisedTools, tool.Name)
+		sess.toolDefinitions[tool.Name] = ToolDefinition{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: append(json.RawMessage(nil), tool.InputSchema...),
+		}
 	}
+	sess.toolListComplete = r.NextCursor == ""
 }
 
 // hasListCursor reports whether a tools/list request carries a pagination cursor,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -746,3 +746,46 @@ func TestToolUsageReportsCalledButNotAdvertised(t *testing.T) {
 		t.Fatalf("unadvertised = %v, want [search weather]", unadvertised)
 	}
 }
+
+func TestToolDefinitionsCaptureDescriptionsSchemasAndCompletePagination(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", ""))
+	s.Ingest(resp(2, t0, proxy.ServerToClient, "1", `"result":{"tools":[{"name":"search","description":"Search docs","inputSchema":{"type":"object","properties":{"query":{"type":"string"}}}}],"nextCursor":"p2"}`))
+	if _, ok := s.ToolDefinitions("s1"); ok {
+		t.Fatal("partial tools/list pagination must not be treated as a complete definition set")
+	}
+
+	s.Ingest(req(3, t0, proxy.ClientToServer, "2", "tools/list", `{"cursor":"p2"}`))
+	s.Ingest(resp(4, t0, proxy.ServerToClient, "2", `"result":{"tools":[{"name":"fetch","description":"Fetch a page","inputSchema":{"type":"object"}}]}`))
+
+	definitions, ok := s.ToolDefinitions("s1")
+	if !ok {
+		t.Fatal("complete paginated tools/list was not exposed")
+	}
+	if len(definitions) != 2 {
+		t.Fatalf("definitions = %+v, want two tools", definitions)
+	}
+	if definitions[0].Name != "search" || definitions[0].Description != "Search docs" || string(definitions[0].InputSchema) == "" {
+		t.Fatalf("search definition = %+v", definitions[0])
+	}
+	if definitions[1].Name != "fetch" || definitions[1].Description != "Fetch a page" {
+		t.Fatalf("fetch definition = %+v", definitions[1])
+	}
+}
+
+func TestToolDriftIsExposedOnSessionHeader(t *testing.T) {
+	s := New()
+	s.Ingest(req(1, time.Now(), proxy.ClientToServer, "1", "tools/list", ""))
+	s.SetToolDrift("s1", ToolDrift{ChangedDescriptions: []string{"search"}})
+
+	headers := s.Sessions()
+	if len(headers) != 1 || !headers[0].HasToolDrift {
+		t.Fatalf("session header drift = %+v", headers)
+	}
+	report, ok := s.ToolDrift("s1")
+	if !ok || len(report.ChangedDescriptions) != 1 || report.ChangedDescriptions[0] != "search" {
+		t.Fatalf("tool drift = %+v, ok=%v", report, ok)
+	}
+}

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -68,16 +68,41 @@ type EventView struct {
 
 // SessionHeader is a lightweight per-session summary for the left panel.
 type SessionHeader struct {
-	ID            string
-	Label         string
-	First         time.Time
-	Last          time.Time
-	Requests      int
-	Responses     int
-	Notifications int
-	Errors        int
-	Pending       int
-	HasCaps       bool
+	ID                   string
+	Label                string
+	First                time.Time
+	Last                 time.Time
+	Requests             int
+	Responses            int
+	Notifications        int
+	Errors               int
+	Pending              int
+	HasCaps              bool
+	HasToolDrift         bool
+	HasToolBaselineError bool
+}
+
+// ToolDefinition is the contract a server advertised for one MCP tool.
+type ToolDefinition struct {
+	Name        string
+	Description string
+	InputSchema json.RawMessage
+}
+
+// ToolDrift is the difference between the current complete tool list and the
+// persisted trust-on-first-use baseline for the session's server label.
+type ToolDrift struct {
+	AddedTools          []string
+	RemovedTools        []string
+	ChangedDescriptions []string
+	ChangedSchemas      []string
+	BaselineError       string
+}
+
+func (d ToolDrift) Empty() bool { return d.Count() == 0 && d.BaselineError == "" }
+
+func (d ToolDrift) Count() int {
+	return len(d.AddedTools) + len(d.RemovedTools) + len(d.ChangedDescriptions) + len(d.ChangedSchemas)
 }
 
 // CapsView is an immutable snapshot of the negotiated capabilities.
@@ -166,19 +191,70 @@ func (s *Store) Sessions() []SessionHeader {
 	for _, id := range s.order {
 		sess := s.sessions[id]
 		out = append(out, SessionHeader{
-			ID:            sess.id,
-			Label:         sess.label,
-			First:         sess.first,
-			Last:          sess.last,
-			Requests:      sess.requests,
-			Responses:     sess.responses,
-			Notifications: sess.notifications,
-			Errors:        sess.errors,
-			Pending:       sess.pending,
-			HasCaps:       sess.caps.set,
+			ID:                   sess.id,
+			Label:                sess.label,
+			First:                sess.first,
+			Last:                 sess.last,
+			Requests:             sess.requests,
+			Responses:            sess.responses,
+			Notifications:        sess.notifications,
+			Errors:               sess.errors,
+			Pending:              sess.pending,
+			HasCaps:              sess.caps.set,
+			HasToolDrift:         sess.toolDrift.Count() > 0,
+			HasToolBaselineError: sess.toolDrift.BaselineError != "",
 		})
 	}
 	return out
+}
+
+// ToolDefinitions returns the current complete tools/list definition set in
+// server order. ok is false until the final page of a listing has arrived.
+func (s *Store) ToolDefinitions(sessionID string) ([]ToolDefinition, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok || !sess.toolListComplete {
+		return nil, false
+	}
+	definitions := make([]ToolDefinition, 0, len(sess.advertisedTools))
+	for _, name := range sess.advertisedTools {
+		definition := sess.toolDefinitions[name]
+		definition.InputSchema = append(json.RawMessage(nil), definition.InputSchema...)
+		definitions = append(definitions, definition)
+	}
+	return definitions, true
+}
+
+// SetToolDrift attaches the current baseline comparison to a session.
+func (s *Store) SetToolDrift(sessionID string, drift ToolDrift) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[sessionID]; ok {
+		sess.toolDrift = drift
+		sess.toolDriftSet = true
+	}
+}
+
+// ToolDrift returns the current baseline comparison for a session.
+func (s *Store) ToolDrift(sessionID string) (ToolDrift, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok || !sess.toolDriftSet {
+		return ToolDrift{}, false
+	}
+	return cloneToolDrift(sess.toolDrift), true
+}
+
+func cloneToolDrift(drift ToolDrift) ToolDrift {
+	return ToolDrift{
+		AddedTools:          slices.Clone(drift.AddedTools),
+		RemovedTools:        slices.Clone(drift.RemovedTools),
+		ChangedDescriptions: slices.Clone(drift.ChangedDescriptions),
+		ChangedSchemas:      slices.Clone(drift.ChangedSchemas),
+		BaselineError:       drift.BaselineError,
+	}
 }
 
 // Timeline returns a snapshot of a session's events, oldest first. A nil slice

--- a/internal/toolbaseline/baseline.go
+++ b/internal/toolbaseline/baseline.go
@@ -1,0 +1,331 @@
+// Package toolbaseline persists and compares trust-on-first-use MCP tool definitions.
+package toolbaseline
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/sessiondiff"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+const baselineVersion = 1
+
+type Report = store.ToolDrift
+
+type Manager struct {
+	dir string
+	mu  sync.Mutex
+}
+
+type snapshot struct {
+	Version int              `json:"version"`
+	Server  string           `json:"server"`
+	Tools   []toolDefinition `json:"tools"`
+}
+
+type toolDefinition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+func New(dir string) *Manager { return &Manager{dir: dir} }
+
+func (m *Manager) Path(server string) string {
+	hash := sha256.Sum256([]byte(server))
+	return filepath.Join(m.dir, fmt.Sprintf("%x.json", hash[:16]))
+}
+
+// Observe creates a first-seen baseline or compares the current definition set
+// with the existing baseline. created reports whether this observation trusted
+// and persisted the first definition set.
+func (m *Manager) Observe(server string, current []store.ToolDefinition) (Report, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	baseline, err := m.load(server)
+	if isIncompleteBaseline(err) {
+		baseline, err = m.loadAfterConcurrentCreate(server)
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		candidate := snapshot{Version: baselineVersion, Server: server, Tools: normalize(current)}
+		if err := m.writeNew(candidate); err == nil {
+			return Report{}, true, nil
+		} else if !errors.Is(err, os.ErrExist) {
+			return Report{}, false, err
+		}
+		baseline, err = m.loadAfterConcurrentCreate(server)
+	}
+	if err != nil {
+		return Report{}, false, err
+	}
+	return compare(baseline.Tools, normalize(current)), false, nil
+}
+
+func (m *Manager) Accept(server string, current []store.ToolDefinition) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.accept(server, current)
+}
+
+func (m *Manager) accept(server string, current []store.ToolDefinition) error {
+	if strings.TrimSpace(server) == "" {
+		return errors.New("tool baseline: empty server label")
+	}
+	return m.write(snapshot{Version: baselineVersion, Server: server, Tools: normalize(current)})
+}
+
+func (m *Manager) Reset(server string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	err := os.Remove(m.Path(server))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func ObserveSession(m *Manager, st *store.Store, sessionID string) (Report, bool, error) {
+	server, definitions, err := sessionDefinitions(st, sessionID)
+	if err != nil {
+		return Report{}, false, err
+	}
+	report, created, err := m.Observe(server, definitions)
+	if err == nil {
+		st.SetToolDrift(sessionID, report)
+	}
+	return report, created, err
+}
+
+func ObserveAll(m *Manager, st *store.Store) error {
+	for _, session := range st.Sessions() {
+		if _, ok := st.ToolDefinitions(session.ID); !ok {
+			continue
+		}
+		if _, _, err := ObserveSession(m, st, session.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func AcceptSession(m *Manager, st *store.Store, sessionID string) (string, error) {
+	server, definitions, err := sessionDefinitions(st, sessionID)
+	if err != nil {
+		return "", err
+	}
+	if err := m.Accept(server, definitions); err != nil {
+		return "", err
+	}
+	st.SetToolDrift(sessionID, Report{})
+	return server, nil
+}
+
+func ResetSession(m *Manager, st *store.Store, sessionID string) (string, error) {
+	server, err := sessionLabel(st, sessionID)
+	if err != nil {
+		return "", err
+	}
+	if err := m.Reset(server); err != nil {
+		return "", err
+	}
+	st.SetToolDrift(sessionID, Report{})
+	return server, nil
+}
+
+func sessionDefinitions(st *store.Store, sessionID string) (string, []store.ToolDefinition, error) {
+	definitions, ok := st.ToolDefinitions(sessionID)
+	if !ok {
+		return "", nil, fmt.Errorf("session %q has no complete tools/list result", sessionID)
+	}
+	server, err := sessionLabel(st, sessionID)
+	if err != nil {
+		return "", nil, err
+	}
+	return server, definitions, nil
+}
+
+func sessionLabel(st *store.Store, sessionID string) (string, error) {
+	for _, session := range st.Sessions() {
+		if session.ID == sessionID {
+			server := session.Label
+			if server == "" {
+				server = session.ID
+			}
+			return server, nil
+		}
+	}
+	return "", fmt.Errorf("session %q not found", sessionID)
+}
+
+func (m *Manager) load(server string) (snapshot, error) {
+	data, err := os.ReadFile(m.Path(server))
+	if err != nil {
+		return snapshot{}, err
+	}
+	var baseline snapshot
+	if err := json.Unmarshal(data, &baseline); err != nil {
+		return snapshot{}, fmt.Errorf("tool baseline %q: %w", server, err)
+	}
+	if baseline.Version != baselineVersion || baseline.Server != server {
+		return snapshot{}, fmt.Errorf("tool baseline %q: unsupported or mismatched baseline", server)
+	}
+	baseline.Tools = normalizeStored(baseline.Tools)
+	return baseline, nil
+}
+
+func (m *Manager) loadAfterConcurrentCreate(server string) (snapshot, error) {
+	for range 100 {
+		baseline, err := m.load(server)
+		if err == nil || !isIncompleteBaseline(err) {
+			return baseline, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return m.load(server)
+}
+
+func isIncompleteBaseline(err error) bool {
+	var syntaxError *json.SyntaxError
+	return errors.As(err, &syntaxError)
+}
+
+func (m *Manager) write(baseline snapshot) error {
+	if err := os.MkdirAll(m.dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(m.dir, ".tool-baseline-*")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer os.Remove(name)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	encoder := json.NewEncoder(tmp)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(baseline); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(name, m.Path(baseline.Server))
+}
+
+func (m *Manager) writeNew(baseline snapshot) error {
+	if strings.TrimSpace(baseline.Server) == "" {
+		return errors.New("tool baseline: empty server label")
+	}
+	if err := os.MkdirAll(m.dir, 0o700); err != nil {
+		return err
+	}
+	path := m.Path(baseline.Server)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	complete := false
+	defer func() {
+		file.Close()
+		if !complete {
+			os.Remove(path)
+		}
+	}()
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(baseline); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	complete = true
+	return nil
+}
+
+func normalize(definitions []store.ToolDefinition) []toolDefinition {
+	tools := make([]toolDefinition, 0, len(definitions))
+	for _, definition := range definitions {
+		if definition.Name == "" {
+			continue
+		}
+		tools = append(tools, toolDefinition{
+			Name:        definition.Name,
+			Description: definition.Description,
+			InputSchema: json.RawMessage(canonicalJSON(definition.InputSchema)),
+		})
+	}
+	slices.SortFunc(tools, func(a, b toolDefinition) int { return strings.Compare(a.Name, b.Name) })
+	return tools
+}
+
+func normalizeStored(definitions []toolDefinition) []toolDefinition {
+	for i := range definitions {
+		definitions[i].InputSchema = json.RawMessage(canonicalJSON(definitions[i].InputSchema))
+	}
+	slices.SortFunc(definitions, func(a, b toolDefinition) int { return strings.Compare(a.Name, b.Name) })
+	return definitions
+}
+
+func compare(before, after []toolDefinition) Report {
+	changes := sessiondiff.CompareToolDefinitions(toSessionDiffTools(before), toSessionDiffTools(after))
+	return Report{
+		AddedTools:          changes.AddedTools,
+		RemovedTools:        changes.RemovedTools,
+		ChangedDescriptions: changes.ChangedDescriptions,
+		ChangedSchemas:      changes.ChangedSchemas,
+	}
+}
+
+func toSessionDiffTools(definitions []toolDefinition) []sessiondiff.ToolDefinition {
+	tools := make([]sessiondiff.ToolDefinition, 0, len(definitions))
+	for _, definition := range definitions {
+		tools = append(tools, sessiondiff.ToolDefinition{
+			Name:        definition.Name,
+			Description: definition.Description,
+			InputSchema: append(json.RawMessage(nil), definition.InputSchema...),
+		})
+	}
+	return tools
+}
+
+func canonicalJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "null"
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if decoder.Decode(&value) != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return strings.TrimSpace(string(raw))
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	return string(canonical)
+}

--- a/internal/toolbaseline/baseline_test.go
+++ b/internal/toolbaseline/baseline_test.go
@@ -1,0 +1,242 @@
+package toolbaseline
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+func TestObserveCreatesBaselineThenDetectsDefinitionDrift(t *testing.T) {
+	m := New(t.TempDir())
+	baseline := []store.ToolDefinition{
+		{Name: "search", Description: "Search docs", InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}}}`)},
+		{Name: "fetch", Description: "Fetch a page", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+
+	report, created, err := m.Observe("docs", baseline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created || !report.Empty() {
+		t.Fatalf("first observation = report %+v, created %v", report, created)
+	}
+
+	changed := []store.ToolDefinition{
+		{Name: "search", Description: "Search every private document", InputSchema: json.RawMessage(`{"properties":{"query":{"minLength":1,"type":"string"}},"type":"object"}`)},
+		{Name: "summarize", Description: "Summarize", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	report, created, err = m.Observe("docs", changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created {
+		t.Fatal("existing baseline was recreated")
+	}
+	if !equalStrings(report.AddedTools, []string{"summarize"}) ||
+		!equalStrings(report.RemovedTools, []string{"fetch"}) ||
+		!equalStrings(report.ChangedDescriptions, []string{"search"}) ||
+		!equalStrings(report.ChangedSchemas, []string{"search"}) {
+		t.Fatalf("drift report = %+v", report)
+	}
+}
+
+func TestConcurrentFirstObservationDoesNotOverwriteTrustedDefinition(t *testing.T) {
+	dir := t.TempDir()
+	managers := []*Manager{New(dir), New(dir)}
+	definitions := [][]store.ToolDefinition{
+		{{Name: "search", Description: "first", InputSchema: json.RawMessage(`{}`)}},
+		{{Name: "search", Description: "second", InputSchema: json.RawMessage(`{}`)}},
+	}
+	type result struct {
+		report  Report
+		created bool
+		err     error
+	}
+	results := make([]result, 2)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range managers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i].report, results[i].created, results[i].err = managers[i].Observe("docs", definitions[i])
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	created := 0
+	drifted := 0
+	for _, result := range results {
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if result.created {
+			created++
+		}
+		if len(result.report.ChangedDescriptions) == 1 {
+			drifted++
+		}
+	}
+	if created != 1 || drifted != 1 {
+		t.Fatalf("results = %+v, want one creator and one drift comparison", results)
+	}
+}
+
+func TestEquivalentSchemaKeyOrderDoesNotDrift(t *testing.T) {
+	m := New(t.TempDir())
+	before := []store.ToolDefinition{{Name: "search", InputSchema: json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}}}`)}}
+	after := []store.ToolDefinition{{Name: "search", InputSchema: json.RawMessage(`{"properties":{"q":{"type":"string"}},"type":"object"}`)}}
+	if _, _, err := m.Observe("docs", before); err != nil {
+		t.Fatal(err)
+	}
+	report, _, err := m.Observe("docs", after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Empty() {
+		t.Fatalf("equivalent schema drifted: %+v", report)
+	}
+}
+
+func TestObserveClassifiesDescriptionAndSchemaDriftSeparately(t *testing.T) {
+	baseline := []store.ToolDefinition{{
+		Name: "search", Description: "Search docs",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}}
+	for _, test := range []struct {
+		name    string
+		current []store.ToolDefinition
+		want    Report
+	}{
+		{
+			name: "description only",
+			current: []store.ToolDefinition{{
+				Name: "search", Description: "Search private docs",
+				InputSchema: json.RawMessage(`{"type":"object"}`),
+			}},
+			want: Report{ChangedDescriptions: []string{"search"}},
+		},
+		{
+			name: "schema only",
+			current: []store.ToolDefinition{{
+				Name: "search", Description: "Search docs",
+				InputSchema: json.RawMessage(`{"type":"object","required":["query"]}`),
+			}},
+			want: Report{ChangedSchemas: []string{"search"}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m := New(t.TempDir())
+			if _, _, err := m.Observe("docs", baseline); err != nil {
+				t.Fatal(err)
+			}
+			report, _, err := m.Observe("docs", test.current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !equalStrings(report.ChangedDescriptions, test.want.ChangedDescriptions) ||
+				!equalStrings(report.ChangedSchemas, test.want.ChangedSchemas) || report.Count() != test.want.Count() {
+				t.Fatalf("report = %+v, want %+v", report, test.want)
+			}
+		})
+	}
+}
+
+func TestAcceptAndResetBaseline(t *testing.T) {
+	dir := t.TempDir()
+	m := New(dir)
+	initial := []store.ToolDefinition{{Name: "search", Description: "old", InputSchema: json.RawMessage(`{}`)}}
+	current := []store.ToolDefinition{{Name: "search", Description: "new", InputSchema: json.RawMessage(`{}`)}}
+	if _, _, err := m.Observe("docs", initial); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Accept("docs", current); err != nil {
+		t.Fatal(err)
+	}
+	report, _, err := m.Observe("docs", current)
+	if err != nil || !report.Empty() {
+		t.Fatalf("accepted baseline = report %+v, err %v", report, err)
+	}
+	path := m.Path("docs")
+	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("baseline mode = %v, err %v", info, err)
+	}
+	if err := m.Reset("docs"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("baseline still exists: %v", err)
+	}
+}
+
+func TestResetSessionNeedsOnlyTheServerLabel(t *testing.T) {
+	m := New(t.TempDir())
+	if err := m.Accept("docs", []store.ToolDefinition{{Name: "search"}}); err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "docs"})
+
+	server, err := ResetSession(m, st, "s1")
+	if err != nil || server != "docs" {
+		t.Fatalf("ResetSession() = server %q, err %v", server, err)
+	}
+	if _, err := os.Stat(m.Path("docs")); !os.IsNotExist(err) {
+		t.Fatalf("baseline still exists: %v", err)
+	}
+}
+
+func TestObserveSessionAttachesDriftToTheStore(t *testing.T) {
+	m := New(t.TempDir())
+	trusted := storeWithDefinitions("Search docs")
+	if _, created, err := ObserveSession(m, trusted, "s1"); err != nil || !created {
+		t.Fatalf("trusted observation = created %v, err %v", created, err)
+	}
+
+	changed := storeWithDefinitions("Search private docs")
+	report, created, err := ObserveSession(m, changed, "s1")
+	if err != nil || created || len(report.ChangedDescriptions) != 1 {
+		t.Fatalf("changed observation = report %+v, created %v, err %v", report, created, err)
+	}
+	attached, ok := changed.ToolDrift("s1")
+	if !ok || !equalStrings(attached.ChangedDescriptions, []string{"search"}) {
+		t.Fatalf("attached drift = %+v, ok %v", attached, ok)
+	}
+}
+
+func storeWithDefinitions(description string) *store.Store {
+	st := store.New()
+	st.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "docs", Seq: 1, Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+	})
+	result, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result": map[string]any{"tools": []any{map[string]any{
+			"name": "search", "description": description, "inputSchema": map[string]any{"type": "object"},
+		}}},
+	})
+	st.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "docs", Seq: 2, Direction: proxy.ServerToClient, Raw: result,
+	})
+	return st
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -885,6 +885,47 @@ func TestToolSummaryListsEveryAdvertisedTool(t *testing.T) {
 	}
 }
 
+func TestDefinitionDriftIsVisibleInSessionsAndToolSummary(t *testing.T) {
+	st := store.New()
+	st.Ingest(env(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	st.Ingest(env(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search"}]}}`))
+	st.SetToolDrift("s1", store.ToolDrift{
+		ChangedDescriptions: []string{"search"},
+		AddedTools:          []string{"write"},
+	})
+
+	m := ready(t, st)
+	if out := ansi.Strip(m.View()); !strings.Contains(out, "! drift") {
+		t.Fatalf("sessions view did not surface drift\n%s", out)
+	}
+	m = typeRunes(t, m, "s")
+	out := ansi.Strip(m.overlayRaw)
+	for _, want := range []string{"tool definition drift", "description changed", "search", "added", "write"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestToolBaselineErrorsAreVisible(t *testing.T) {
+	st := store.New()
+	st.Ingest(env(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	st.Ingest(env(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`))
+	st.SetToolDrift("s1", store.ToolDrift{BaselineError: "baseline file is invalid"})
+
+	m := ready(t, st)
+	if out := ansi.Strip(m.View()); !strings.Contains(out, "! baseline") {
+		t.Fatalf("sessions view did not surface the baseline error\n%s", out)
+	}
+	m = typeRunes(t, m, "s")
+	out := ansi.Strip(m.overlayRaw)
+	for _, want := range []string{"tool baseline error", "baseline file is invalid"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing %q\n%s", want, out)
+		}
+	}
+}
+
 // summaryHasRow reports whether a stripped summary line starts with name and
 // contains cell somewhere after it.
 func summaryHasRow(styled, name, cell string) bool {

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -8,8 +8,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
+	"github.com/kerlenton/mcpsnoop/internal/toolbaseline"
 )
 
 // Run starts the hub and the live TUI. It blocks until the user quits or ctx is
@@ -18,10 +20,18 @@ import (
 // ready and keeps pending-call timers live.
 func Run(ctx context.Context, socketPath, sessionsDir string) error {
 	st := store.New()
+	baselines := toolbaseline.New(paths.ToolBaselinesDir())
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
 
 	h := hub.New(socketPath, sessionsDir, func(e proxy.Envelope) {
-		st.Ingest(e)
+		event := st.Ingest(e)
+		if event.Kind == store.EventResponse && event.Call != nil && event.Call.Method == "tools/list" {
+			if _, complete := st.ToolDefinitions(e.SessionID); complete {
+				if _, _, err := toolbaseline.ObserveSession(baselines, st, e.SessionID); err != nil {
+					st.SetToolDrift(e.SessionID, store.ToolDrift{BaselineError: err.Error()})
+				}
+			}
+		}
 		p.Send(frameMsg{})
 	})
 
@@ -39,6 +49,9 @@ func Run(ctx context.Context, socketPath, sessionsDir string) error {
 
 // RunOpen starts the TUI using a preloaded store without starting the live hub.
 func RunOpen(ctx context.Context, st *store.Store) error {
+	if err := toolbaseline.ObserveAll(toolbaseline.New(paths.ToolBaselinesDir()), st); err != nil {
+		return err
+	}
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
 
 	_, err := p.Run()
@@ -50,6 +63,9 @@ func RunOpen(ctx context.Context, st *store.Store) error {
 
 // RunOpenWithInput starts the TUI using a preloaded store and a custom input reader (e.g., controlling TTY).
 func RunOpenWithInput(ctx context.Context, st *store.Store, in io.Reader) error {
+	if err := toolbaseline.ObserveAll(toolbaseline.New(paths.ToolBaselinesDir()), st); err != nil {
+		return err
+	}
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx), tea.WithInput(in))
 	_, err := p.Run()
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -391,7 +391,16 @@ func (m Model) renderSessionsTable(w, h int) string {
 				break
 			}
 		}
-		segs := []cell{seg(cellL(s.Label, nameW), m.styles.neutral)}
+		name := s.Label
+		nameStyle := m.styles.neutral
+		if s.HasToolBaselineError {
+			name = "! baseline " + name
+			nameStyle = m.styles.respErr
+		} else if s.HasToolDrift {
+			name = "! drift " + name
+			nameStyle = m.styles.warn
+		}
+		segs := []cell{seg(cellL(name, nameW), nameStyle)}
 		if showClient {
 			client := valueOr(m.clients[s.ID], "-")
 			segs = append(segs, gap, seg(cellL(client, clientW), m.styles.dim))
@@ -1165,11 +1174,12 @@ func (m Model) capsTitle(label, version string, w int) string {
 // summary table column widths, all padded with lipgloss.Width so styled cells
 // stay aligned.
 const (
-	sumToolW  = 18
-	sumCallsW = 7
-	sumErrW   = 6
-	sumLatW   = 10
-	covLabelW = 11
+	sumToolW    = 18
+	sumCallsW   = 7
+	sumErrW     = 6
+	sumLatW     = 10
+	covLabelW   = 11
+	driftLabelW = 20
 )
 
 func (m Model) summaryContent() string {
@@ -1177,6 +1187,7 @@ func (m Model) summaryContent() string {
 	label := m.currentLabel()
 	summary, _ := m.store.ToolSummary(sid)
 	_, unused, undeclared, hasTools := m.store.ToolUsage(sid)
+	drift, hasDrift := m.store.ToolDrift(sid)
 	w, _ := m.overlayDims()
 
 	calls := 0
@@ -1191,11 +1202,19 @@ func (m Model) summaryContent() string {
 	gap := max(w-lipgloss.Width(left)-lipgloss.Width(right), 1)
 	header := left + strings.Repeat(" ", gap) + right
 
-	if len(summary.Tools) == 0 && !hasTools {
+	if len(summary.Tools) == 0 && !hasTools && !hasDrift {
 		return header + "\n\n" + m.styles.dim.Render("no tool calls observed yet for this session")
 	}
 
 	var sections []string
+	if hasDrift && drift.BaselineError != "" {
+		sections = append(sections, m.styles.respErr.Render("tool baseline error")+"\n"+m.styles.warn.Render(drift.BaselineError))
+	}
+	if hasDrift && !drift.Empty() {
+		if drift.Count() > 0 {
+			sections = append(sections, m.definitionDriftSection(drift, w))
+		}
+	}
 
 	// TABLE: every advertised tool plus any called one, so the full tool set is
 	// visible from the start and its counts fill in as calls arrive. Uncalled
@@ -1257,6 +1276,26 @@ func (m Model) summaryContent() string {
 	}
 
 	return header + "\n\n" + strings.Join(sections, "\n\n")
+}
+
+func (m Model) definitionDriftSection(drift store.ToolDrift, width int) string {
+	var lines []string
+	for _, change := range []struct {
+		label string
+		names []string
+	}{
+		{"added", drift.AddedTools},
+		{"removed", drift.RemovedTools},
+		{"description changed", drift.ChangedDescriptions},
+		{"schema changed", drift.ChangedSchemas},
+	} {
+		if len(change.names) == 0 {
+			continue
+		}
+		indent := strings.Repeat(" ", driftLabelW)
+		lines = append(lines, m.styles.dim.Render(cellL(change.label, driftLabelW))+m.styles.warn.Render(wrapWords(change.names, indent, width)))
+	}
+	return m.styles.warn.Render("tool definition drift") + "\n" + strings.Join(lines, "\n")
 }
 
 // wrapWords lays space-separated words into lines no wider than width, each


### PR DESCRIPTION
## Summary

Persist a trust-on-first-use baseline for each server label and flag later MCP tool-definition changes in the TUI and CI.

The baseline includes tool descriptions and input schemas, so changes that can alter model behavior are visible even when tool names stay the same. Added and removed tools are reported as drift as well.

## Changes

- retain complete paginated `tools/list` definitions in the store
- report description changes from the existing captured-session `diff` path
- persist versioned baselines under the existing mcpsnoop state directory
- detect description, schema, added-tool, and removed-tool drift
- show drift in the sessions table and tool summary
- add `mcpsnoop baseline` to inspect, accept, or reset trusted definitions
- add opt-in `drift` support to `mcpsnoop check --fail-on`

## Scope and risk

This is detection and reporting only. It does not block calls, change trust automatically, or touch the proxy byte path.

Baselines are keyed by the existing server label, so users with otherwise-colliding command names or target hosts should set a stable unique `--label`. The default `check` signals remain unchanged.

Concurrent first observations use exclusive creation so one process cannot overwrite another process's first trusted definition set. Invalid baseline state is surfaced as an error rather than silently ignored.

## Verification

```bash
make check
go test -race ./internal/toolbaseline -run TestConcurrentFirstObservationDoesNotOverwriteTrustedDefinition -count=100
GOOS=windows GOARCH=amd64 make build
GOOS=linux GOARCH=amd64 make build
```

Closes #94
