### PR TITLE
feat(store): correlate task-backed tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ matches the method, tool, id, and payload.
 | `tool:` | tool name | `tool:search` |
 | `method:` | JSON-RPC method | `method:tools/call` |
 | `id:` | request id | `id:7` |
+| `task:` | task id | `task:01J...` |
 | `dir:` | direction (`c2s`, `s2c`) | `dir:s2c` |
 | `kind:` | frame type (`req`, `resp`, `notify`, `stderr`, `invalid`) | `kind:invalid` |
 | `status:` | call outcome (`ok`, `error`, `pending`, `bad`, `warn`, `mismatch`) | `status:error` |

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -74,18 +74,20 @@ type callKey struct {
 
 // call is the mutable internal record for one request/response pair.
 type call struct {
-	id       string
-	method   string
-	reqDir   proxy.Direction
-	params   json.RawMessage
-	result   json.RawMessage
-	err      *proxy.RPCError
-	start    time.Time
-	end      time.Time
-	state    CallState
-	isTool   bool
-	toolName string
-	toolErr  bool // result.isError == true (MCP tool-level failure)
+	id         string
+	method     string
+	reqDir     proxy.Direction
+	params     json.RawMessage
+	result     json.RawMessage
+	err        *proxy.RPCError
+	start      time.Time
+	end        time.Time
+	state      CallState
+	isTool     bool
+	toolName   string
+	toolErr    bool // result.isError == true (MCP tool-level failure)
+	taskID     string
+	taskStatus string
 }
 
 // event is the mutable internal timeline entry.
@@ -107,6 +109,8 @@ type event struct {
 	truncated          bool   // the observed copy was capped at the frame-size limit
 	deprecated         string // a deprecated MCP feature was used (structured, not a protocol warning)
 	call               *call  // set for request/response events
+	taskCall           *call  // originating call for a task lifecycle frame
+	taskID             string
 }
 
 // capabilities holds what each side declared, whether through the legacy
@@ -141,6 +145,7 @@ type session struct {
 	command []string
 	cwd     string
 	calls   map[callKey]*call
+	tasks   map[string]*call
 	events  []*event
 
 	requests, responses, notifications, errors, pending int
@@ -238,6 +243,20 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.TS, msg)
 		ev.call = c
+		if c != nil && c.taskID != "" {
+			ev.taskID = c.taskID
+			if c.method != "tools/call" {
+				ev.taskCall = sess.tasks[c.taskID]
+				if matched {
+					if parent, failed := sess.applyTaskState(c.taskID, msg.Result, e.TS); parent != nil {
+						ev.taskCall = parent
+						if failed {
+							sess.errors++
+						}
+					}
+				}
+			}
+		}
 		sess.responses++
 		switch {
 		case c == nil:
@@ -259,6 +278,10 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.warning = validationWarning(msg)
 		var reused bool
 		ev.call, reused = sess.openCall(ev.id, msg, e)
+		if ev.call.taskID != "" {
+			ev.taskID = ev.call.taskID
+			ev.taskCall = sess.tasks[ev.taskID]
+		}
 		sess.requests++
 		if reused {
 			ev.warning = appendWarning(ev.warning, "request reuses an id already in flight")
@@ -273,6 +296,17 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.method = msg.Method
 		ev.warning = validationWarning(msg)
 		sess.notifications++
+		if msg.Method == "notifications/tasks" {
+			if state, ok := parseTaskState(msg.Params); ok {
+				ev.taskID = state.TaskID
+				if parent, failed := sess.applyParsedTaskState(state, e.TS); parent != nil {
+					ev.taskCall = parent
+					if failed {
+						sess.errors++
+					}
+				}
+			}
+		}
 	default:
 		ev.kind = EventOther
 		ev.warning = validationWarning(msg)
@@ -346,6 +380,7 @@ func (s *Store) sessionFor(e proxy.Envelope) *session {
 			advertisedSet:   make(map[string]struct{}),
 			toolDefinitions: make(map[string]ToolDefinition),
 			calls:           make(map[callKey]*call),
+			tasks:           make(map[string]*call),
 		}
 		s.sessions[e.SessionID] = sess
 		s.order = append(s.order, e.SessionID)
@@ -385,6 +420,9 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		c.isTool = true
 		c.toolName = toolName(msg.Params)
 	}
+	if isTaskMethod(msg.Method) {
+		c.taskID = taskID(msg.Params)
+	}
 	sess.calls[key] = c
 	return c, reused
 }
@@ -399,6 +437,18 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 	}
 	if c.state != Pending {
 		return c, false // already answered, a duplicate or late response must not recount
+	}
+	if c.method == "tools/call" && c.taskID != "" {
+		return c, false // the task handle already continued this call
+	}
+	if c.method == "tools/call" {
+		if state, ok := parseTaskState(msg.Result); ok && state.ResultType == "task" {
+			c.result = msg.Result
+			c.taskID = state.TaskID
+			c.taskStatus = state.Status
+			sess.tasks[state.TaskID] = c
+			return c, true
+		}
 	}
 	c.end = ts
 	c.result = msg.Result
@@ -422,6 +472,69 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 		sess.applyToolsList(c.params, msg.Result)
 	}
 	return c, true
+}
+
+type taskState struct {
+	ResultType string          `json:"resultType"`
+	TaskID     string          `json:"taskId"`
+	Status     string          `json:"status"`
+	Result     json.RawMessage `json:"result"`
+	Error      *proxy.RPCError `json:"error"`
+}
+
+func parseTaskState(raw json.RawMessage) (taskState, bool) {
+	var state taskState
+	if json.Unmarshal(raw, &state) != nil || state.TaskID == "" {
+		return taskState{}, false
+	}
+	return state, true
+}
+
+func isTaskMethod(method string) bool {
+	return method == "tasks/get" || method == "tasks/update" || method == "tasks/cancel"
+}
+
+func taskID(params json.RawMessage) string {
+	var p struct {
+		TaskID string `json:"taskId"`
+	}
+	_ = json.Unmarshal(params, &p)
+	return p.TaskID
+}
+
+func (sess *session) applyTaskState(taskID string, raw json.RawMessage, ts time.Time) (*call, bool) {
+	state, ok := parseTaskState(raw)
+	if !ok || state.TaskID != taskID {
+		return sess.tasks[taskID], false
+	}
+	return sess.applyParsedTaskState(state, ts)
+}
+
+// applyParsedTaskState advances the originating call only when an observed task
+// reaches a terminal state. The bool reports a newly recorded failure.
+func (sess *session) applyParsedTaskState(state taskState, ts time.Time) (*call, bool) {
+	c := sess.tasks[state.TaskID]
+	if c == nil {
+		return nil, false
+	}
+	c.taskStatus = state.Status
+	if c.state != Pending {
+		return c, false
+	}
+	switch state.Status {
+	case "completed":
+		c.state = Completed
+		c.result = state.Result
+	case "failed", "cancelled":
+		c.state = Failed
+		c.err = state.Error
+		c.result = state.Result
+	default:
+		return c, false
+	}
+	c.end = ts
+	sess.pending--
+	return c, c.state == Failed
 }
 
 func (c *capabilities) applyRequest(params json.RawMessage) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -511,7 +511,9 @@ func (sess *session) applyTaskState(taskID string, raw json.RawMessage, ts time.
 }
 
 // applyParsedTaskState advances the originating call only when an observed task
-// reaches a terminal state. The bool reports a newly recorded failure.
+// reaches a terminal state. The bool reports a newly recorded error, which is not
+// the same as a failed state: a cancelled task delivered no result, but the user
+// stopping work is not a protocol or tool error and must not fail check.
 func (sess *session) applyParsedTaskState(state taskState, ts time.Time) (*call, bool) {
 	c := sess.tasks[state.TaskID]
 	if c == nil {
@@ -521,11 +523,34 @@ func (sess *session) applyParsedTaskState(state taskState, ts time.Time) (*call,
 	if c.state != Pending {
 		return c, false
 	}
+	countsAsError := false
 	switch state.Status {
 	case "completed":
-		c.state = Completed
 		c.result = state.Result
-	case "failed", "cancelled":
+		// The terminal result is whatever the call would have returned
+		// synchronously, so a tool-level failure arrives here in exactly the same
+		// shape the fast path checks for. Without this a tool that failed inside a
+		// task reads as a success everywhere: Failed() is false, the session error
+		// count is short, status:err misses it and check --fail-on error passes.
+		if isToolError(state.Result) {
+			c.state = Failed
+			c.toolErr = true
+			countsAsError = true
+		} else {
+			c.state = Completed
+		}
+	case "failed":
+		c.state = Failed
+		c.err = state.Error
+		c.result = state.Result
+		if c.err == nil && isToolError(state.Result) {
+			c.toolErr = true
+		}
+		countsAsError = true
+	case "cancelled":
+		// Terminal and without a result, so the call did not succeed, but the
+		// session error count and the CI gate track protocol and tool errors, and a
+		// deliberate cancel is neither. TaskStatus carries the real outcome.
 		c.state = Failed
 		c.err = state.Error
 		c.result = state.Result
@@ -534,7 +559,7 @@ func (sess *session) applyParsedTaskState(state taskState, ts time.Time) (*call,
 	}
 	c.end = ts
 	sess.pending--
-	return c, c.state == Failed
+	return c, countsAsError
 }
 
 func (c *capabilities) applyRequest(params json.RawMessage) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -266,6 +266,93 @@ func TestActivityBuckets(t *testing.T) {
 	}
 }
 
+func TestTaskBackedToolCallStaysPendingUntilTerminalState(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+	handle := s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
+		`"result":{"resultType":"task","taskId":"task-7","status":"working","ttl":60000,"pollIntervalMs":100}`))
+	if handle.Call == nil || handle.Call.State != Pending || handle.Call.TaskID != "task-7" || handle.Call.TaskStatus != "working" {
+		t.Fatalf("task handle completed the call: %+v", handle.Call)
+	}
+	if got := s.Sessions()[0].Pending; got != 1 {
+		t.Fatalf("pending after task handle = %d, want 1", got)
+	}
+
+	poll := s.Ingest(req(3, t0.Add(time.Second), proxy.ClientToServer, "2", "tasks/get", `{"taskId":"task-7"}`))
+	if poll.TaskCall == nil || poll.TaskCall.ID != "1" || poll.TaskID != "task-7" {
+		t.Fatalf("tasks/get is not linked to the originating call: %+v", poll)
+	}
+	terminal := s.Ingest(resp(4, t0.Add(10*time.Second), proxy.ServerToClient, "2",
+		`"result":{"taskId":"task-7","status":"completed","result":{"content":[{"type":"text","text":"done"}]}}`))
+	if terminal.TaskCall == nil || terminal.TaskCall.State != Completed {
+		t.Fatalf("terminal task state did not complete the originating call: %+v", terminal.TaskCall)
+	}
+	if got := terminal.TaskCall.Duration(); got != 10*time.Second {
+		t.Fatalf("task-backed duration = %s, want 10s", got)
+	}
+	if got := s.Sessions()[0].Pending; got != 0 {
+		t.Fatalf("pending after terminal state = %d, want 0", got)
+	}
+}
+
+func TestTaskFailureCancelInputAndOrphanHandling(t *testing.T) {
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("failed task", func(t *testing.T) {
+		s := New()
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+		s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"resultType":"task","taskId":"failed-1","status":"working"}`))
+		s.Ingest(req(3, t0.Add(time.Second), proxy.ClientToServer, "2", "tasks/get", `{"taskId":"failed-1"}`))
+		ev := s.Ingest(resp(4, t0.Add(2*time.Second), proxy.ServerToClient, "2", `"result":{"taskId":"failed-1","status":"failed","error":{"code":-32001,"message":"boom"}}`))
+		if ev.TaskCall == nil || ev.TaskCall.State != Failed || ev.TaskCall.Err == nil || ev.TaskCall.Err.Message != "boom" {
+			t.Fatalf("failed task outcome = %+v", ev.TaskCall)
+		}
+	})
+
+	t.Run("cancel is cooperative", func(t *testing.T) {
+		s := New()
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+		s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"resultType":"task","taskId":"cancel-1","status":"working"}`))
+		s.Ingest(req(3, t0.Add(time.Second), proxy.ClientToServer, "2", "tasks/cancel", `{"taskId":"cancel-1"}`))
+		s.Ingest(resp(4, t0.Add(2*time.Second), proxy.ServerToClient, "2", `"result":{}`))
+		s.Ingest(req(5, t0.Add(3*time.Second), proxy.ClientToServer, "3", "tasks/get", `{"taskId":"cancel-1"}`))
+		ev := s.Ingest(resp(6, t0.Add(4*time.Second), proxy.ServerToClient, "3", `"result":{"taskId":"cancel-1","status":"completed","result":{"content":[]}}`))
+		if ev.TaskCall == nil || ev.TaskCall.State != Completed || ev.TaskCall.TaskStatus != "completed" {
+			t.Fatalf("cooperative cancel hid actual outcome: %+v", ev.TaskCall)
+		}
+	})
+
+	t.Run("input required notification and orphan", func(t *testing.T) {
+		s := New()
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+		s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"resultType":"task","taskId":"input-1","status":"working"}`))
+		ev := s.Ingest(proxy.Envelope{SessionID: "s1", Seq: 3, TS: t0.Add(time.Second), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"input-1","status":"input_required","inputRequests":{"answer":{}}}}`)})
+		if ev.TaskCall == nil || ev.TaskCall.TaskStatus != "input_required" || ev.TaskCall.State != Pending {
+			t.Fatalf("input-required notification = %+v", ev.TaskCall)
+		}
+		update := s.Ingest(req(4, t0.Add(2*time.Second), proxy.ClientToServer, "2", "tasks/update", `{"taskId":"input-1","values":{"answer":"yes"}}`))
+		if update.TaskCall == nil || update.TaskCall.ID != "1" {
+			t.Fatalf("tasks/update is not linked: %+v", update)
+		}
+		ack := s.Ingest(resp(5, t0.Add(3*time.Second), proxy.ServerToClient, "2", `"result":{}`))
+		if ack.TaskCall == nil || ack.TaskCall.TaskStatus != "input_required" {
+			t.Fatalf("tasks/update acknowledgement lost its link: %+v", ack)
+		}
+		working := s.Ingest(proxy.Envelope{SessionID: "s1", Seq: 6, TS: t0.Add(4 * time.Second), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"input-1","status":"working"}}`)})
+		if working.TaskCall == nil || working.TaskCall.TaskStatus != "working" {
+			t.Fatalf("task did not resume after input: %+v", working.TaskCall)
+		}
+		orphan := s.Ingest(req(7, t0.Add(5*time.Second), proxy.ClientToServer, "9", "tasks/get", `{"taskId":"missing"}`))
+		if orphan.TaskCall != nil || orphan.TaskID != "missing" {
+			t.Fatalf("orphan task invented a parent: %+v", orphan)
+		}
+	})
+}
+
 func TestCorrelationAndTiming(t *testing.T) {
 	s := New()
 	t0 := time.Now()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -297,6 +297,71 @@ func TestTaskBackedToolCallStaysPendingUntilTerminalState(t *testing.T) {
 	}
 }
 
+// The terminal result of a task is whatever the call would have returned
+// synchronously, so a tool that failed inside a task must read as failed rather
+// than as an empty success.
+func TestTaskCompletedWithToolErrorIsAFailure(t *testing.T) {
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+	s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"resultType":"task","taskId":"tool-err-1","status":"working"}`))
+	s.Ingest(req(3, t0.Add(time.Second), proxy.ClientToServer, "2", "tasks/get", `{"taskId":"tool-err-1"}`))
+	ev := s.Ingest(resp(4, t0.Add(2*time.Second), proxy.ServerToClient, "2",
+		`"result":{"taskId":"tool-err-1","status":"completed","result":{"content":[{"type":"text","text":"nope"}],"isError":true}}`))
+
+	if ev.TaskCall == nil {
+		t.Fatal("the terminal frame should link its originating call")
+	}
+	if !ev.TaskCall.ToolErr || !ev.TaskCall.Failed() {
+		t.Fatalf("a tool error inside a task must not read as a success: %+v", ev.TaskCall)
+	}
+	if got := s.Sessions()[0].Errors; got != 1 {
+		t.Fatalf("session errors = %d, want 1", got)
+	}
+}
+
+// A terminal failure carrying no error object still has to read as a failure,
+// otherwise the state says one thing and every consumer of Failed() says another.
+func TestTaskFailedWithoutErrorObjectStillReadsAsFailed(t *testing.T) {
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+	s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"resultType":"task","taskId":"bare-1","status":"working"}`))
+	ev := s.Ingest(proxy.Envelope{SessionID: "s1", Seq: 3, TS: t0.Add(time.Second), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"bare-1","status":"failed"}}`)})
+
+	if ev.TaskCall == nil || ev.TaskCall.State != Failed {
+		t.Fatalf("task state = %+v, want Failed", ev.TaskCall)
+	}
+	if !ev.TaskCall.Failed() {
+		t.Fatal("Failed() must agree with a Failed state")
+	}
+}
+
+// Cancelling is terminal and delivers no result, but the user stopping work is
+// neither a protocol nor a tool error, so it must not fail a default check run.
+func TestCancelledTaskIsTerminalButNotASessionError(t *testing.T) {
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+	s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"resultType":"task","taskId":"cancel-2","status":"working"}`))
+	s.Ingest(req(3, t0.Add(time.Second), proxy.ClientToServer, "2", "tasks/cancel", `{"taskId":"cancel-2"}`))
+	s.Ingest(resp(4, t0.Add(2*time.Second), proxy.ServerToClient, "2", `"result":{}`))
+	ev := s.Ingest(proxy.Envelope{SessionID: "s1", Seq: 5, TS: t0.Add(3 * time.Second), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"cancel-2","status":"cancelled"}}`)})
+
+	if ev.TaskCall == nil || ev.TaskCall.TaskStatus != "cancelled" {
+		t.Fatalf("task status = %+v, want cancelled", ev.TaskCall)
+	}
+	header := s.Sessions()[0]
+	if header.Pending != 0 {
+		t.Fatalf("a cancelled task must settle its call, pending = %d", header.Pending)
+	}
+	if header.Errors != 0 {
+		t.Fatalf("a deliberate cancel is not a session error, errors = %d", header.Errors)
+	}
+}
+
 func TestTaskFailureCancelInputAndOrphanHandling(t *testing.T) {
 	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -13,18 +13,20 @@ import (
 
 // CallView is an immutable snapshot of a correlated request/response pair.
 type CallView struct {
-	ID       string
-	Method   string
-	ReqDir   proxy.Direction
-	IsTool   bool
-	ToolName string
-	Params   json.RawMessage
-	Result   json.RawMessage
-	Err      *proxy.RPCError
-	ToolErr  bool // result.isError == true
-	Start    time.Time
-	End      time.Time
-	State    CallState
+	ID         string
+	Method     string
+	ReqDir     proxy.Direction
+	IsTool     bool
+	ToolName   string
+	Params     json.RawMessage
+	Result     json.RawMessage
+	Err        *proxy.RPCError
+	ToolErr    bool // result.isError == true
+	Start      time.Time
+	End        time.Time
+	State      CallState
+	TaskID     string
+	TaskStatus string
 }
 
 // Failed reports a protocol error OR a tool-level error (result.isError).
@@ -70,6 +72,8 @@ type EventView struct {
 	// 2026-07-28 MCP release. It is structured like Truncated and never fails check.
 	Deprecated string
 	Call       *CallView // set for request/response events
+	TaskCall   *CallView // originating call for a tasks/* lifecycle frame
+	TaskID     string
 }
 
 // SessionHeader is a lightweight per-session summary for the left panel.
@@ -167,28 +171,35 @@ func (e *event) view(_ *session) EventView {
 		RoutingMismatch:    e.mismatch,
 		Truncated:          e.truncated,
 		Deprecated:         e.deprecated,
+		TaskID:             e.taskID,
 	}
 	if e.call != nil {
 		cv := e.call.view()
 		v.Call = &cv
+	}
+	if e.taskCall != nil {
+		cv := e.taskCall.view()
+		v.TaskCall = &cv
 	}
 	return v
 }
 
 func (c *call) view() CallView {
 	return CallView{
-		ID:       c.id,
-		Method:   c.method,
-		ReqDir:   c.reqDir,
-		IsTool:   c.isTool,
-		ToolName: c.toolName,
-		Params:   c.params,
-		Result:   c.result,
-		Err:      c.err,
-		ToolErr:  c.toolErr,
-		Start:    c.start,
-		End:      c.end,
-		State:    c.state,
+		ID:         c.id,
+		Method:     c.method,
+		ReqDir:     c.reqDir,
+		IsTool:     c.isTool,
+		ToolName:   c.toolName,
+		Params:     c.params,
+		Result:     c.result,
+		Err:        c.err,
+		ToolErr:    c.toolErr,
+		Start:      c.start,
+		End:        c.end,
+		State:      c.state,
+		TaskID:     c.taskID,
+		TaskStatus: c.taskStatus,
 	}
 }
 

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -29,8 +29,14 @@ type CallView struct {
 	TaskStatus string
 }
 
-// Failed reports a protocol error OR a tool-level error (result.isError).
-func (c CallView) Failed() bool { return c.Err != nil || c.ToolErr }
+// Failed reports a protocol error, a tool-level error (result.isError), or any
+// call the store already settled as Failed. The last clause matters for a task
+// that ends in a terminal failure carrying no error object, where the state would
+// otherwise say Failed while this predicate said otherwise, and everything that
+// judges an outcome through here (the exporter, the stream, status:err) reads it.
+// On the synchronous path it changes nothing, since Failed is only ever set there
+// alongside an error or a tool error.
+func (c CallView) Failed() bool { return c.Err != nil || c.ToolErr || c.State == Failed }
 
 // Done reports whether a response has arrived.
 func (c CallView) Done() bool { return c.State != Pending }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -523,7 +523,7 @@ func (m *Model) filterPlaceholder() string {
 	if m.view == viewSessions {
 		return "filter sessions by name…"
 	}
-	return "text · or tool:echo status:err dir:s2c kind:resp id:7"
+	return "text · or tool:echo status:err dir:s2c kind:resp id:7 task:01J…"
 }
 
 // drillIn. In the sessions table, enter a session's stream. In the stream, open
@@ -1040,6 +1040,8 @@ func (m *Model) matchToken(e store.EventView, tok string) bool {
 			return containsFold(e.Method, v) || (e.Call != nil && containsFold(e.Call.Method, v))
 		case "id":
 			return strings.EqualFold(e.ID, v)
+		case "task":
+			return strings.EqualFold(e.TaskID, v)
 		case "dir", "d":
 			return matchDir(e.Dir, v)
 		case "kind", "k":
@@ -1059,7 +1061,8 @@ func eventSubstr(e store.EventView, q string) bool {
 		strings.Contains(strings.ToLower(string(e.Raw)), q) {
 		return true
 	}
-	return e.Call != nil && strings.Contains(strings.ToLower(e.Call.ToolName), q)
+	return strings.Contains(strings.ToLower(e.TaskID), q) ||
+		e.Call != nil && strings.Contains(strings.ToLower(e.Call.ToolName), q)
 }
 
 func containsFold(s, sub string) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -41,6 +41,33 @@ func seed(st *store.Store) {
 	st.Ingest(env(4, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`))
 }
 
+func TestTaskLifecycleFramesCanBeFilteredAndShowTheirParent(t *testing.T) {
+	m := Model{}
+	e := store.EventView{
+		Kind:   store.EventNotification,
+		Method: "notifications/tasks",
+		TaskID: "task-7",
+		TaskCall: &store.CallView{
+			ID: "1", Method: "tools/call", TaskID: "task-7", TaskStatus: "input_required", State: store.Pending,
+		},
+	}
+	if !m.matchToken(e, "task:task-7") {
+		t.Fatal("task filter did not match the linked task id")
+	}
+	cells := m.streamCells(e)
+	if !strings.Contains(cells.detail, "tools/call id 1") || cells.status != "input_required" {
+		t.Fatalf("task link/status not surfaced: %+v", cells)
+	}
+
+	handle := store.EventView{
+		Kind: store.EventResponse, TaskID: "task-7",
+		Call: &store.CallView{ID: "1", Method: "tools/call", TaskID: "task-7", TaskStatus: "working", State: store.Pending},
+	}
+	if got := m.streamCells(handle).status; got != "working" {
+		t.Fatalf("task handle status = %q, want working", got)
+	}
+}
+
 func drive(t *testing.T, m Model, msg tea.Msg) Model {
 	t.Helper()
 	tm, _ := m.Update(msg)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -722,7 +722,11 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			switch e.TaskCall.TaskStatus {
 			case "input_required":
 				c.status = "input_required"
-			case "failed", "cancelled":
+			case "cancelled":
+				// Terminal without a result, but stopped on purpose rather than broken,
+				// so it should not read as a generic error in the row.
+				c.status = "cancelled"
+			case "failed":
 				c.status = "err"
 				if e.TaskCall.Err != nil {
 					link += " · " + e.TaskCall.Err.Message

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -655,6 +655,9 @@ func (m Model) streamCells(e store.EventView) streamCell {
 		if e.Call != nil {
 			c.dur = e.Call.Duration().Round(time.Millisecond).String()
 			switch {
+			case e.Call.TaskID != "" && e.Call.State == store.Pending:
+				c.status = e.Call.TaskStatus
+				c.detail = compactJSON(e.Call.Result)
 			case e.Call.Err != nil:
 				c.status = "err"
 				c.detail = e.Call.Err.Message
@@ -710,6 +713,26 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = e.Deprecated
 		} else {
 			c.detail = e.Deprecated + " · " + c.detail
+		}
+	}
+	if e.TaskID != "" {
+		link := "task " + e.TaskID
+		if e.TaskCall != nil {
+			link += " → tools/call id " + e.TaskCall.ID
+			switch e.TaskCall.TaskStatus {
+			case "input_required":
+				c.status = "input_required"
+			case "failed", "cancelled":
+				c.status = "err"
+				if e.TaskCall.Err != nil {
+					link += " · " + e.TaskCall.Err.Message
+				}
+			}
+		}
+		if c.detail == "" {
+			c.detail = link
+		} else {
+			c.detail = link + " · " + c.detail
 		}
 	}
 	return c


### PR DESCRIPTION
## What and why

I changed task-backed `tools/call` correlation so a task handle keeps the original call open until the observed task reaches a terminal state. Task lifecycle frames now link back to that call, terminal results and errors drive its outcome, and duration/pending accounting cover the full task lifetime.

The stream shows the task-to-call link, highlights `input_required`, and supports a `task:` filter. I also added lifecycle coverage for completion, failure, cooperative cancellation, input updates, notifications, and orphan polls.

Fixes #121

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
