### PR TITLE
feat(tui): show schema findings in tool summary

### DIFF
--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// SchemaFindingKind names a JSON Schema construct that clients handle
+// inconsistently. A finding is an observation, not a verdict: a schema using
+// oneOf is not wrong, only likely to be interpreted differently across clients.
 type SchemaFindingKind string
 
 const (
@@ -21,6 +24,14 @@ type SchemaFinding struct {
 	Kind SchemaFindingKind
 }
 
+// analyzeSchema reports the constructs a tool's advertised input schema uses
+// that are known to travel badly. Nothing is resolved or fetched: an external
+// $ref is recognized by its form alone.
+//
+// Findings are deduplicated by kind. A finding carries only its kind, so two
+// entries of the same kind are indistinguishable and add nothing; collapsing
+// them lets a caller treat "more than one finding" as "more than one kind of
+// problem", which is the question a reader actually has.
 func analyzeSchema(raw json.RawMessage) []SchemaFinding {
 	if len(raw) == 0 {
 		return nil
@@ -32,58 +43,101 @@ func analyzeSchema(raw json.RawMessage) []SchemaFinding {
 	}
 
 	var findings []SchemaFinding
-	walkSchema(v, &findings)
+	seen := make(map[SchemaFindingKind]bool, 7)
+	walkSchema(v, &findings, seen)
 	return findings
 }
 
-func walkSchema(v any, findings *[]SchemaFinding) {
+func addFinding(findings *[]SchemaFinding, seen map[SchemaFindingKind]bool, kind SchemaFindingKind) {
+	if seen[kind] {
+		return
+	}
+	seen[kind] = true
+	*findings = append(*findings, SchemaFinding{Kind: kind})
+}
+
+// typingKeywords are the ways a subschema can say what it accepts other than
+// with an explicit "type". A property using any of them is typed, just not
+// directly, so flagging it as untyped would be wrong and would also bury the
+// construct it actually uses.
+var typingKeywords = []string{"$ref", "oneOf", "anyOf", "allOf", "not", "enum", "const"}
+
+func isTyped(schema map[string]any) bool {
+	if _, ok := schema["type"]; ok {
+		return true
+	}
+	for _, k := range typingKeywords {
+		if _, ok := schema[k]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func walkSchema(v any, findings *[]SchemaFinding, seen map[SchemaFindingKind]bool) {
 	node, ok := v.(map[string]any)
 	if !ok {
 		return
 	}
 
-	if _, ok := node["oneOf"]; ok {
-		*findings = append(*findings, SchemaFinding{Kind: FindingOneOf})
-	}
-	if _, ok := node["anyOf"]; ok {
-		*findings = append(*findings, SchemaFinding{Kind: FindingAnyOf})
-	}
-	if _, ok := node["allOf"]; ok {
-		*findings = append(*findings, SchemaFinding{Kind: FindingAllOf})
-	}
-	if _, ok := node["not"]; ok {
-		*findings = append(*findings, SchemaFinding{Kind: FindingNot})
+	for _, key := range []struct {
+		name string
+		kind SchemaFindingKind
+	}{
+		{"oneOf", FindingOneOf},
+		{"anyOf", FindingAnyOf},
+		{"allOf", FindingAllOf},
+		{"not", FindingNot},
+	} {
+		if _, ok := node[key.name]; ok {
+			addFinding(findings, seen, key.kind)
+		}
 	}
 	if ref, ok := node["$ref"].(string); ok {
+		// A reference starting with # points inside this document. Anything else
+		// points outside it, which is both a portability problem and the case the
+		// spec warns implementers not to follow blindly.
 		kind := FindingExternalRef
 		if strings.HasPrefix(ref, "#") {
 			kind = FindingRef
 		}
-		*findings = append(*findings, SchemaFinding{Kind: kind})
+		addFinding(findings, seen, kind)
 	}
 
 	if props, ok := node["properties"].(map[string]any); ok {
 		for _, child := range props {
 			if schema, ok := child.(map[string]any); ok {
-				if _, hasType := schema["type"]; !hasType {
-					*findings = append(*findings, SchemaFinding{Kind: FindingUntypedProperty})
+				if !isTyped(schema) {
+					addFinding(findings, seen, FindingUntypedProperty)
 				}
-				walkSchema(schema, findings)
+				walkSchema(schema, findings, seen)
 			}
 		}
 	}
 
-	for _, key := range []string{"oneOf", "anyOf", "allOf"} {
+	// Subschemas that hold a list of schemas.
+	for _, key := range []string{"oneOf", "anyOf", "allOf", "prefixItems"} {
 		if arr, ok := node[key].([]any); ok {
 			for _, child := range arr {
-				walkSchema(child, findings)
+				walkSchema(child, findings, seen)
 			}
 		}
 	}
 
-	for _, key := range []string{"not", "items"} {
+	// Subschemas that hold a single schema. A construct nested in any of these
+	// is just as real as one at the top, so the walk has to reach them.
+	for _, key := range []string{"not", "items", "additionalProperties", "if", "then", "else", "contains", "propertyNames"} {
 		if child, ok := node[key]; ok {
-			walkSchema(child, findings)
+			walkSchema(child, findings, seen)
+		}
+	}
+
+	// Subschemas held in a map keyed by name.
+	for _, key := range []string{"$defs", "definitions", "patternProperties", "dependentSchemas"} {
+		if group, ok := node[key].(map[string]any); ok {
+			for _, child := range group {
+				walkSchema(child, findings, seen)
+			}
 		}
 	}
 }

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type SchemaFindingKind string
+
+const (
+	FindingOneOf           SchemaFindingKind = "oneOf"
+	FindingAnyOf           SchemaFindingKind = "anyOf"
+	FindingAllOf           SchemaFindingKind = "allOf"
+	FindingNot             SchemaFindingKind = "not"
+	FindingRef             SchemaFindingKind = "ref"
+	FindingExternalRef     SchemaFindingKind = "externalRef"
+	FindingUntypedProperty SchemaFindingKind = "untypedProperty"
+)
+
+type SchemaFinding struct {
+	Kind SchemaFindingKind
+}
+
+func analyzeSchema(raw json.RawMessage) []SchemaFinding {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+
+	var findings []SchemaFinding
+	walkSchema(v, &findings)
+	return findings
+}
+
+func walkSchema(v any, findings *[]SchemaFinding) {
+	node, ok := v.(map[string]any)
+	if !ok {
+		return
+	}
+
+	if _, ok := node["oneOf"]; ok {
+		*findings = append(*findings, SchemaFinding{Kind: FindingOneOf})
+	}
+	if _, ok := node["anyOf"]; ok {
+		*findings = append(*findings, SchemaFinding{Kind: FindingAnyOf})
+	}
+	if _, ok := node["allOf"]; ok {
+		*findings = append(*findings, SchemaFinding{Kind: FindingAllOf})
+	}
+	if _, ok := node["not"]; ok {
+		*findings = append(*findings, SchemaFinding{Kind: FindingNot})
+	}
+	if ref, ok := node["$ref"].(string); ok {
+		kind := FindingExternalRef
+		if strings.HasPrefix(ref, "#") {
+			kind = FindingRef
+		}
+		*findings = append(*findings, SchemaFinding{Kind: kind})
+	}
+
+	if props, ok := node["properties"].(map[string]any); ok {
+		for _, child := range props {
+			if schema, ok := child.(map[string]any); ok {
+				if _, hasType := schema["type"]; !hasType {
+					*findings = append(*findings, SchemaFinding{Kind: FindingUntypedProperty})
+				}
+				walkSchema(schema, findings)
+			}
+		}
+	}
+
+	for _, key := range []string{"oneOf", "anyOf", "allOf"} {
+		if arr, ok := node[key].([]any); ok {
+			for _, child := range arr {
+				walkSchema(child, findings)
+			}
+		}
+	}
+
+	for _, key := range []string{"not", "items"} {
+		if child, ok := node[key]; ok {
+			walkSchema(child, findings)
+		}
+	}
+}

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestAnalyzeSchemaClean(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"query":{"type":"string"},
+			"limit":{"type":"integer"}
+		}
+	}`)
+
+	got := analyzeSchema(schema)
+
+	if len(got) != 0 {
+		t.Fatalf("got %v findings, want none", got)
+	}
+}
+
+func TestAnalyzeSchemaOneOf(t *testing.T) {
+	schema := json.RawMessage(`{
+		"oneOf": [
+			{"type":"string"},
+			{"type":"integer"}
+		]
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingOneOf},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaAnyOf(t *testing.T) {
+	schema := json.RawMessage(`{
+		"anyOf": [
+			{"type":"string"},
+			{"type":"integer"}
+		]
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingAnyOf},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaAllOf(t *testing.T) {
+	schema := json.RawMessage(`{
+		"allOf": [
+			{"type":"string"},
+			{"type":"integer"}
+		]
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingAllOf},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaNot(t *testing.T) {
+	schema := json.RawMessage(`{
+		"not": {
+			"type":"string"
+		}
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingNot},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaRef(t *testing.T) {
+	schema := json.RawMessage(`{
+		"$ref": "#/$defs/Foo"
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingRef},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaPropertyNamedLikeKeyword(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"oneOf": {
+				"type": "string"
+			}
+		}
+	}`)
+
+	got := analyzeSchema(schema)
+
+	if len(got) != 0 {
+		t.Fatalf("got %v, want none", got)
+	}
+}
+
+func TestAnalyzeSchemaExternalRef(t *testing.T) {
+	schema := json.RawMessage(`{
+		"$ref": "https://example.com/schema.json"
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingExternalRef},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaUntypedProperty(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {}
+		}
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingUntypedProperty},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaNestedUntypedProperty(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"filter":{
+				"type":"object",
+				"properties":{
+					"value":{
+						"description":"whatever"
+					}
+				}
+			}
+		}
+	}`)
+
+	got := analyzeSchema(schema)
+
+	want := []SchemaFinding{
+		{Kind: FindingUntypedProperty},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnalyzeSchemaTopLevelWithoutTypeIsNotFlaggedAsUntypedProperty(t *testing.T) {
+	schema := json.RawMessage(`{
+		"oneOf":[
+			{
+				"type":"object",
+				"properties":{
+					"a":{"type":"string"}
+				}
+			},
+			{
+				"type":"object",
+				"properties":{
+					"b":{"type":"string"}
+				}
+			}
+		]
+	}`)
+
+	got := analyzeSchema(schema)
+
+	for _, finding := range got {
+		if finding.Kind == FindingUntypedProperty {
+			t.Fatalf("got %v, top-level schema must not be treated as a property", got)
+		}
+	}
+}

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -214,6 +215,131 @@ func TestAnalyzeSchemaTopLevelWithoutTypeIsNotFlaggedAsUntypedProperty(t *testin
 	for _, finding := range got {
 		if finding.Kind == FindingUntypedProperty {
 			t.Fatalf("got %v, top-level schema must not be treated as a property", got)
+		}
+	}
+}
+
+// A real MCP inputSchema is an object whose parameters live under properties, so
+// that is where a construct actually appears. Flagging such a property as
+// untyped would be wrong (its type comes from the reference or the branches) and
+// would also hide the construct behind the untyped label.
+func TestAnalyzeSchemaConstructOnAPropertyIsNotAlsoUntyped(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema string
+		want   []SchemaFinding
+	}{
+		{
+			name:   "oneOf",
+			schema: `{"type":"object","properties":{"config":{"oneOf":[{"type":"string"},{"type":"number"}]}}}`,
+			want:   []SchemaFinding{{Kind: FindingOneOf}},
+		},
+		{
+			name:   "internal ref",
+			schema: `{"type":"object","properties":{"user":{"$ref":"#/$defs/User"}}}`,
+			want:   []SchemaFinding{{Kind: FindingRef}},
+		},
+		{
+			name:   "external ref",
+			schema: `{"type":"object","properties":{"user":{"$ref":"https://example.com/user.json"}}}`,
+			want:   []SchemaFinding{{Kind: FindingExternalRef}},
+		},
+		{
+			name:   "anyOf",
+			schema: `{"type":"object","properties":{"v":{"anyOf":[{"type":"string"}]}}}`,
+			want:   []SchemaFinding{{Kind: FindingAnyOf}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeSchema(json.RawMessage(tc.schema))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// enum and const pin the accepted values more tightly than a type would, so a
+// property using either is not ambiguous and must not be reported as untyped.
+func TestAnalyzeSchemaEnumAndConstAreNotUntyped(t *testing.T) {
+	for _, schema := range []string{
+		`{"type":"object","properties":{"mode":{"enum":["fast","slow"]}}}`,
+		`{"type":"object","properties":{"version":{"const":2}}}`,
+	} {
+		if got := analyzeSchema(json.RawMessage(schema)); len(got) != 0 {
+			t.Fatalf("analyzeSchema(%s) = %v, want no findings", schema, got)
+		}
+	}
+}
+
+// Findings carry only a kind, so repeats of one kind are indistinguishable and
+// collapsing them keeps "more than one finding" meaning "more than one kind".
+func TestAnalyzeSchemaDeduplicatesByKind(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"a":{"description":"no type"},
+			"b":{"description":"also no type"},
+			"c":{"description":"still no type"}
+		}
+	}`)
+
+	got := analyzeSchema(schema)
+	want := []SchemaFinding{{Kind: FindingUntypedProperty}}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// A construct is just as real inside these containers as at the top level, so
+// the walk has to reach them or a schema reads as clean when it is not.
+func TestAnalyzeSchemaReachesEveryContainer(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema string
+		want   SchemaFindingKind
+	}{
+		{"additionalProperties", `{"type":"object","additionalProperties":{"oneOf":[{"type":"string"}]}}`, FindingOneOf},
+		{"if", `{"type":"object","if":{"oneOf":[{"type":"string"}]}}`, FindingOneOf},
+		{"then", `{"type":"object","then":{"$ref":"https://example.com/x.json"}}`, FindingExternalRef},
+		{"else", `{"type":"object","else":{"anyOf":[{"type":"string"}]}}`, FindingAnyOf},
+		{"contains", `{"type":"array","contains":{"allOf":[{"type":"string"}]}}`, FindingAllOf},
+		{"prefixItems", `{"type":"array","prefixItems":[{"oneOf":[{"type":"string"}]}]}`, FindingOneOf},
+		{"patternProperties", `{"type":"object","patternProperties":{"^a":{"$ref":"#/$defs/A"}}}`, FindingRef},
+		{"$defs", `{"type":"object","$defs":{"X":{"oneOf":[{"type":"string"}]}}}`, FindingOneOf},
+		{"definitions", `{"type":"object","definitions":{"X":{"anyOf":[{"type":"string"}]}}}`, FindingAnyOf},
+		{"dependentSchemas", `{"type":"object","dependentSchemas":{"a":{"allOf":[{"type":"string"}]}}}`, FindingAllOf},
+		{"propertyNames", `{"type":"object","propertyNames":{"$ref":"#/$defs/N"}}`, FindingRef},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := analyzeSchema(json.RawMessage(tc.schema))
+			if len(got) != 1 || got[0].Kind != tc.want {
+				t.Fatalf("got %v, want exactly [%s]", got, tc.want)
+			}
+		})
+	}
+}
+
+// Nothing may be resolved or fetched: an external reference is recognized by its
+// form alone, and the schema it points at is never read.
+func TestAnalyzeSchemaClassifiesRefsByFormOnly(t *testing.T) {
+	cases := map[string]SchemaFindingKind{
+		"#":                          FindingRef,
+		"#/$defs/User":               FindingRef,
+		"#/definitions/User":         FindingRef,
+		"https://example.com/u.json": FindingExternalRef,
+		"./shared.json#/User":        FindingExternalRef,
+		"urn:example:user":           FindingExternalRef,
+		"file:///etc/schema.json":    FindingExternalRef,
+	}
+	for ref, want := range cases {
+		schema := json.RawMessage(`{"type":"object","properties":{"u":{"$ref":` + strconv.Quote(ref) + `}}}`)
+		got := analyzeSchema(schema)
+		if len(got) != 1 || got[0].Kind != want {
+			t.Fatalf("$ref %q: got %v, want [%s]", ref, got, want)
 		}
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -791,10 +791,13 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 
 		sess.advertisedSet[tool.Name] = struct{}{}
 		sess.advertisedTools = append(sess.advertisedTools, tool.Name)
+		schema := append(json.RawMessage(nil), tool.InputSchema...)
+
 		sess.toolDefinitions[tool.Name] = ToolDefinition{
 			Name:        tool.Name,
 			Description: tool.Description,
-			InputSchema: append(json.RawMessage(nil), tool.InputSchema...),
+			InputSchema: schema,
+			Findings:    analyzeSchema(schema),
 		}
 	}
 	sess.toolListComplete = r.NextCursor == ""

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1144,7 +1144,7 @@ func TestToolDefinitionsCaptureDescriptionsSchemasAndCompletePagination(t *testi
 	}
 
 	s.Ingest(req(3, t0, proxy.ClientToServer, "2", "tools/list", `{"cursor":"p2"}`))
-	s.Ingest(resp(4, t0, proxy.ServerToClient, "2", `"result":{"tools":[{"name":"fetch","description":"Fetch a page","inputSchema":{"type":"object"}}]}`))
+	s.Ingest(resp(4, t0, proxy.ServerToClient, "2", `"result":{"tools":[{"name":"fetch","description":"Fetch a page","inputSchema":{"oneOf":[{"type":"object"},{"type":"string"}]}}]}`))
 
 	definitions, ok := s.ToolDefinitions("s1")
 	if !ok {
@@ -1156,8 +1156,15 @@ func TestToolDefinitionsCaptureDescriptionsSchemasAndCompletePagination(t *testi
 	if definitions[0].Name != "search" || definitions[0].Description != "Search docs" || string(definitions[0].InputSchema) == "" {
 		t.Fatalf("search definition = %+v", definitions[0])
 	}
+	if len(definitions[0].Findings) != 0 {
+		t.Fatalf("search findings = %v, want none (flat typed schema)", definitions[0].Findings)
+	}
 	if definitions[1].Name != "fetch" || definitions[1].Description != "Fetch a page" {
 		t.Fatalf("fetch definition = %+v", definitions[1])
+	}
+	got := definitions[1].Findings
+	if len(got) != 1 || got[0].Kind != FindingOneOf {
+		t.Fatalf("fetch findings = %v, want one oneOf finding", got)
 	}
 }
 

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -111,6 +111,7 @@ type ToolDefinition struct {
 	Name        string
 	Description string
 	InputSchema json.RawMessage
+	Findings    []SchemaFinding
 }
 
 // ToolDrift is the difference between the current complete tool list and the

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1177,9 +1177,14 @@ func TestSummaryHeaderShowsOnlyCallsAndSort(t *testing.T) {
 			t.Fatalf("header should show only calls, found %q: %q", banned, header)
 		}
 	}
-	// The clean tool shows · for zero errors; the erroring tool shows a count.
-	if !summaryHasRow(out, "good", "·") || summaryHasRow(out, "bad", "·") {
-		t.Fatalf("ERR column should show · only for the clean tool\n%s", out)
+	// The clean tool shows · in ERR; the erroring tool shows 1 in ERR.
+	// Both rows also contain the SCHEMA column, so check the row text instead
+	// of counting dots.
+	if !strings.Contains(out, "good                    1     ·") {
+		t.Fatalf("good row should show · in ERR\n%s", out)
+	}
+	if !strings.Contains(out, "bad                     1     1") {
+		t.Fatalf("bad row should show 1 in ERR\n%s", out)
 	}
 	// The erroring tool sorts above the clean one, not alphabetically.
 	if strings.Index(out, "bad") > strings.Index(out, "good") {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1177,14 +1177,11 @@ func TestSummaryHeaderShowsOnlyCallsAndSort(t *testing.T) {
 			t.Fatalf("header should show only calls, found %q: %q", banned, header)
 		}
 	}
-	// The clean tool shows · in ERR; the erroring tool shows 1 in ERR.
-	// Both rows also contain the SCHEMA column, so check the row text instead
-	// of counting dots.
-	if !strings.Contains(out, "good                    1     ·") {
-		t.Fatalf("good row should show · in ERR\n%s", out)
-	}
-	if !strings.Contains(out, "bad                     1     1") {
-		t.Fatalf("bad row should show 1 in ERR\n%s", out)
+	// The clean tool shows · for zero errors; the erroring tool shows a count.
+	// This works because an empty SCHEMA cell is blank, so the only · in a row
+	// is the ERR one.
+	if !summaryHasRow(out, "good", "·") || summaryHasRow(out, "bad", "·") {
+		t.Fatalf("ERR column should show · only for the clean tool\n%s", out)
 	}
 	// The erroring tool sorts above the clean one, not alphabetically.
 	if strings.Index(out, "bad") > strings.Index(out, "good") {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1269,6 +1269,7 @@ func (m Model) capsTitle(label, version string, w int) string {
 // stay aligned.
 const (
 	sumToolW    = 18
+	sumSchemaW  = 7
 	sumCallsW   = 7
 	sumErrW     = 6
 	sumLatW     = 10
@@ -1282,6 +1283,13 @@ func (m Model) summaryContent() string {
 	summary, _ := m.store.ToolSummary(sid)
 	_, unused, undeclared, hasTools := m.store.ToolUsage(sid)
 	drift, hasDrift := m.store.ToolDrift(sid)
+	findingsByName := map[string][]store.SchemaFinding{}
+
+	if definitions, ok := m.store.ToolDefinitions(sid); ok {
+		for _, d := range definitions {
+			findingsByName[d.Name] = d.Findings
+		}
+	}
 	w, _ := m.overlayDims()
 
 	calls := 0
@@ -1310,11 +1318,6 @@ func (m Model) summaryContent() string {
 		}
 	}
 
-	// TABLE: every advertised tool plus any called one, so the full tool set is
-	// visible from the start and its counts fill in as calls arrive. Uncalled
-	// tools are faint 0-call rows; problems sort to the top (errors first, then by
-	// the shown median latency descending), so idle tools sink to the bottom. The
-	// ERR column carries the only verdict color, plus the cyan pending spinner.
 	tools := slices.Clone(summary.Tools)
 	for _, name := range unused {
 		tools = append(tools, store.ToolStats{Name: name})
@@ -1337,7 +1340,8 @@ func (m Model) summaryContent() string {
 	})
 	var t strings.Builder
 	t.WriteString(m.styles.dim.Render(cellL("TOOL", sumToolW) +
-		cellR("CALLS", sumCallsW) + cellR("ERR", sumErrW) + cellR("LATENCY", sumLatW)))
+		cellR("CALLS", sumCallsW) + cellR("ERR", sumErrW) + cellR("LATENCY", sumLatW) +
+		"  " + cellL("SCHEMA", sumSchemaW)))
 	for _, tool := range tools {
 		base := m.styles.neutral
 		if tool.Calls == 0 {
@@ -1347,29 +1351,49 @@ func (m Model) summaryContent() string {
 		if tool.Errors > 0 {
 			errCell = m.styles.respErr.Render(fmt.Sprintf("%d", tool.Errors))
 		}
-		// LATENCY is the median (p50), a plain number the reader judges for
-		// themselves. A tool whose calls are all still in flight shows a live cyan
-		// spinner rather than a dash.
 		lat := base.Render(formatLatency(tool.P50))
 		if tool.Pending > 0 && tool.Pending == tool.Calls {
 			lat = m.styles.pending.Render(m.spinnerFrame())
 		}
+		// SCHEMA names the first (highest-priority) construct a tool's advertised
+		// schema uses that is known to travel badly across clients, plus a "+" when
+		// there is more than one. Purely observational, so it carries the warn
+		// color, never the ERR column's red.
+		schemaCell := m.styles.faint.Render(cellL("·", sumSchemaW))
+		if findings := findingsByName[tool.Name]; len(findings) > 0 {
+			label := schemaKindLabel(findings[0].Kind)
+			if len(findings) > 1 {
+				label += "+"
+			}
+			schemaCell = m.styles.warn.Render(cellL(label, sumSchemaW))
+		}
 		t.WriteString("\n" + base.Render(cellL(tool.Name, sumToolW)) +
 			cellR(base.Render(fmt.Sprintf("%d", tool.Calls)), sumCallsW) +
 			cellR(errCell, sumErrW) +
-			cellR(lat, sumLatW))
+			cellR(lat, sumLatW) +
+			"  " + schemaCell)
 	}
 	sections = append(sections, t.String())
 
-	// DRIFT: tools the client called that the server never advertised in
-	// tools/list. They appear in the table too, but a red line flags them as a
-	// contract mismatch worth noticing.
 	if len(undeclared) > 0 {
 		indent := strings.Repeat(" ", covLabelW)
 		sections = append(sections, m.styles.dim.Render(cellL("undeclared", covLabelW))+m.styles.respErr.Render(wrapWords(undeclared, indent, w)))
 	}
 
 	return header + "\n\n" + strings.Join(sections, "\n\n")
+}
+
+// schemaKindLabel is the short display text for a schema finding kind in the
+// narrow SCHEMA column. Display wording is a TUI concern, not the store's.
+func schemaKindLabel(k store.SchemaFindingKind) string {
+	switch k {
+	case store.FindingExternalRef:
+		return "ext ref"
+	case store.FindingUntypedProperty:
+		return "untyped"
+	default:
+		return string(k)
+	}
 }
 
 func (m Model) definitionDriftSection(drift store.ToolDrift, width int) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1318,6 +1318,12 @@ func (m Model) summaryContent() string {
 		}
 	}
 
+	// TABLE: every advertised tool plus any called one, so the full tool set is
+	// visible from the start and its counts fill in as calls arrive. Uncalled
+	// tools are faint 0-call rows; problems sort to the top (errors first, then by
+	// the shown median latency descending), so idle tools sink to the bottom. The
+	// ERR column carries the only verdict color, plus the cyan pending spinner,
+	// and SCHEMA carries warn.
 	tools := slices.Clone(summary.Tools)
 	for _, name := range unused {
 		tools = append(tools, store.ToolStats{Name: name})
@@ -1351,17 +1357,23 @@ func (m Model) summaryContent() string {
 		if tool.Errors > 0 {
 			errCell = m.styles.respErr.Render(fmt.Sprintf("%d", tool.Errors))
 		}
+		// LATENCY is the median (p50), a plain number the reader judges for
+		// themselves. A tool whose calls are all still in flight shows a live cyan
+		// spinner rather than a dash.
 		lat := base.Render(formatLatency(tool.P50))
 		if tool.Pending > 0 && tool.Pending == tool.Calls {
 			lat = m.styles.pending.Render(m.spinnerFrame())
 		}
-		// SCHEMA names the first (highest-priority) construct a tool's advertised
-		// schema uses that is known to travel badly across clients, plus a "+" when
-		// there is more than one. Purely observational, so it carries the warn
-		// color, never the ERR column's red.
-		schemaCell := m.styles.faint.Render(cellL("·", sumSchemaW))
+		// SCHEMA names the most notable construct a tool's advertised schema uses
+		// that is known to travel badly across clients, plus a "+" when there is
+		// more than one kind. Purely observational, so it carries the warn color,
+		// never the ERR column's red.
+		// An empty cell is left blank rather than dotted. The ERR column already
+		// uses · to mean zero, and repeating it here both adds noise on the common
+		// case of a clean schema and makes a row match a search for either column.
+		schemaCell := cellL("", sumSchemaW)
 		if findings := findingsByName[tool.Name]; len(findings) > 0 {
-			label := schemaKindLabel(findings[0].Kind)
+			label := schemaKindLabel(headlineFinding(findings))
 			if len(findings) > 1 {
 				label += "+"
 			}
@@ -1375,12 +1387,45 @@ func (m Model) summaryContent() string {
 	}
 	sections = append(sections, t.String())
 
+	// DRIFT: tools the client called that the server never advertised in
+	// tools/list. They appear in the table too, but a red line flags them as a
+	// contract mismatch worth noticing.
 	if len(undeclared) > 0 {
 		indent := strings.Repeat(" ", covLabelW)
 		sections = append(sections, m.styles.dim.Render(cellL("undeclared", covLabelW))+m.styles.respErr.Render(wrapWords(undeclared, indent, w)))
 	}
 
 	return header + "\n\n" + strings.Join(sections, "\n\n")
+}
+
+// schemaHeadlineOrder ranks findings for the single-label SCHEMA column. An
+// external reference leads because it points outside the wire entirely, which is
+// both the least portable case and the one the spec warns implementers about.
+// The composition keywords follow, then an internal reference, then an untyped
+// property, which is the weakest signal since a description often carries the
+// meaning a type would.
+var schemaHeadlineOrder = []store.SchemaFindingKind{
+	store.FindingExternalRef,
+	store.FindingOneOf,
+	store.FindingAnyOf,
+	store.FindingAllOf,
+	store.FindingNot,
+	store.FindingRef,
+	store.FindingUntypedProperty,
+}
+
+// headlineFinding picks which finding the column names. The store returns them
+// in the order the walk met them, which is an artifact of schema layout rather
+// than of how much each one matters, so the choice is made here.
+func headlineFinding(findings []store.SchemaFinding) store.SchemaFindingKind {
+	for _, want := range schemaHeadlineOrder {
+		for _, f := range findings {
+			if f.Kind == want {
+				return want
+			}
+		}
+	}
+	return findings[0].Kind
 }
 
 // schemaKindLabel is the short display text for a schema finding kind in the


### PR DESCRIPTION
## What and why

I added schema findings to the tool summary so it is immediately visible when a
tool definition uses JSON Schema constructs that many MCP clients handle
inconsistently.

The analysis is purely observational. It flags composition keywords, internal
and external `$ref`s, and untyped properties without validating, resolving, or
fetching anything. Findings are shown in a dedicated SCHEMA column.

Fixes #129

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [ ] Updated the README / docs if user-facing behaviour changed