### PR TITLE
feat: bound saved session backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ shim your client spawns, forwarding bytes verbatim while shipping a copy of ever
 frame to the hub. `mcpsnoop` with no arguments is that hub and its live TUI. They
 pair through a well-known socket and on-disk logs, so neither has to start first.
 
+The hub loads the newest 100 saved sessions by default, keeping startup work
+bounded without deleting older traces. Use `mcpsnoop --history-limit N` to pick
+another limit, or `mcpsnoop --history-limit 0` to load the full history. Older
+sessions remain available through `mcpsnoop open <session-id>` and
+`mcpsnoop export <session-id>`.
+
 Because it sits in the actual pipe, not off to the side like the Inspector, it
 sees exactly what your real client and server say to each other, whatever the
 server is written in.

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/hub"
 	"github.com/kerlenton/mcpsnoop/internal/otlpsink"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
@@ -241,6 +242,7 @@ func newRootCmd() *cobra.Command {
 		redactValues           redactValuesFlag
 		redactPaths            redactPathsFlag
 		otlpHeaders            otlpHeadersFlag
+		historyLimit           int
 	)
 	cmd := &cobra.Command{
 		Use:   "mcpsnoop [flags] -- <server command> [args...]",
@@ -257,7 +259,10 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return codeOf(runHubFn())
+				if historyLimit < 0 {
+					return errors.New("--history-limit must be non-negative")
+				}
+				return codeOf(runHubFn(historyLimit))
 			}
 			cfg, ok, err := loadConfig()
 			if err != nil {
@@ -283,6 +288,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
 	flags.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text, repeatable")
 	flags.Var(&redactPaths, "redact-path", "JSONPath selecting values to scrub in saved trace payloads, repeatable")
+	flags.IntVar(&historyLimit, "history-limit", hub.DefaultBackfillLimit, "maximum session logs to load in the TUI, 0 loads all")
 	// Stop parsing at the first positional so the wrapped command keeps its flags.
 	flags.SetInterspersed(false)
 
@@ -557,11 +563,11 @@ func newHTTPCmd() *cobra.Command {
 }
 
 // runHub runs the live TUI, collecting traffic from all shims and past sessions.
-func runHub() int {
+func runHub(historyLimit int) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := tui.Run(ctx, paths.SocketPath(), paths.SessionsDir()); err != nil {
+	if err := tui.RunWithHistoryLimit(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit); err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: %v\n", err)
 		return 1
 	}

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	hubpkg "github.com/kerlenton/mcpsnoop/internal/hub"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 )
@@ -90,8 +91,13 @@ func TestRootWithoutDashDashStopsAtFirstPositional(t *testing.T) {
 
 func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	hub := false
+	gotLimit := -1
 	origHub := runHubFn
-	runHubFn = func() int { hub = true; return 0 }
+	runHubFn = func(limit int) int {
+		hub = true
+		gotLimit = limit
+		return 0
+	}
 	defer func() { runHubFn = origHub }()
 
 	origShim := runShimFn
@@ -106,6 +112,26 @@ func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	}
 	if !hub {
 		t.Fatal("bare mcpsnoop did not launch the hub")
+	}
+	if gotLimit != hubpkg.DefaultBackfillLimit {
+		t.Fatalf("history limit = %d, want default %d", gotLimit, hubpkg.DefaultBackfillLimit)
+	}
+}
+
+func TestRootHistoryLimitConfiguresHub(t *testing.T) {
+	gotLimit := -1
+	origHub := runHubFn
+	runHubFn = func(limit int) int {
+		gotLimit = limit
+		return 0
+	}
+	defer func() { runHubFn = origHub }()
+
+	if code := execute([]string{"--history-limit", "7"}); code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if gotLimit != 7 {
+		t.Fatalf("history limit = %d, want 7", gotLimit)
 	}
 }
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -28,21 +28,47 @@ type Handler func(proxy.Envelope)
 
 // Hub collects envelopes from shims (socket) and past sessions (files).
 type Hub struct {
-	socketPath  string
-	sessionsDir string
-	handler     Handler
+	socketPath    string
+	sessionsDir   string
+	handler       Handler
+	backfillLimit int
+	onBackfill    func(BackfillReport)
 
 	mu   sync.Mutex
 	seen map[string]uint64 // session id -> highest seq forwarded
 }
 
+// DefaultBackfillLimit bounds startup work while keeping recent history useful.
+const DefaultBackfillLimit = 100
+
+// Options controls hub startup behavior. BackfillLimit 0 replays all history.
+type Options struct {
+	BackfillLimit int
+	OnBackfill    func(BackfillReport)
+}
+
+// BackfillReport describes how much saved history was replayed at startup.
+type BackfillReport struct {
+	Loaded int
+	Total  int
+}
+
 // New creates a hub. handler is invoked for every deduplicated envelope.
 func New(socketPath, sessionsDir string, handler Handler) *Hub {
+	return NewWithOptions(socketPath, sessionsDir, handler, Options{
+		BackfillLimit: DefaultBackfillLimit,
+	})
+}
+
+// NewWithOptions creates a hub with explicit startup behavior.
+func NewWithOptions(socketPath, sessionsDir string, handler Handler, opts Options) *Hub {
 	return &Hub{
-		socketPath:  socketPath,
-		sessionsDir: sessionsDir,
-		handler:     handler,
-		seen:        make(map[string]uint64),
+		socketPath:    socketPath,
+		sessionsDir:   sessionsDir,
+		handler:       handler,
+		backfillLimit: opts.BackfillLimit,
+		onBackfill:    opts.OnBackfill,
+		seen:          make(map[string]uint64),
 	}
 }
 
@@ -62,7 +88,10 @@ func (h *Hub) Run(ctx context.Context) error {
 	// from disk so a live shim that reconnects (e.g. after a hub restart) can't
 	// race its high-Seq frames ahead of the file's history and cause the gate to
 	// drop it. Shims keep retrying their connection until we accept.
-	h.backfill(ctx)
+	report := h.backfill(ctx)
+	if h.onBackfill != nil {
+		h.onBackfill(report)
+	}
 
 	// Stop accepting when the context is done.
 	go func() {
@@ -119,11 +148,11 @@ func (h *Hub) handleConn(conn net.Conn) {
 	}
 }
 
-// backfill replays envelopes from every session log on disk.
-func (h *Hub) backfill(ctx context.Context) {
+// backfill replays envelopes from the newest configured session logs on disk.
+func (h *Hub) backfill(ctx context.Context) BackfillReport {
 	entries, err := os.ReadDir(h.sessionsDir)
 	if err != nil {
-		return
+		return BackfillReport{}
 	}
 	// Oldest first, so historical order roughly matches real time.
 	files := make([]string, 0, len(entries))
@@ -133,12 +162,18 @@ func (h *Hub) backfill(ctx context.Context) {
 		}
 	}
 	slices.Sort(files)
+	report := BackfillReport{Total: len(files)}
+	if h.backfillLimit > 0 && len(files) > h.backfillLimit {
+		files = files[len(files)-h.backfillLimit:]
+	}
+	report.Loaded = len(files)
 	for _, f := range files {
 		if ctx.Err() != nil {
-			return
+			return report
 		}
 		h.replayFile(f)
 	}
+	return report
 }
 
 func (h *Hub) replayFile(path string) {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -18,7 +18,9 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
@@ -152,30 +154,53 @@ func (h *Hub) handleConn(conn net.Conn) {
 	}
 }
 
-// backfill replays envelopes from the newest configured session logs on disk.
+// backfill replays the most recently modified session logs on disk, oldest
+// first so historical order roughly matches real time.
 func (h *Hub) backfill(ctx context.Context) BackfillReport {
 	entries, err := os.ReadDir(h.sessionsDir)
 	if err != nil {
 		return BackfillReport{}
 	}
-	// Oldest first, so historical order roughly matches real time.
-	files := make([]string, 0, len(entries))
+
+	// Order by modification time, not by name. A log is named <label>-<pid>.jsonl,
+	// so sorting by name orders by server label first and would keep whichever
+	// labels sort last rather than whichever sessions ran last. exporter's
+	// newest-session lookup already resolves recency the same way.
+	type sessionLog struct {
+		path    string
+		modTime time.Time
+	}
+	logs := make([]sessionLog, 0, len(entries))
 	for _, e := range entries {
-		if !e.IsDir() && filepath.Ext(e.Name()) == ".jsonl" {
-			files = append(files, filepath.Join(h.sessionsDir, e.Name()))
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
 		}
+		info, err := e.Info()
+		if err != nil {
+			continue // the file went away between the listing and the stat
+		}
+		logs = append(logs, sessionLog{
+			path:    filepath.Join(h.sessionsDir, e.Name()),
+			modTime: info.ModTime(),
+		})
 	}
-	slices.Sort(files)
-	report := BackfillReport{Total: len(files)}
-	if h.backfillLimit > 0 && len(files) > h.backfillLimit {
-		files = files[len(files)-h.backfillLimit:]
+	slices.SortFunc(logs, func(a, b sessionLog) int {
+		if c := a.modTime.Compare(b.modTime); c != 0 {
+			return c
+		}
+		return strings.Compare(a.path, b.path) // deterministic for equal timestamps
+	})
+
+	report := BackfillReport{Total: len(logs)}
+	if h.backfillLimit > 0 && len(logs) > h.backfillLimit {
+		logs = logs[len(logs)-h.backfillLimit:]
 	}
-	report.Loaded = len(files)
-	for _, f := range files {
+	for _, l := range logs {
 		if ctx.Err() != nil {
-			return report
+			return report // count only what was actually replayed
 		}
-		h.replayFile(f)
+		h.replayFile(l.path)
+		report.Loaded++
 	}
 	return report
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -96,5 +97,33 @@ func TestHubBackfillLiveDedup(t *testing.T) {
 	case e := <-got:
 		t.Fatalf("unexpected extra frame: %+v", e)
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestHubBackfillLimitReplaysNewestSessions(t *testing.T) {
+	sessionsDir := t.TempDir()
+	writeLog(t, sessionsDir, "001-oldest", env("001-oldest", 1, "initialize"))
+	writeLog(t, sessionsDir, "002-middle", env("002-middle", 1, "initialize"))
+	writeLog(t, sessionsDir, "003-newest", env("003-newest", 1, "initialize"))
+
+	var got []string
+	h := NewWithOptions("", sessionsDir, func(e proxy.Envelope) {
+		got = append(got, e.SessionID)
+	}, Options{BackfillLimit: 2})
+
+	report := h.backfill(context.Background())
+
+	want := []string{"002-middle", "003-newest"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("backfilled sessions = %v, want %v", got, want)
+	}
+	if report.Loaded != 2 || report.Total != 3 {
+		t.Fatalf("backfill report = %+v, want loaded=2 total=3", report)
+	}
+	if _, ok := h.seen["001-oldest"]; ok {
+		t.Fatal("out-of-bound session should not consume a seen entry")
+	}
+	if _, err := os.Stat(filepath.Join(sessionsDir, "001-oldest.jsonl")); err != nil {
+		t.Fatalf("out-of-bound session should remain openable on disk: %v", err)
 	}
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -100,11 +100,27 @@ func TestHubBackfillLiveDedup(t *testing.T) {
 	}
 }
 
+// touchLog writes a session log and stamps it, so recency is set by the
+// modification time rather than by the file name.
+func touchLog(t *testing.T, dir, session string, modTime time.Time, envs ...proxy.Envelope) {
+	t.Helper()
+	writeLog(t, dir, session, envs...)
+	path := filepath.Join(dir, session+".jsonl")
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHubBackfillLimitReplaysNewestSessions(t *testing.T) {
 	sessionsDir := t.TempDir()
-	writeLog(t, sessionsDir, "001-oldest", env("001-oldest", 1, "initialize"))
-	writeLog(t, sessionsDir, "002-middle", env("002-middle", 1, "initialize"))
-	writeLog(t, sessionsDir, "003-newest", env("003-newest", 1, "initialize"))
+	now := time.Now()
+	// The names deliberately sort against the timestamps. A real log is named
+	// <label>-<pid>.jsonl, so a name sort orders by server label, and the newest
+	// session of an early-sorting label would otherwise be dropped in favour of a
+	// stale one whose label sorts later.
+	touchLog(t, sessionsDir, "zulu-oldest", now.Add(-3*time.Hour), env("zulu-oldest", 1, "initialize"))
+	touchLog(t, sessionsDir, "mike-middle", now.Add(-2*time.Hour), env("mike-middle", 1, "initialize"))
+	touchLog(t, sessionsDir, "alpha-newest", now.Add(-1*time.Hour), env("alpha-newest", 1, "initialize"))
 
 	var got []string
 	h := NewWithOptions("", sessionsDir, func(e proxy.Envelope) {
@@ -113,17 +129,59 @@ func TestHubBackfillLimitReplaysNewestSessions(t *testing.T) {
 
 	report := h.backfill(context.Background())
 
-	want := []string{"002-middle", "003-newest"}
+	// Oldest of the kept pair first, so replay order still tracks real time.
+	want := []string{"mike-middle", "alpha-newest"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("backfilled sessions = %v, want %v", got, want)
 	}
 	if report.Loaded != 2 || report.Total != 3 {
 		t.Fatalf("backfill report = %+v, want loaded=2 total=3", report)
 	}
-	if _, ok := h.seen["001-oldest"]; ok {
+	if _, ok := h.seen["zulu-oldest"]; ok {
 		t.Fatal("out-of-bound session should not consume a seen entry")
 	}
-	if _, err := os.Stat(filepath.Join(sessionsDir, "001-oldest.jsonl")); err != nil {
+	if _, err := os.Stat(filepath.Join(sessionsDir, "zulu-oldest.jsonl")); err != nil {
 		t.Fatalf("out-of-bound session should remain openable on disk: %v", err)
+	}
+}
+
+func TestHubBackfillLimitZeroReplaysEverything(t *testing.T) {
+	sessionsDir := t.TempDir()
+	now := time.Now()
+	touchLog(t, sessionsDir, "zulu-oldest", now.Add(-2*time.Hour), env("zulu-oldest", 1, "initialize"))
+	touchLog(t, sessionsDir, "alpha-newest", now.Add(-1*time.Hour), env("alpha-newest", 1, "initialize"))
+
+	var got []string
+	h := NewWithOptions("", sessionsDir, func(e proxy.Envelope) {
+		got = append(got, e.SessionID)
+	}, Options{BackfillLimit: 0})
+
+	report := h.backfill(context.Background())
+
+	want := []string{"zulu-oldest", "alpha-newest"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("backfilled sessions = %v, want %v", got, want)
+	}
+	if report.Loaded != 2 || report.Total != 2 {
+		t.Fatalf("backfill report = %+v, want loaded=2 total=2", report)
+	}
+}
+
+// A cancelled backfill must report what it actually replayed, not what it
+// intended to.
+func TestHubBackfillReportCountsOnlyReplayedLogs(t *testing.T) {
+	sessionsDir := t.TempDir()
+	now := time.Now()
+	touchLog(t, sessionsDir, "one", now.Add(-2*time.Hour), env("one", 1, "initialize"))
+	touchLog(t, sessionsDir, "two", now.Add(-1*time.Hour), env("two", 1, "initialize"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	h := NewWithOptions("", sessionsDir, func(proxy.Envelope) {}, Options{})
+	report := h.backfill(ctx)
+
+	if report.Loaded != 0 || report.Total != 2 {
+		t.Fatalf("backfill report = %+v, want loaded=0 total=2", report)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"cmp"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -73,6 +74,13 @@ const (
 
 // frameMsg signals that the store ingested a new envelope.
 type frameMsg struct{}
+
+// historyTruncatedMsg tells the TUI that startup intentionally loaded only the
+// newest saved sessions.
+type historyTruncatedMsg struct {
+	loaded int
+	total  int
+}
 
 // tickMsg drives the shared animation and refresh clock.
 type tickMsg time.Time
@@ -235,6 +243,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.refresh()
 			m.refreshLiveOverlay()
 		}
+		return m, nil
+
+	case historyTruncatedMsg:
+		m.setFlash(fmt.Sprintf("loaded newest %d of %d sessions; older traces stay on disk", msg.loaded, msg.total))
 		return m, nil
 
 	case replayDoneMsg:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1074,6 +1074,20 @@ func TestSummaryUpdatesLive(t *testing.T) {
 	}
 }
 
+func TestHistoryTruncatedMessageIsVisible(t *testing.T) {
+	m := ready(t, store.New())
+	m = drive(t, m, historyTruncatedMsg{loaded: 100, total: 243})
+
+	if !m.flashActive() {
+		t.Fatal("truncated history should show a visible notice")
+	}
+	for _, want := range []string{"100", "243", "older traces stay on disk"} {
+		if !strings.Contains(m.flash, want) {
+			t.Fatalf("history notice %q does not contain %q", m.flash, want)
+		}
+	}
+}
+
 func TestSummaryPendingToolShowsSpinner(t *testing.T) {
 	st := store.New()
 	// A tool call requested but never answered: pending, with no latency yet.

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -19,11 +19,17 @@ import (
 // a periodic tick in the model catches anything sent before the program loop is
 // ready and keeps pending-call timers live.
 func Run(ctx context.Context, socketPath, sessionsDir string) error {
+	return RunWithHistoryLimit(ctx, socketPath, sessionsDir, hub.DefaultBackfillLimit)
+}
+
+// RunWithHistoryLimit starts the live TUI with a bounded history replay.
+// A historyLimit of 0 loads every session log.
+func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
 	st := store.New()
 	baselines := toolbaseline.New(paths.ToolBaselinesDir())
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
 
-	h := hub.New(socketPath, sessionsDir, func(e proxy.Envelope) {
+	h := hub.NewWithOptions(socketPath, sessionsDir, func(e proxy.Envelope) {
 		event := st.Ingest(e)
 		if event.Kind == store.EventResponse && event.Call != nil && event.Call.Method == "tools/list" {
 			if _, complete := st.ToolDefinitions(e.SessionID); complete {
@@ -33,6 +39,13 @@ func Run(ctx context.Context, socketPath, sessionsDir string) error {
 			}
 		}
 		p.Send(frameMsg{})
+	}, hub.Options{
+		BackfillLimit: historyLimit,
+		OnBackfill: func(report hub.BackfillReport) {
+			if report.Loaded < report.Total {
+				p.Send(historyTruncatedMsg{loaded: report.Loaded, total: report.Total})
+			}
+		},
 	})
 
 	hubCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
## What and why

Implements the safe, non-destructive first part of #107. The live hub now replays only the newest 100 saved sessions by default, which bounds startup I/O, store growth from historical data, and the initial `seen` map population.

`--history-limit N` overrides the bound and `--history-limit 0` restores full-history loading. When history is truncated, the TUI reports how many sessions were loaded and makes clear that older traces remain on disk. Those traces still resolve directly through `mcpsnoop open <session-id>` and `mcpsnoop export <session-id>`.

This intentionally does not add automatic retention or deletion. A prune workflow is destructive and can follow separately with explicit dry-run semantics.

## Tests

- `make check` (gofmt, go vet, staticcheck, full `go test -race ./...`)
- `go build ./...`
- regression coverage for newest-N selection, backfill reporting, preservation of out-of-bound logs, CLI flag wiring, and the visible truncation notice

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change
- [x] Updated the README for user-facing behavior

Implementation and tests were prepared with AI assistance and manually validated against the repository contribution guide and full local gate.