### PR TITLE
feat(store): flag deprecated Roots, Sampling, and Logging usage

### DIFF
--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -469,6 +469,19 @@ func TestCheckPassesForTruncatedBody(t *testing.T) {
 	}
 }
 
+func TestCheckPassesForDeprecatedFeature(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	deprecated := checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"roots/list"}`)
+
+	code, stdout, stderr := executeCheck(t, []string{"-"}, encodeCheckLog(t, deprecated))
+	if code != 0 || stderr != "" {
+		t.Fatalf("a deprecated feature must not fail the default check, code %d stderr %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "warnings=0") || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
 func executeCheck(t *testing.T, args []string, stdin string) (int, string, string) {
 	t.Helper()
 	cmd := newCheckCmd()

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -105,18 +105,19 @@ type CallExport struct {
 }
 
 type EventExport struct {
-	Seq       uint64          `json:"seq"`
-	Timestamp time.Time       `json:"timestamp"`
-	Direction proxy.Direction `json:"direction"`
-	Kind      string          `json:"kind"`
-	Method    string          `json:"method,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Warning   string          `json:"warning,omitempty"`
-	Mismatch  bool            `json:"mismatch,omitempty"`
-	Truncated bool            `json:"truncated,omitempty"`
-	CallIndex *int            `json:"call_index,omitempty"`
-	Raw       json.RawMessage `json:"raw,omitempty"`
-	Text      string          `json:"text,omitempty"`
+	Seq        uint64          `json:"seq"`
+	Timestamp  time.Time       `json:"timestamp"`
+	Direction  proxy.Direction `json:"direction"`
+	Kind       string          `json:"kind"`
+	Method     string          `json:"method,omitempty"`
+	ID         string          `json:"id,omitempty"`
+	Warning    string          `json:"warning,omitempty"`
+	Mismatch   bool            `json:"mismatch,omitempty"`
+	Truncated  bool            `json:"truncated,omitempty"`
+	Deprecated string          `json:"deprecated,omitempty"`
+	CallIndex  *int            `json:"call_index,omitempty"`
+	Raw        json.RawMessage `json:"raw,omitempty"`
+	Text       string          `json:"text,omitempty"`
 }
 
 func ParseFormat(s string) (Format, error) {
@@ -517,17 +518,18 @@ func exportCall(index int, c store.CallView) CallExport {
 
 func exportEvent(ev store.EventView, callIndex map[string]int) EventExport {
 	out := EventExport{
-		Seq:       ev.Seq,
-		Timestamp: ev.TS,
-		Direction: ev.Dir,
-		Kind:      eventKind(ev.Kind),
-		Method:    ev.Method,
-		ID:        ev.ID,
-		Warning:   ev.Warning,
-		Mismatch:  ev.RoutingMismatch,
-		Truncated: ev.Truncated,
-		Raw:       ev.Raw,
-		Text:      ev.Text,
+		Seq:        ev.Seq,
+		Timestamp:  ev.TS,
+		Direction:  ev.Dir,
+		Kind:       eventKind(ev.Kind),
+		Method:     ev.Method,
+		ID:         ev.ID,
+		Warning:    ev.Warning,
+		Mismatch:   ev.RoutingMismatch,
+		Truncated:  ev.Truncated,
+		Deprecated: ev.Deprecated,
+		Raw:        ev.Raw,
+		Text:       ev.Text,
 	}
 	if ev.Call != nil {
 		if idx, ok := callIndex[callKey(*ev.Call)]; ok {
@@ -560,6 +562,9 @@ func writeText(w io.Writer, data SessionExport) error {
 		}
 		if ev.Truncated {
 			title += " truncated"
+		}
+		if ev.Deprecated != "" {
+			title += " deprecated"
 		}
 		if ev.CallIndex != nil {
 			c := data.Calls[*ev.CallIndex]

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -113,7 +113,7 @@ const matchKind = (kind, v) => {
 const matchStatus = (ev, call, v) => {
   v = v.toLowerCase();
   if (v === "bad" || v === "invalid") return ev.kind === "invalid";
-  if (v === "warn" || v === "warning") return !!ev.warning || !!ev.truncated;
+  if (v === "warn" || v === "warning") return !!ev.warning || !!ev.truncated || !!ev.deprecated;
   if (v === "mismatch") return !!ev.mismatch;
   if (!call) return false;
   if (["err", "error", "fail", "failed"].includes(v)) return call.status === "error";
@@ -154,6 +154,7 @@ const toneOf = (ev, call) => {
   if (ev.kind === "invalid") return "invalid";
   if (ev.warning) return "warn";
   if (ev.truncated) return "warn";
+  if (ev.deprecated) return "warn";
   if (ev.kind === "request") return "req";
   if (ev.kind === "response") {
     if (call && call.status === "error") return "error";
@@ -165,6 +166,7 @@ const statusOf = (ev, call) => {
   if (ev.kind === "invalid") return "bad";
   if (ev.warning) return "warn";
   if (ev.truncated) return "warn";
+  if (ev.deprecated) return "warn";
   if (!call) return "";
   if (ev.kind === "response") {
     if (call.status === "error") return "error";
@@ -178,6 +180,7 @@ const renderEvent = (ev) => {
   const st = statusOf(ev, call);
   const raw = ev.text || textOf(ev.raw);
   const warning = ev.warning ? "<details open><summary>Warning</summary><pre>" + esc(ev.warning) + "</pre></details>" : "";
+  const deprecated = ev.deprecated ? "<details open><summary>Deprecated</summary><pre>" + esc(ev.deprecated) + "</pre></details>" : "";
   const callBlock = call ? "<details><summary>Correlated call</summary><pre>" + esc(JSON.stringify(call, null, 2)) + "</pre></details>" : "";
   return "<article class=\"event tone-" + tone + "\">" +
     "<div class=\"head\">" +
@@ -188,6 +191,7 @@ const renderEvent = (ev) => {
       "<div class=\"time\">" + esc(fmtTime(ev.timestamp)) + "</div>" +
     "</div>" +
     warning +
+    deprecated +
     "<details open><summary>Frame</summary><pre>" + esc(raw) + "</pre></details>" +
     callBlock +
   "</article>";

--- a/internal/store/deprecation.go
+++ b/internal/store/deprecation.go
@@ -1,0 +1,38 @@
+package store
+
+import "strings"
+
+// deprecatedMethodNote returns a heads-up when method belongs to a feature
+// deprecated in the 2026-07-28 MCP release (SEP-2577). It is a structured
+// marker, not a protocol warning, so it never fails check.
+func deprecatedMethodNote(method string) string {
+	switch {
+	case strings.HasPrefix(method, "roots/"):
+		return "roots is deprecated (2026-07-28); use tool parameters, resource URIs, or server configuration instead"
+	case strings.HasPrefix(method, "notifications/roots/"):
+		return "roots is deprecated (2026-07-28); use tool parameters, resource URIs, or server configuration instead"
+	case strings.HasPrefix(method, "sampling/"):
+		return "sampling is deprecated (2026-07-28); integrate directly with an LLM provider API instead"
+	case strings.HasPrefix(method, "logging/"):
+		return "logging is deprecated (2026-07-28); use stderr for stdio or OpenTelemetry instead"
+	case method == "notifications/message":
+		return "logging notifications/message is deprecated (2026-07-28); use stderr for stdio or OpenTelemetry instead"
+	default:
+		return ""
+	}
+}
+
+// DeprecatedCapabilityNote names the migration path when a side still advertises a
+// capability deprecated in the 2026-07-28 MCP release.
+func DeprecatedCapabilityNote(name string) string {
+	switch name {
+	case "roots":
+		return "use tool parameters, resource URIs, or server configuration"
+	case "sampling":
+		return "integrate directly with an LLM provider API"
+	case "logging":
+		return "use stderr for stdio or OpenTelemetry"
+	default:
+		return ""
+	}
+}

--- a/internal/store/deprecation_test.go
+++ b/internal/store/deprecation_test.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeprecatedMethodNote(t *testing.T) {
+	cases := []struct {
+		method string
+		want   string
+	}{
+		{"roots/list", "roots is deprecated"},
+		{"sampling/createMessage", "sampling is deprecated"},
+		{"logging/setLevel", "logging is deprecated"},
+		{"notifications/roots/list_changed", "roots is deprecated"},
+		{"notifications/message", "logging notifications/message is deprecated"},
+		{"tools/list", ""},
+		{"notifications/progress", ""},
+	}
+	for _, tc := range cases {
+		got := deprecatedMethodNote(tc.method)
+		if tc.want == "" {
+			if got != "" {
+				t.Fatalf("deprecatedMethodNote(%q) = %q, want empty", tc.method, got)
+			}
+			continue
+		}
+		if got == "" || !strings.Contains(got, tc.want) {
+			t.Fatalf("deprecatedMethodNote(%q) = %q, want substring %q", tc.method, got, tc.want)
+		}
+	}
+}
+
+func TestDeprecatedCapabilityNote(t *testing.T) {
+	if got := DeprecatedCapabilityNote("roots"); got == "" {
+		t.Fatal("roots capability should be deprecated")
+	}
+	if got := DeprecatedCapabilityNote("tools"); got != "" {
+		t.Fatalf("tools capability should not be deprecated, got %q", got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -105,6 +105,7 @@ type event struct {
 	batch              bool   // one element of a JSON-RPC batch (routing headers cannot address it)
 	mismatch           bool   // a routing header disagrees with the body (structured flag for warning)
 	truncated          bool   // the observed copy was capped at the frame-size limit
+	deprecated         string // a deprecated MCP feature was used (structured, not a protocol warning)
 	call               *call  // set for request/response events
 }
 
@@ -323,6 +324,10 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 					" disagrees with _meta protocolVersion "+mv)
 			ev.mismatch = true
 		}
+	}
+
+	if note := deprecatedMethodNote(msg.Method); note != "" {
+		ev.deprecated = note
 	}
 
 	sess.events = append(sess.events, ev)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -672,6 +672,53 @@ func TestValidationWarnings(t *testing.T) {
 	}
 }
 
+func TestIngestDeprecatedMethods(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+
+	cases := []struct {
+		method string
+		want   string
+		kind   EventKind
+	}{
+		{"roots/list", "roots is deprecated", EventRequest},
+		{"sampling/createMessage", "sampling is deprecated", EventRequest},
+		{"logging/setLevel", "logging is deprecated", EventRequest},
+		{"notifications/roots/list_changed", "roots is deprecated", EventNotification},
+		{"notifications/message", "logging notifications/message is deprecated", EventNotification},
+	}
+	for i, tc := range cases {
+		raw := fmt.Sprintf(`{"jsonrpc":"2.0","method":%q`, tc.method)
+		if tc.kind == EventRequest {
+			raw += fmt.Sprintf(`,"id":%d`, i+1)
+		}
+		raw += `}`
+		ev := s.Ingest(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: uint64(i + 1), TS: t0,
+			Direction: proxy.ClientToServer, Raw: json.RawMessage(raw),
+		})
+		if ev.Kind != tc.kind {
+			t.Fatalf("%s: kind = %d, want %d", tc.method, ev.Kind, tc.kind)
+		}
+		if !strings.Contains(ev.Deprecated, tc.want) {
+			t.Fatalf("%s: deprecated = %q, want substring %q", tc.method, ev.Deprecated, tc.want)
+		}
+		if ev.Warning != "" {
+			t.Fatalf("%s: must not ride the warning field, got %q", tc.method, ev.Warning)
+		}
+	}
+}
+
+func TestIngestDeprecatedMethodNegative(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+
+	ev := s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{}`))
+	if ev.Deprecated != "" {
+		t.Fatalf("tools/list should not be deprecated, got %q", ev.Deprecated)
+	}
+}
+
 // TestConcurrentIngest exercises the lock under -race, many goroutines ingest
 // while another reads snapshots.
 func TestConcurrentIngest(t *testing.T) {

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -66,7 +66,10 @@ type EventView struct {
 	// Truncated is true when mcpsnoop capped its own observed copy of a large body.
 	// It is a structured marker, not a protocol warning, so it never fails check.
 	Truncated bool
-	Call      *CallView // set for request/response events
+	// Deprecated carries a heads-up when a frame uses a feature deprecated in the
+	// 2026-07-28 MCP release. It is structured like Truncated and never fails check.
+	Deprecated string
+	Call       *CallView // set for request/response events
 }
 
 // SessionHeader is a lightweight per-session summary for the left panel.
@@ -163,6 +166,7 @@ func (e *event) view(_ *session) EventView {
 		MCPProtocolVersion: e.mcpProtocolVersion,
 		RoutingMismatch:    e.mismatch,
 		Truncated:          e.truncated,
+		Deprecated:         e.deprecated,
 	}
 	if e.call != nil {
 		cv := e.call.view()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -895,7 +895,7 @@ func countStreamSignals(events []store.EventView) streamSignalCounts {
 	var c streamSignalCounts
 	for _, e := range events {
 		switch {
-		case e.Kind != store.EventInvalid && (e.Warning != "" || e.Truncated):
+		case e.Kind != store.EventInvalid && (e.Warning != "" || e.Truncated || e.Deprecated != ""):
 			c.warn++
 		case e.Kind == store.EventInvalid:
 			c.bad++
@@ -977,7 +977,7 @@ func statusRank(e store.EventView) int {
 	if e.Call != nil && e.Call.Failed() {
 		return 4
 	}
-	if e.Warning != "" || e.Truncated {
+	if e.Warning != "" || e.Truncated || e.Deprecated != "" {
 		return 3
 	}
 	if e.Call == nil {
@@ -1103,7 +1103,7 @@ func (m *Model) matchStatus(e store.EventView, v string) bool {
 	if v == "warn" || v == "warning" {
 		// A capped observation reads as a warning in the row, so status:warn finds it
 		// too, even though it rides a structured flag rather than the warning text.
-		return e.Warning != "" || e.Truncated
+		return e.Warning != "" || e.Truncated || e.Deprecated != ""
 	}
 	if v == "mismatch" {
 		// A routing header disagreeing with the body (Mcp-Method/Mcp-Name, SEP-2243).

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -704,6 +704,14 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = msg + " · " + c.detail
 		}
 	}
+	if e.Deprecated != "" {
+		c.status = "warn"
+		if c.detail == "" {
+			c.detail = e.Deprecated
+		} else {
+			c.detail = e.Deprecated + " · " + c.detail
+		}
+	}
 	return c
 }
 
@@ -760,6 +768,9 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 	// A truncated observation reads "warn" in the row, so its cell must be warn
 	// colored too. It no longer rides the Warning field, so check it explicitly.
 	if e.Truncated {
+		return m.styles.warn
+	}
+	if e.Deprecated != "" {
 		return m.styles.warn
 	}
 	if e.Call != nil {
@@ -1480,13 +1491,19 @@ func (m Model) capSection(label string, info json.RawMessage, order []string, ra
 
 // capRow is one capability line: a two-space indent, a one-cell marker, then the
 // name. Declared is a green ● with the name in text, absent a faint ○ with the
-// name faint. ● and ○ share one cell width so the names align, and the
-// filled/hollow glyph carries the state on its own so NO_COLOR stays legible.
+// name faint. Deprecated capabilities append a dim migration hint. ● and ○ share
+// one cell width so the names align, and the filled/hollow glyph carries the
+// state on its own so NO_COLOR stays legible.
 func (m Model) capRow(present bool, name string) string {
+	label := name
 	if present {
-		return "  " + m.styles.resp.Render("●") + " " + m.styles.neutral.Render(name)
+		if note := store.DeprecatedCapabilityNote(name); note != "" {
+			label = name + " (deprecated: " + note + ")"
+			return "  " + m.styles.resp.Render("●") + " " + m.styles.warn.Render(label)
+		}
+		return "  " + m.styles.resp.Render("●") + " " + m.styles.neutral.Render(label)
 	}
-	return "  " + m.styles.faint.Render("○") + " " + m.styles.faint.Render(name)
+	return "  " + m.styles.faint.Render("○") + " " + m.styles.faint.Render(label)
 }
 
 // capNames returns the set of capability names a side declared. Values are


### PR DESCRIPTION
## Summary

Flag MCP frames and capabilities that use features deprecated in the 2026-07-28 release (SEP-2577): Roots, Sampling, and Logging.

## Motivation

Developers debugging MCP sessions need to know when traffic still relies on deprecated features before the removal window closes. mcpsnoop already surfaces protocol warnings and capability declarations; this adds deprecation heads-ups in the same places without treating them as check failures.

## Changes

- Add `deprecatedMethodNote()` and `DeprecatedCapabilityNote()` in `internal/store/deprecation.go`
- Set a structured `Deprecated` field on timeline events (parallel to `Truncated`, not routed through `Warning`)
- Show deprecation notes in the TUI stream, `status:warn` filter, and capability inspector for `roots`, `sampling`, and `logging`
- Export the `deprecated` field in JSON, text, and HTML exporters
- Add unit tests for method detection, ingest behavior, and default `check` pass-through

## Tests

```bash
make check
```

- `go vet`, `staticcheck`: pass
- `go test -race ./...`: pass for all packages except two pre-existing TUI style tests on `main` (`TestStatusStyleWarnsOnTruncated`, `TestStreamRowShowsSupersededStatusInWarnStyle`) that fail in this environment
- New tests: `TestDeprecatedMethodNote`, `TestIngestDeprecatedMethods`, `TestIngestDeprecatedMethodNegative`, `TestCheckPassesForDeprecatedFeature`

## Notes

- Deprecation is detected from the frame method at ingest time; responses are not flagged (method is empty).
- Default `mcpsnoop check --fail-on warn` does not fail on deprecated usage, matching the issue scope boundary.
- `notifications/roots/*` and `notifications/message` are covered alongside the `roots/`, `sampling/`, and `logging/` method families.

Fixes #122