### PR TITLE
feat: gate checks on deprecated protocol features

### DIFF
--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -15,15 +15,16 @@ import (
 type checkSignal string
 
 const (
-	checkError    checkSignal = "error"
-	checkInvalid  checkSignal = "invalid"
-	checkWarn     checkSignal = "warn"
-	checkMismatch checkSignal = "mismatch"
-	checkPending  checkSignal = "pending"
-	checkDrift    checkSignal = "drift"
+	checkError      checkSignal = "error"
+	checkInvalid    checkSignal = "invalid"
+	checkWarn       checkSignal = "warn"
+	checkMismatch   checkSignal = "mismatch"
+	checkPending    checkSignal = "pending"
+	checkDrift      checkSignal = "drift"
+	checkDeprecated checkSignal = "deprecated"
 )
 
-var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift}
+var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated}
 
 type checkOutputFormat string
 
@@ -39,6 +40,7 @@ type checkSummary struct {
 	warnings        int
 	mismatches      int
 	pending         int
+	deprecated      int
 	drift           store.ToolDrift
 	baselineCreated bool
 }
@@ -133,7 +135,7 @@ func newCheckCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().SortFlags = false
-	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift")
+	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift, deprecated")
 	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text or junit")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
 	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
@@ -195,10 +197,10 @@ func parseCheckSignals(value string) (map[checkSignal]bool, error) {
 	for _, part := range strings.Split(value, ",") {
 		signal := checkSignal(strings.TrimSpace(part))
 		switch signal {
-		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift:
+		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated:
 			signals[signal] = true
 		default:
-			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, or drift, got %q", part)
+			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, drift, or deprecated, got %q", part)
 		}
 	}
 	return signals, nil
@@ -255,6 +257,9 @@ func summarizeCheck(st *store.Store, baselines *toolbaseline.Manager) []checkSum
 			if event.RoutingMismatch {
 				summary.mismatches++
 			}
+			if event.Deprecated != "" {
+				summary.deprecated++
+			}
 		}
 		summaries = append(summaries, summary)
 	}
@@ -290,6 +295,8 @@ func (s checkSummary) count(signal checkSignal) int {
 			n++
 		}
 		return n
+	case checkDeprecated:
+		return s.deprecated
 	default:
 		return 0
 	}

--- a/cmd/mcpsnoop/check_junit.go
+++ b/cmd/mcpsnoop/check_junit.go
@@ -124,6 +124,8 @@ func checkSignalFailureReason(sessionID string, signal checkSignal, count int) s
 		singular, plural = "pending call", "pending calls"
 	case checkDrift:
 		singular, plural = "tool definition change", "tool definition changes"
+	case checkDeprecated:
+		singular, plural = "deprecated protocol feature", "deprecated protocol features"
 	default:
 		singular, plural = "signal", "signals"
 	}

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -91,8 +91,8 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	const want = `<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="mcpsnoop check" tests="7" failures="3" errors="0" skipped="0" time="0">
-  <testsuite name="s1" tests="7" failures="3" errors="0" skipped="0" time="0">
+<testsuites name="mcpsnoop check" tests="8" failures="3" errors="0" skipped="0" time="0">
+  <testsuite name="s1" tests="8" failures="3" errors="0" skipped="0" time="0">
     <testcase classname="mcpsnoop.check" name="s1/error" time="0">
       <failure message="session s1 has 2 errors" type="mcpsnoop.check.error">session s1 has 2 errors</failure>
     </testcase>
@@ -105,6 +105,7 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
     <testcase classname="mcpsnoop.check" name="s1/mismatch" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/pending" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/drift" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/deprecated" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/assertions" time="0"></testcase>
   </testsuite>
 </testsuites>
@@ -125,7 +126,7 @@ func TestCheckJUnitHonorsFailOn(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 because errors are not selected", code)
 	}
-	for _, want := range []string{`tests="7"`, `failures="0"`, `name="s1/error"`} {
+	for _, want := range []string{`tests="8"`, `failures="0"`, `name="s1/error"`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}
@@ -479,6 +480,34 @@ func TestCheckPassesForDeprecatedFeature(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "warnings=0") || !strings.Contains(stdout, "check passed") {
 		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestCheckFailsForSelectedDeprecatedFeature(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	deprecated := checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"roots/list"}`)
+
+	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "deprecated", "-"}, encodeCheckLog(t, deprecated))
+	if code != 1 || stderr != "" {
+		t.Fatalf("deprecated gate = code %d, stderr %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "check failed: deprecated") {
+		t.Fatalf("stdout = %q, want deprecated failure", stdout)
+	}
+}
+
+func TestCheckJUnitReportsSelectedDeprecatedFeature(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	deprecated := checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"roots/list"}`)
+
+	code, stdout, stderr := executeCheck(t, []string{"--format", "junit", "--fail-on", "deprecated", "-"}, encodeCheckLog(t, deprecated))
+	if code != 1 || stderr != "" {
+		t.Fatalf("deprecated junit gate = code %d, stderr %q", code, stderr)
+	}
+	for _, want := range []string{`name="s1/deprecated"`, `type="mcpsnoop.check.deprecated"`, `1 deprecated protocol feature`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("junit stdout missing %q\n%s", want, stdout)
+		}
 	}
 }
 


### PR DESCRIPTION
## What and why

Adds deprecated protocol features to the existing check gate, selected-text output, summary counts, and JUnit failures. This makes --fail-on deprecated actionable instead of silently accepting deprecated usage.

Closes #134

## Testing

- go test ./cmd/mcpsnoop
- go vet ./...
- staticcheck ./...
- gofmt -s check

The full go test ./... reaches unrelated existing failures in internal/tui: TestStreamRowShowsSupersededStatusInWarnStyle and TestStatusStyleWarnsOnTruncated.

## Checklist

- [ ] make check passes (blocked by the unrelated internal/tui failures above)
- [x] Added or updated tests for the change
- [x] README/docs are unchanged because the existing CLI option is now implemented as documented