### PR TITLE
feat(store): correlate multi round-trip requests as one operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,19 +210,25 @@ matches the method, tool, id, and payload.
 |---|---|---|
 | `tool:` | tool name | `tool:search` |
 | `method:` | JSON-RPC method | `method:tools/call` |
-| `id:` | request id | `id:7` |
+| `id:` | request id, and any retry continuing it | `id:7` |
 | `task:` | task id | `task:01J...` |
 | `dir:` | direction (`c2s`, `s2c`) | `dir:s2c` |
 | `kind:` | frame type (`req`, `resp`, `notify`, `stderr`, `invalid`) | `kind:invalid` |
-| `status:` | call outcome (`ok`, `error`, `pending`, `bad`, `warn`, `mismatch`) | `status:error` |
+| `status:` | call outcome (`ok`, `error`, `cancelled`, `pending`, `bad`, `warn`, `mismatch`) | `status:error` |
 
 Stack tokens to get specific.
 
 ```text
 tool:search status:pending        # in-flight calls to one search tool
 method:tools/call status:error    # tool calls that failed
-dir:s2c kind:req                  # server-initiated requests (sampling, roots)
+dir:s2c kind:req                  # server-initiated requests (servers before 2026-07-28)
 ```
+
+The last one only finds anything on a server speaking 2025-11-25 or earlier. The
+2026-07-28 revision removed server-initiated requests, and a server that needs
+something from the client now answers the client's own request asking for it,
+then the client retries. mcpsnoop links those retries back to the request they
+continue, so the exchange reads as one call rather than several.
 
 ## Exporting sessions
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,6 +11,8 @@ package store
 
 import (
 	"encoding/json"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -95,6 +97,14 @@ type call struct {
 	errored    bool
 	taskID     string
 	taskStatus string
+	// opName is the tool, prompt or resource this call names, kept so a retry can
+	// be matched back to it without re-parsing the original params.
+	opName string
+	// mrtrState and mrtrKeys park what an InputRequiredResult asked for. The spec
+	// requires the retry to carry a different JSON-RPC id, so there is no shared
+	// identifier and the link has to be inferred from these instead.
+	mrtrState string
+	mrtrKeys  string
 }
 
 // event is the mutable internal timeline entry.
@@ -118,6 +128,9 @@ type event struct {
 	call               *call  // set for request/response events
 	taskCall           *call  // originating call for a task lifecycle frame
 	taskID             string
+	// mrtrRoot is the id of the request this one continues, set when a multi
+	// round-trip retry was recognised. Empty on an ordinary request.
+	mrtrRoot string
 }
 
 // capabilities holds what each side declared, whether through the legacy
@@ -153,7 +166,10 @@ type session struct {
 	cwd     string
 	calls   map[callKey]*call
 	tasks   map[string]*call
-	events  []*event
+	// awaiting holds operations that answered with an InputRequiredResult and are
+	// waiting for the client to retry. It stays tiny, only in-flight ones live here.
+	awaiting []*call
+	events   []*event
 
 	requests, responses, notifications, errors, pending int
 
@@ -284,6 +300,21 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.id = string(msg.ID)
 		ev.warning = validationWarning(msg)
 		var reused bool
+		if root := sess.matchRetry(msg); root != nil {
+			// A continuation, not a new call. Mapping the retry id onto the same
+			// call object lets completeCall find it, so the operation keeps one
+			// pending slot and one duration however many round trips it takes.
+			sess.calls[callKey{dir: e.Direction, id: ev.id}] = root
+			root.mrtrState, root.mrtrKeys = "", ""
+			sess.unpark(root)
+			ev.call = root
+			ev.kind = EventRequest
+			ev.method = msg.Method
+			ev.mrtrRoot = root.id
+			ev.warning = validationWarning(msg)
+			sess.requests++ // a request on the wire, even though not a new call
+			break
+		}
 		ev.call, reused = sess.openCall(ev.id, msg, e)
 		if ev.call.taskID != "" {
 			ev.taskID = ev.call.taskID
@@ -430,6 +461,7 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 	if isTaskMethod(msg.Method) {
 		c.taskID = taskID(msg.Params)
 	}
+	c.opName = operationName(msg)
 	sess.calls[key] = c
 	return c, reused
 }
@@ -447,6 +479,16 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 	}
 	if c.method == "tools/call" && c.taskID != "" {
 		return c, false // the task handle already continued this call
+	}
+	if state, ok := parseInputRequired(msg.Result); ok {
+		// The operation is not finished, it is waiting on the client. Keep it
+		// pending and open so its duration ends up spanning the whole exchange,
+		// including the time the user spends answering.
+		c.result = msg.Result
+		c.mrtrState = state.requestState
+		c.mrtrKeys = state.keys
+		sess.park(c)
+		return c, true
 	}
 	if c.method == "tools/call" {
 		if state, ok := parseTaskState(msg.Result); ok && state.ResultType == "task" {
@@ -783,6 +825,115 @@ func isToolError(result json.RawMessage) bool {
 // it in params.name, resources/read in params.uri); everything else returns ""
 // so a method that merely happens to carry a "name" param is never falsely
 // flagged, keeping the mismatch signal safe for a CI gate.
+// inputRequired is the parked half of a multi round-trip exchange (SEP-2322).
+type inputRequired struct {
+	requestState string
+	keys         string
+}
+
+// parseInputRequired recognises the result a server sends when it needs more
+// input before it can finish. Only prompts/get, resources/read and tools/call
+// can receive one, but the result shape is enough to tell, so the method is not
+// re-checked here.
+func parseInputRequired(raw json.RawMessage) (inputRequired, bool) {
+	if len(raw) == 0 {
+		return inputRequired{}, false
+	}
+	var r struct {
+		ResultType    string                     `json:"resultType"`
+		RequestState  string                     `json:"requestState"`
+		InputRequests map[string]json.RawMessage `json:"inputRequests"`
+	}
+	if json.Unmarshal(raw, &r) != nil || r.ResultType != "input_required" {
+		return inputRequired{}, false
+	}
+	return inputRequired{requestState: r.RequestState, keys: sortedKeySet(r.InputRequests)}, true
+}
+
+// retrySignals reads the two things a retry carries that can tie it back to the
+// request it continues.
+func retrySignals(params json.RawMessage) (state, keys string) {
+	if len(params) == 0 {
+		return "", ""
+	}
+	var p struct {
+		RequestState   string                     `json:"requestState"`
+		InputResponses map[string]json.RawMessage `json:"inputResponses"`
+	}
+	if json.Unmarshal(params, &p) != nil {
+		return "", ""
+	}
+	return p.RequestState, sortedKeySet(p.InputResponses)
+}
+
+// sortedKeySet renders a key set so two of them can be compared as strings.
+func sortedKeySet(m map[string]json.RawMessage) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return strings.Join(keys, "\x00")
+}
+
+func (sess *session) park(c *call) {
+	for _, p := range sess.awaiting {
+		if p == c {
+			return // a longer chain re-parks the same operation
+		}
+	}
+	sess.awaiting = append(sess.awaiting, c)
+}
+
+func (sess *session) unpark(c *call) {
+	for i, p := range sess.awaiting {
+		if p == c {
+			sess.awaiting = append(sess.awaiting[:i], sess.awaiting[i+1:]...)
+			return
+		}
+	}
+}
+
+// matchRetry finds the operation a request continues, or nil when it is a new
+// one. Because the spec requires the retry to use a different id, the link is
+// inferred. An echoed requestState is opaque and server-minted, so an exact
+// match is conclusive on its own. When the server issued none, the fallback
+// needs the method, the operation name and the full set of answered keys to
+// agree, and gives up when more than one parked operation fits, since a wrong
+// link is worse than no link.
+func (sess *session) matchRetry(msg proxy.RPCMessage) *call {
+	state, keys := retrySignals(msg.Params)
+	if state == "" && keys == "" {
+		return nil
+	}
+	name := operationName(msg)
+	var fallback *call
+	matches := 0
+	for _, c := range sess.awaiting {
+		if c.state != Pending {
+			continue
+		}
+		if state != "" {
+			if c.mrtrState == state {
+				return c
+			}
+			continue
+		}
+		if c.mrtrState == "" && c.mrtrKeys != "" && c.mrtrKeys == keys &&
+			c.method == msg.Method && c.opName == name {
+			fallback = c
+			matches++
+		}
+	}
+	if matches == 1 {
+		return fallback
+	}
+	return nil
+}
+
 func operationName(msg proxy.RPCMessage) string {
 	if len(msg.Params) == 0 {
 		return ""

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1175,3 +1175,146 @@ func TestToolDriftIsExposedOnSessionHeader(t *testing.T) {
 		t.Fatalf("tool drift = %+v, ok=%v", report, ok)
 	}
 }
+
+// A server that needs more input answers the original request and the client
+// retries under a different id, so the operation has to stay one call with one
+// duration that includes the time the user spent answering.
+func TestMRTRRetryContinuesTheSameOperation(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s.Ingest(resp(2, t0.Add(10*time.Millisecond), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","inputRequests":{"login":{"method":"elicitation/create"}},"requestState":"opaque-blob"}`))
+
+	if h := s.Sessions()[0]; h.Pending != 1 {
+		t.Fatalf("an operation waiting on the client is still pending, got %d", h.Pending)
+	}
+
+	// The user takes 5s to answer, then the client retries under a new id.
+	ev := s.Ingest(req(3, t0.Add(5*time.Second), proxy.ClientToServer, "2", "tools/call",
+		`{"name":"book","inputResponses":{"login":{"action":"accept"}},"requestState":"opaque-blob"}`))
+	if ev.MRTRRoot != "1" {
+		t.Fatalf("retry should point at the request it continues, got %q", ev.MRTRRoot)
+	}
+	if ev.Call == nil || ev.Call.ID != "1" {
+		t.Fatalf("retry should continue the original call, got %+v", ev.Call)
+	}
+
+	done := s.Ingest(resp(4, t0.Add(6*time.Second), proxy.ServerToClient, "2", `"result":{"content":[]}`))
+	if done.Call == nil || done.Call.State != Completed {
+		t.Fatalf("the terminal answer should complete the operation, got %+v", done.Call)
+	}
+	if got := done.Call.Duration(); got < 6*time.Second {
+		t.Fatalf("duration = %v, want the whole exchange including the user wait", got)
+	}
+	h := s.Sessions()[0]
+	if h.Pending != 0 {
+		t.Fatalf("pending = %d, want 0", h.Pending)
+	}
+	if h.Requests != 2 {
+		t.Fatalf("both frames are requests on the wire, requests = %d", h.Requests)
+	}
+	if n := len(s.Calls("s1")); n != 1 {
+		t.Fatalf("one logical operation must stay one call, got %d", n)
+	}
+}
+
+// A chain can run to any length, and every retry links back to the same root.
+func TestMRTRHandlesAChainLongerThanTwo(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","requestState":"st-1"}`))
+	ev2 := s.Ingest(req(3, t0.Add(2*time.Second), proxy.ClientToServer, "2", "tools/call",
+		`{"name":"book","requestState":"st-1"}`))
+	s.Ingest(resp(4, t0.Add(3*time.Second), proxy.ServerToClient, "2",
+		`"result":{"resultType":"input_required","requestState":"st-2"}`))
+	ev3 := s.Ingest(req(5, t0.Add(4*time.Second), proxy.ClientToServer, "3", "tools/call",
+		`{"name":"book","requestState":"st-2"}`))
+	done := s.Ingest(resp(6, t0.Add(5*time.Second), proxy.ServerToClient, "3", `"result":{"content":[]}`))
+
+	for i, ev := range []EventView{ev2, ev3} {
+		if ev.MRTRRoot != "1" {
+			t.Fatalf("retry %d should link to the root, got %q", i+1, ev.MRTRRoot)
+		}
+	}
+	if done.Call.State != Completed || done.Call.Duration() < 5*time.Second {
+		t.Fatalf("chain should close once and span the whole exchange, got %+v", done.Call)
+	}
+	if n := len(s.Calls("s1")); n != 1 {
+		t.Fatalf("a three-step chain is still one call, got %d", n)
+	}
+}
+
+// Without a requestState the fallback needs method, operation name and the full
+// answered key set to agree.
+func TestMRTRLinksOnKeySetWhenNoRequestState(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "resources/read", `{"uri":"file:///a"}`))
+	s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","inputRequests":{"who":{"method":"elicitation/create"}}}`))
+	ev := s.Ingest(req(3, t0.Add(2*time.Second), proxy.ClientToServer, "2", "resources/read",
+		`{"uri":"file:///a","inputResponses":{"who":{"action":"accept"}}}`))
+	if ev.MRTRRoot != "1" {
+		t.Fatalf("a non-tool request should link too, got %q", ev.MRTRRoot)
+	}
+}
+
+// Two identical operations in flight cannot be told apart without a state, so
+// neither is linked. A wrong link is worse than none.
+func TestMRTRRefusesAnAmbiguousLink(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	for i, id := range []string{"1", "2"} {
+		s.Ingest(req(uint64(2*i+1), t0, proxy.ClientToServer, id, "tools/call", `{"name":"book"}`))
+		s.Ingest(resp(uint64(2*i+2), t0.Add(time.Second), proxy.ServerToClient, id,
+			`"result":{"resultType":"input_required","inputRequests":{"who":{"method":"elicitation/create"}}}`))
+	}
+	ev := s.Ingest(req(9, t0.Add(2*time.Second), proxy.ClientToServer, "3", "tools/call",
+		`{"name":"book","inputResponses":{"who":{"action":"accept"}}}`))
+	if ev.MRTRRoot != "" {
+		t.Fatalf("an ambiguous retry must not be linked, got %q", ev.MRTRRoot)
+	}
+	if n := len(s.Calls("s1")); n != 3 {
+		t.Fatalf("an unlinked retry stays its own call, got %d", n)
+	}
+}
+
+// An ordinary request that happens to follow one must not be swallowed.
+func TestMRTRLeavesUnrelatedRequestsAlone(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","requestState":"st-1"}`))
+	ev := s.Ingest(req(3, t0.Add(2*time.Second), proxy.ClientToServer, "2", "tools/call", `{"name":"other"}`))
+	if ev.MRTRRoot != "" {
+		t.Fatalf("an unrelated call must not be linked, got %q", ev.MRTRRoot)
+	}
+	if n := len(s.Calls("s1")); n != 2 {
+		t.Fatalf("want two independent calls, got %d", n)
+	}
+}
+
+// The per-tool statistics must see one call, not one per round trip, or a
+// chatty elicitation would inflate both the call count and the percentiles.
+func TestMRTRCountsOneCallInTheToolSummary(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","requestState":"st-1"}`))
+	s.Ingest(req(3, t0.Add(2*time.Second), proxy.ClientToServer, "2", "tools/call",
+		`{"name":"book","requestState":"st-1"}`))
+	s.Ingest(resp(4, t0.Add(3*time.Second), proxy.ServerToClient, "2", `"result":{"content":[]}`))
+
+	summary, ok := s.ToolSummary("s1")
+	if !ok || len(summary.Tools) != 1 {
+		t.Fatalf("want one tool, got %+v", summary.Tools)
+	}
+	if got := summary.Tools[0].Calls; got != 1 {
+		t.Fatalf("calls = %d, want 1: a retry is a continuation, not another call", got)
+	}
+}

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -84,6 +84,9 @@ type EventView struct {
 	Call       *CallView // set for request/response events
 	TaskCall   *CallView // originating call for a tasks/* lifecycle frame
 	TaskID     string
+	// MRTRRoot is the id of the request this one continues, set when a multi
+	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
+	MRTRRoot string
 }
 
 // SessionHeader is a lightweight per-session summary for the left panel.
@@ -182,6 +185,7 @@ func (e *event) view(_ *session) EventView {
 		Truncated:          e.truncated,
 		Deprecated:         e.deprecated,
 		TaskID:             e.taskID,
+		MRTRRoot:           e.mrtrRoot,
 	}
 	if e.call != nil {
 		cv := e.call.view()
@@ -415,7 +419,10 @@ func (s *Store) Calls(sessionID string) []CallView {
 	}
 	out := make([]CallView, 0, len(sess.events))
 	for _, ev := range sess.events {
-		if ev.kind == EventRequest && ev.call != nil {
+		// A multi round-trip retry points at the call it continues, so counting it
+		// again here would report one logical operation as several and feed its
+		// duration into the statistics twice.
+		if ev.kind == EventRequest && ev.call != nil && ev.mrtrRoot == "" {
 			out = append(out, ev.call.view())
 		}
 	}
@@ -440,7 +447,10 @@ func (s *Store) ToolSummary(sessionID string) (SessionToolSummary, bool) {
 	var slowest []SlowToolCall
 	callIndex := 0
 	for _, ev := range sess.events {
-		if ev.kind != EventRequest || ev.call == nil {
+		// Skipping a continuation matters twice over: it would count one logical
+		// operation as several calls, and feed the same duration into the
+		// percentiles once per round trip.
+		if ev.kind != EventRequest || ev.call == nil || ev.mrtrRoot != "" {
 			continue
 		}
 		c := ev.call

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1039,7 +1039,10 @@ func (m *Model) matchToken(e store.EventView, tok string) bool {
 		case "method", "m":
 			return containsFold(e.Method, v) || (e.Call != nil && containsFold(e.Call.Method, v))
 		case "id":
-			return strings.EqualFold(e.ID, v)
+			// A retry belongs to the operation it continues, so filtering by the
+			// original id gathers the whole multi round-trip chain rather than
+			// just its first leg. Its own id still finds it on its own.
+			return strings.EqualFold(e.ID, v) || strings.EqualFold(e.MRTRRoot, v)
 		case "task":
 			return strings.EqualFold(e.TaskID, v)
 		case "dir", "d":

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -739,6 +739,16 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = link + " · " + c.detail
 		}
 	}
+	if e.MRTRRoot != "" {
+		// A multi round-trip retry carries a different id by design, so without
+		// saying what it continues the row looks like an unrelated second call.
+		link := "continues id " + e.MRTRRoot
+		if c.detail == "" {
+			c.detail = link
+		} else {
+			c.detail = link + " · " + c.detail
+		}
+	}
 	return c
 }
 


### PR DESCRIPTION
Closes #130