### PR TITLE
feat: add JUnit output to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Gate a recorded agent run on errors, stream corruption, protocol warnings,
 routing-header mismatches, or calls that never got a response.
 
 ```bash
-mcpsnoop check [--fail-on error,invalid,warn,mismatch,pending] [session-id|log.jsonl|-]
+mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending] [session-id|log.jsonl|-]
 ```
 
 The three default signals (error, invalid, warn) fail the check. Add `pending`
@@ -278,11 +278,26 @@ to gate on calls that never got a response, or `mismatch` to gate specifically o
 a routing header (Mcp-Method or Mcp-Name) disagreeing with the body. Pass a
 comma-separated subset to select only the conditions relevant to a job. Omit the
 session to check the newest capture, or use `-` to read JSONL from stdin.
+Use `--format junit` to write one JUnit `<testcase>` per signal and session;
+failures follow the same `--fail-on` selection as the text output.
 
 ```bash
 mcpsnoop check build-agent
 mcpsnoop check --fail-on error,invalid artifacts/session.jsonl
 mcpsnoop check --fail-on mismatch gateway-run.jsonl
+```
+
+```yaml
+- name: Check captured MCP session
+  run: |
+    mkdir -p test-results
+    mcpsnoop check --format junit artifacts/session.jsonl > test-results/mcpsnoop.xml
+- name: Upload mcpsnoop JUnit report
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: mcpsnoop-junit
+    path: test-results/mcpsnoop.xml
 ```
 
 ## Watching from another machine

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -22,6 +22,13 @@ const (
 
 var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending}
 
+type checkOutputFormat string
+
+const (
+	checkFormatText  checkOutputFormat = "text"
+	checkFormatJUnit checkOutputFormat = "junit"
+)
+
 type checkSummary struct {
 	sessionID  string
 	errors     int
@@ -32,7 +39,7 @@ type checkSummary struct {
 }
 
 func newCheckCmd() *cobra.Command {
-	var failOn string
+	var failOn, formatFlag string
 	cmd := &cobra.Command{
 		Use:   "check [session-id|log.jsonl|-]",
 		Short: "Fail when a captured session contains selected signals",
@@ -40,6 +47,11 @@ func newCheckCmd() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			signals, err := parseCheckSignals(failOn)
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
+				return exitCode(2)
+			}
+			format, err := parseCheckOutputFormat(formatFlag)
 			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
 				return exitCode(2)
@@ -56,23 +68,35 @@ func newCheckCmd() *cobra.Command {
 			}
 
 			anyFailed := false
-			for _, summary := range summarizeCheck(st) {
-				fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d\n",
-					summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending)
-				if failed := summary.failed(signals); len(failed) > 0 {
-					fmt.Fprintf(cmd.OutOrStdout(), "check failed: %s\n", strings.Join(failed, ","))
-					anyFailed = true
+			summaries := summarizeCheck(st)
+			if format == checkFormatJUnit {
+				if err := writeCheckJUnit(cmd.OutOrStdout(), summaries, signals); err != nil {
+					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
+					return exitCode(1)
+				}
+				anyFailed = checkFailed(summaries, signals)
+			} else {
+				for _, summary := range summaries {
+					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d\n",
+						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending)
+					if failed := summary.failed(signals); len(failed) > 0 {
+						fmt.Fprintf(cmd.OutOrStdout(), "check failed: %s\n", strings.Join(failed, ","))
+						anyFailed = true
+					}
 				}
 			}
 			if anyFailed {
 				return exitCode(1)
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "check passed")
+			if format == checkFormatText {
+				fmt.Fprintln(cmd.OutOrStdout(), "check passed")
+			}
 			return nil
 		},
 	}
 	cmd.Flags().SortFlags = false
 	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending")
+	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text or junit")
 	return cmd
 }
 
@@ -88,6 +112,17 @@ func parseCheckSignals(value string) (map[checkSignal]bool, error) {
 		}
 	}
 	return signals, nil
+}
+
+func parseCheckOutputFormat(value string) (checkOutputFormat, error) {
+	switch checkOutputFormat(strings.ToLower(strings.TrimSpace(value))) {
+	case checkFormatText:
+		return checkFormatText, nil
+	case checkFormatJUnit:
+		return checkFormatJUnit, nil
+	default:
+		return "", fmt.Errorf("--format must be text or junit, got %q", value)
+	}
 }
 
 func loadCheckSession(cmd *cobra.Command, arg string) (*store.Store, string, error) {
@@ -124,17 +159,36 @@ func summarizeCheck(st *store.Store) []checkSummary {
 	return summaries
 }
 
-func (s checkSummary) failed(selected map[checkSignal]bool) []string {
-	counts := map[checkSignal]int{
-		checkError:    s.errors,
-		checkInvalid:  s.invalid,
-		checkWarn:     s.warnings,
-		checkMismatch: s.mismatches,
-		checkPending:  s.pending,
+func checkFailed(summaries []checkSummary, selected map[checkSignal]bool) bool {
+	for _, summary := range summaries {
+		if len(summary.failed(selected)) > 0 {
+			return true
+		}
 	}
+	return false
+}
+
+func (s checkSummary) count(signal checkSignal) int {
+	switch signal {
+	case checkError:
+		return s.errors
+	case checkInvalid:
+		return s.invalid
+	case checkWarn:
+		return s.warnings
+	case checkMismatch:
+		return s.mismatches
+	case checkPending:
+		return s.pending
+	default:
+		return 0
+	}
+}
+
+func (s checkSummary) failed(selected map[checkSignal]bool) []string {
 	var failed []string
 	for _, signal := range checkSignalOrder {
-		if selected[signal] && counts[signal] > 0 {
+		if selected[signal] && s.count(signal) > 0 {
 			failed = append(failed, string(signal))
 		}
 	}

--- a/cmd/mcpsnoop/check_junit.go
+++ b/cmd/mcpsnoop/check_junit.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
 )
 
 type checkJUnitSuites struct {
@@ -40,8 +41,8 @@ type checkJUnitFailure struct {
 	Body    string `xml:",chardata"`
 }
 
-func writeCheckJUnit(w io.Writer, summaries []checkSummary, selected map[checkSignal]bool) error {
-	payload := buildCheckJUnit(summaries, selected)
+func writeCheckJUnit(w io.Writer, summaries []checkSummary, selected map[checkSignal]bool, assertionFailures [][]string) error {
+	payload := buildCheckJUnit(summaries, selected, assertionFailures)
 	if _, err := io.WriteString(w, xml.Header); err != nil {
 		return err
 	}
@@ -57,9 +58,9 @@ func writeCheckJUnit(w io.Writer, summaries []checkSummary, selected map[checkSi
 	return err
 }
 
-func buildCheckJUnit(summaries []checkSummary, selected map[checkSignal]bool) checkJUnitSuites {
+func buildCheckJUnit(summaries []checkSummary, selected map[checkSignal]bool, assertionFailures [][]string) checkJUnitSuites {
 	out := checkJUnitSuites{Name: "mcpsnoop check", Time: "0"}
-	for _, summary := range summaries {
+	for i, summary := range summaries {
 		suite := checkJUnitSuite{
 			Name:  summary.sessionID,
 			Tests: len(checkSignalOrder),
@@ -84,6 +85,23 @@ func buildCheckJUnit(summaries []checkSummary, selected map[checkSignal]bool) ch
 			}
 			suite.Cases = append(suite.Cases, testcase)
 		}
+		assertions := checkJUnitCase{
+			Classname: "mcpsnoop.check",
+			Name:      summary.sessionID + "/assertions",
+			Time:      "0",
+		}
+		if i < len(assertionFailures) && len(assertionFailures[i]) > 0 {
+			reason := strings.Join(assertionFailures[i], "; ")
+			assertions.Failure = &checkJUnitFailure{
+				Message: reason,
+				Type:    "mcpsnoop.check.assertion",
+				Body:    strings.Join(assertionFailures[i], "\n"),
+			}
+			suite.Failures++
+		}
+		suite.Cases = append(suite.Cases, assertions)
+		suite.Tests++
+
 		out.Tests += suite.Tests
 		out.Failures += suite.Failures
 		out.Suites = append(out.Suites, suite)
@@ -104,6 +122,8 @@ func checkSignalFailureReason(sessionID string, signal checkSignal, count int) s
 		singular, plural = "routing mismatch", "routing mismatches"
 	case checkPending:
 		singular, plural = "pending call", "pending calls"
+	case checkDrift:
+		singular, plural = "tool definition change", "tool definition changes"
 	default:
 		singular, plural = "signal", "signals"
 	}

--- a/cmd/mcpsnoop/check_junit.go
+++ b/cmd/mcpsnoop/check_junit.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+)
+
+type checkJUnitSuites struct {
+	XMLName  xml.Name          `xml:"testsuites"`
+	Name     string            `xml:"name,attr"`
+	Tests    int               `xml:"tests,attr"`
+	Failures int               `xml:"failures,attr"`
+	Errors   int               `xml:"errors,attr"`
+	Skipped  int               `xml:"skipped,attr"`
+	Time     string            `xml:"time,attr"`
+	Suites   []checkJUnitSuite `xml:"testsuite"`
+}
+
+type checkJUnitSuite struct {
+	Name     string           `xml:"name,attr"`
+	Tests    int              `xml:"tests,attr"`
+	Failures int              `xml:"failures,attr"`
+	Errors   int              `xml:"errors,attr"`
+	Skipped  int              `xml:"skipped,attr"`
+	Time     string           `xml:"time,attr"`
+	Cases    []checkJUnitCase `xml:"testcase"`
+}
+
+type checkJUnitCase struct {
+	Classname string             `xml:"classname,attr"`
+	Name      string             `xml:"name,attr"`
+	Time      string             `xml:"time,attr"`
+	Failure   *checkJUnitFailure `xml:"failure,omitempty"`
+}
+
+type checkJUnitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Body    string `xml:",chardata"`
+}
+
+func writeCheckJUnit(w io.Writer, summaries []checkSummary, selected map[checkSignal]bool) error {
+	payload := buildCheckJUnit(summaries, selected)
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(payload); err != nil {
+		return err
+	}
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\n")
+	return err
+}
+
+func buildCheckJUnit(summaries []checkSummary, selected map[checkSignal]bool) checkJUnitSuites {
+	out := checkJUnitSuites{Name: "mcpsnoop check", Time: "0"}
+	for _, summary := range summaries {
+		suite := checkJUnitSuite{
+			Name:  summary.sessionID,
+			Tests: len(checkSignalOrder),
+			Time:  "0",
+			Cases: make([]checkJUnitCase, 0, len(checkSignalOrder)),
+		}
+		for _, signal := range checkSignalOrder {
+			count := summary.count(signal)
+			testcase := checkJUnitCase{
+				Classname: "mcpsnoop.check",
+				Name:      fmt.Sprintf("%s/%s", summary.sessionID, signal),
+				Time:      "0",
+			}
+			if selected[signal] && count > 0 {
+				reason := checkSignalFailureReason(summary.sessionID, signal, count)
+				testcase.Failure = &checkJUnitFailure{
+					Message: reason,
+					Type:    "mcpsnoop.check." + string(signal),
+					Body:    reason,
+				}
+				suite.Failures++
+			}
+			suite.Cases = append(suite.Cases, testcase)
+		}
+		out.Tests += suite.Tests
+		out.Failures += suite.Failures
+		out.Suites = append(out.Suites, suite)
+	}
+	return out
+}
+
+func checkSignalFailureReason(sessionID string, signal checkSignal, count int) string {
+	var singular, plural string
+	switch signal {
+	case checkError:
+		singular, plural = "error", "errors"
+	case checkInvalid:
+		singular, plural = "invalid frame", "invalid frames"
+	case checkWarn:
+		singular, plural = "warning", "warnings"
+	case checkMismatch:
+		singular, plural = "routing mismatch", "routing mismatches"
+	case checkPending:
+		singular, plural = "pending call", "pending calls"
+	default:
+		singular, plural = "signal", "signals"
+	}
+	word := plural
+	if count == 1 {
+		word = singular
+	}
+	return fmt.Sprintf("session %s has %d %s", sessionID, count, word)
+}

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -76,6 +76,71 @@ func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
 	}
 }
 
+func TestCheckWritesJUnitGolden(t *testing.T) {
+	log := encodeCheckLog(t, checkSignalEnvelopes()...)
+
+	code, stdout, stderr := executeCheck(t, []string{"--format", "junit", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	const want = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="mcpsnoop check" tests="5" failures="3" errors="0" skipped="0" time="0">
+  <testsuite name="s1" tests="5" failures="3" errors="0" skipped="0" time="0">
+    <testcase classname="mcpsnoop.check" name="s1/error" time="0">
+      <failure message="session s1 has 2 errors" type="mcpsnoop.check.error">session s1 has 2 errors</failure>
+    </testcase>
+    <testcase classname="mcpsnoop.check" name="s1/invalid" time="0">
+      <failure message="session s1 has 1 invalid frame" type="mcpsnoop.check.invalid">session s1 has 1 invalid frame</failure>
+    </testcase>
+    <testcase classname="mcpsnoop.check" name="s1/warn" time="0">
+      <failure message="session s1 has 1 warning" type="mcpsnoop.check.warn">session s1 has 1 warning</failure>
+    </testcase>
+    <testcase classname="mcpsnoop.check" name="s1/mismatch" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/pending" time="0"></testcase>
+  </testsuite>
+</testsuites>
+`
+	if stdout != want {
+		t.Fatalf("stdout mismatch\nwant:\n%s\ngot:\n%s", want, stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckJUnitHonorsFailOn(t *testing.T) {
+	log := encodeCheckLog(t, checkErrorEnvelopes()...)
+
+	code, stdout, stderr := executeCheck(t, []string{"--format", "junit", "--fail-on", "invalid,warn", "-"}, log)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 because errors are not selected", code)
+	}
+	for _, want := range []string{`tests="5"`, `failures="0"`, `name="s1/error"`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "<failure") {
+		t.Fatalf("stdout should not contain failures:\n%s", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckRejectsUnknownFormat(t *testing.T) {
+	code, stdout, stderr := executeCheck(t, []string{"--format", "json", "-"}, "{}\n")
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "mcpsnoop check: --format must be text or junit") {
+		t.Fatalf("stderr = %q, want --format error", stderr)
+	}
+}
+
 func TestCheckRejectsUnknownOrEmptyFailOnValues(t *testing.T) {
 	for _, value := range []string{"error,bogus", ""} {
 		t.Run(value, func(t *testing.T) {

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -81,6 +81,9 @@ func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
 }
 
 func TestCheckWritesJUnitGolden(t *testing.T) {
+	// checkSignalEnvelopes carries a tools/list, so the run observes a baseline.
+	// Isolate it the way the drift tests do, or it writes into the real state dir.
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	log := encodeCheckLog(t, checkSignalEnvelopes()...)
 
 	code, stdout, stderr := executeCheck(t, []string{"--format", "junit", "-"}, log)
@@ -88,8 +91,8 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	const want = `<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="mcpsnoop check" tests="5" failures="3" errors="0" skipped="0" time="0">
-  <testsuite name="s1" tests="5" failures="3" errors="0" skipped="0" time="0">
+<testsuites name="mcpsnoop check" tests="7" failures="3" errors="0" skipped="0" time="0">
+  <testsuite name="s1" tests="7" failures="3" errors="0" skipped="0" time="0">
     <testcase classname="mcpsnoop.check" name="s1/error" time="0">
       <failure message="session s1 has 2 errors" type="mcpsnoop.check.error">session s1 has 2 errors</failure>
     </testcase>
@@ -101,6 +104,8 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
     </testcase>
     <testcase classname="mcpsnoop.check" name="s1/mismatch" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/pending" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/drift" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/assertions" time="0"></testcase>
   </testsuite>
 </testsuites>
 `
@@ -113,13 +118,14 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
 }
 
 func TestCheckJUnitHonorsFailOn(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	log := encodeCheckLog(t, checkErrorEnvelopes()...)
 
 	code, stdout, stderr := executeCheck(t, []string{"--format", "junit", "--fail-on", "invalid,warn", "-"}, log)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 because errors are not selected", code)
 	}
-	for _, want := range []string{`tests="5"`, `failures="0"`, `name="s1/error"`} {
+	for _, want := range []string{`tests="7"`, `failures="0"`, `name="s1/error"`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}


### PR DESCRIPTION
## Summary
- add `mcpsnoop check --format junit` with one JUnit testcase per session signal
- keep failure counts aligned with `--fail-on` so XML output and the exit code agree
- document a GitHub Actions snippet for collecting the XML report

## Validation
- `go test ./cmd/mcpsnoop`
- `go test ./internal/exporter`
- `PATH="$PATH:$(go env GOPATH)/bin" make check`

Fixes #96.

AI assistance: I used OpenAI Codex to implement and validate this change.
