### PR TITLE
fix(check): summarize max-duration failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ other and with `--fail-on`, and any failure exits non-zero.
 
 | Flag | Fails when |
 |---|---|
-| `--max-duration <dur>` | a completed tool call took longer than the budget, e.g. `--max-duration 500ms` |
+| `--max-duration <dur>` | one or more completed tool calls exceeded the budget; reports their count and the worst call |
 | `--expect-tool <name>` | the named tool was never called (repeatable) |
 | `--forbid-tool <name>` | the named tool was called (repeatable) |
 

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -168,13 +168,32 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 
 	var failures []string
 	if a.maxDuration > 0 {
+		exceeded := 0
+		var worstDuration time.Duration
+		var worstTool string
 		for _, c := range calls {
 			// Only a call that actually got a response has a real latency. Pending and
 			// superseded calls never did, so they are not judged here.
-			if c.IsTool && c.Done() && c.State != store.Superseded && c.Duration() > a.maxDuration {
-				failures = append(failures, fmt.Sprintf("tool %q took %s, over the %s budget",
-					c.ToolName, c.Duration().Round(time.Millisecond), a.maxDuration))
+			if !c.IsTool || !c.Done() || c.State == store.Superseded {
+				continue
 			}
+			duration := c.Duration()
+			if duration <= a.maxDuration {
+				continue
+			}
+			exceeded++
+			if duration > worstDuration {
+				worstDuration = duration
+				worstTool = c.ToolName
+			}
+		}
+		if exceeded > 0 {
+			plural := ""
+			if exceeded > 1 {
+				plural = "s"
+			}
+			failures = append(failures, fmt.Sprintf("%d tool call%s exceeded the %s budget; worst was %q at %s",
+				exceeded, plural, a.maxDuration, worstTool, worstDuration.Round(time.Millisecond)))
 		}
 	}
 	for _, name := range a.expectTools {

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -399,13 +399,39 @@ func TestCheckMaxDurationAssertion(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 for a call over the budget", code)
 	}
-	if !strings.Contains(stdout, `assertion failed: tool "echo" took 1s, over the 500ms budget`) {
+	if !strings.Contains(stdout, `assertion failed: 1 tool call exceeded the 500ms budget; worst was "echo" at 1s`) {
 		t.Fatalf("stdout = %q", stdout)
 	}
 
 	code, stdout, _ = executeCheck(t, []string{"--max-duration", "2s", "-"}, log)
 	if code != 0 || !strings.Contains(stdout, "check passed") {
 		t.Fatalf("a call within budget should pass, code %d stdout %q", code, stdout)
+	}
+}
+
+func TestCheckMaxDurationSummarizesSlowCalls(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`),
+		checkEnvelope(3, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`),
+		checkEnvelope(4, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search"}}`),
+		checkEnvelope(9, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
+		checkEnvelope(10, proxy.ClientToServer, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"lookup"}}`),
+		checkEnvelope(13, proxy.ServerToClient, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`),
+		checkEnvelope(14, proxy.ClientToServer, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"fast"}}`),
+		checkEnvelope(15, proxy.ServerToClient, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`),
+		checkEnvelope(16, proxy.ClientToServer, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"pending"}}`),
+	)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-duration", "1s", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for calls over the budget", code)
+	}
+	if strings.Count(stdout, "assertion failed:") != 1 {
+		t.Fatalf("stdout should contain one bounded assertion failure, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `assertion failed: 3 tool calls exceeded the 1s budget; worst was "search" at 5s`) {
+		t.Fatalf("stdout = %q", stdout)
 	}
 }
 
@@ -446,7 +472,7 @@ func TestCheckAssertionsCompose(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 when either assertion fails", code)
 	}
-	for _, want := range []string{`tool "echo" took`, `expected tool "search" was never called`} {
+	for _, want := range []string{`worst was "echo" at 1s`, `expected tool "search" was never called`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}


### PR DESCRIPTION
## What and why

Collapse all `--max-duration` violations for a session into one assertion message containing the breach count and worst call. This keeps CI output bounded for large captures while preserving the non-zero exit behavior and leaving `--expect-tool` and `--forbid-tool` unchanged.

Fixes #135

## Testing

- `go test ./cmd/mcpsnoop -run '^TestCheck(MaxDurationAssertion|MaxDurationSummarizesSlowCalls|AssertionsCompose)$' -count=1`
- `make check`
- `go build ./...`
- `git diff --check`

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed