### PR TITLE
feat(store): flag invalid MRTR requestState echoes

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -341,6 +341,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			ev.warning = validationWarning(msg)
 			ev.mrtrStateIssue = stateIssue
 			if warning := stateIssue.warning(); warning != "" {
+				// The spec makes the echo a MUST for the client, so a violation is a
+				// protocol error on the wire rather than an observation of ours. It
+				// therefore rides the warning field like any other protocol warning,
+				// which means a default check run fails on it. That is deliberate: a
+				// client mangling server state is worth stopping a build for.
 				ev.warning = appendWarning(ev.warning, warning)
 			}
 			sess.requests++ // a request on the wire, even though not a new call
@@ -998,6 +1003,18 @@ func (sess *session) matchRetry(msg proxy.RPCMessage) (*call, MRTRStateIssue) {
 	return nil, ""
 }
 
+// classifyMRTRState compares the state a retry carried with the one the server
+// issued. It only ever compares opaque bytes: the spec forbids the client from
+// inspecting the contents, and an observer has no more reason to than a client
+// does.
+//
+// One case is out of reach. A server may answer with requestState and no
+// inputRequests at all, and then a tampered retry echoes a state that matches
+// nothing and answers no keys, so there is nothing left to link it by and it
+// reads as an unrelated call rather than a violation. Linking on the method and
+// operation name alone would catch it, but would also fuse two genuinely
+// separate calls to the same tool, and a wrong link is worse than a missed one.
+// See TestMRTRCannotSeeTamperingOnAStateOnlyExchange.
 func classifyMRTRState(c *call, retryState string, retryHasState bool) MRTRStateIssue {
 	switch {
 	case c.mrtrHasState && !retryHasState:

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -47,6 +47,28 @@ func (s CallState) String() string {
 	}
 }
 
+// MRTRStateIssue classifies how a retry violated the requestState echo contract.
+type MRTRStateIssue string
+
+const (
+	MRTRStateChanged  MRTRStateIssue = "changed"
+	MRTRStateMissing  MRTRStateIssue = "missing"
+	MRTRStateInvented MRTRStateIssue = "invented"
+)
+
+func (i MRTRStateIssue) warning() string {
+	switch i {
+	case MRTRStateChanged:
+		return "MRTR retry changed requestState"
+	case MRTRStateMissing:
+		return "MRTR retry is missing requestState"
+	case MRTRStateInvented:
+		return "MRTR retry invented requestState"
+	default:
+		return ""
+	}
+}
+
 // EventKind classifies a single timeline entry.
 type EventKind int
 
@@ -100,11 +122,12 @@ type call struct {
 	// opName is the tool, prompt or resource this call names, kept so a retry can
 	// be matched back to it without re-parsing the original params.
 	opName string
-	// mrtrState and mrtrKeys park what an InputRequiredResult asked for. The spec
-	// requires the retry to carry a different JSON-RPC id, so there is no shared
-	// identifier and the link has to be inferred from these instead.
-	mrtrState string
-	mrtrKeys  string
+	// mrtrState, its presence bit, and mrtrKeys park what an InputRequiredResult
+	// asked for. The retry uses a different JSON-RPC id, so these are also the
+	// evidence used to infer the link.
+	mrtrState    string
+	mrtrHasState bool
+	mrtrKeys     string
 }
 
 // event is the mutable internal timeline entry.
@@ -131,6 +154,9 @@ type event struct {
 	// mrtrRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised. Empty on an ordinary request.
 	mrtrRoot string
+	// mrtrStateIssue is set only when a linked retry changed the opaque state,
+	// omitted an issued state, or supplied one the server never issued.
+	mrtrStateIssue MRTRStateIssue
 }
 
 // capabilities holds what each side declared, whether through the legacy
@@ -300,18 +326,23 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.id = string(msg.ID)
 		ev.warning = validationWarning(msg)
 		var reused bool
-		if root := sess.matchRetry(msg); root != nil {
+		if root, stateIssue := sess.matchRetry(msg); root != nil {
 			// A continuation, not a new call. Mapping the retry id onto the same
 			// call object lets completeCall find it, so the operation keeps one
 			// pending slot and one duration however many round trips it takes.
 			sess.calls[callKey{dir: e.Direction, id: ev.id}] = root
 			root.mrtrState, root.mrtrKeys = "", ""
+			root.mrtrHasState = false
 			sess.unpark(root)
 			ev.call = root
 			ev.kind = EventRequest
 			ev.method = msg.Method
 			ev.mrtrRoot = root.id
 			ev.warning = validationWarning(msg)
+			ev.mrtrStateIssue = stateIssue
+			if warning := stateIssue.warning(); warning != "" {
+				ev.warning = appendWarning(ev.warning, warning)
+			}
 			sess.requests++ // a request on the wire, even though not a new call
 			break
 		}
@@ -494,6 +525,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 		// including the time the user spends answering.
 		c.result = msg.Result
 		c.mrtrState = state.requestState
+		c.mrtrHasState = state.hasRequestState
 		c.mrtrKeys = state.keys
 		sess.park(c)
 		return c, true
@@ -835,8 +867,9 @@ func isToolError(result json.RawMessage) bool {
 // flagged, keeping the mismatch signal safe for a CI gate.
 // inputRequired is the parked half of a multi round-trip exchange (SEP-2322).
 type inputRequired struct {
-	requestState string
-	keys         string
+	requestState    string
+	hasRequestState bool
+	keys            string
 	// methods names the server-to-client requests carried inside inputRequests.
 	// The 2026-07-28 revision routes sampling and roots exclusively through this
 	// map, so it is the only place their method names still appear.
@@ -853,7 +886,7 @@ func parseInputRequired(raw json.RawMessage) (inputRequired, bool) {
 	}
 	var r struct {
 		ResultType    string                     `json:"resultType"`
-		RequestState  string                     `json:"requestState"`
+		RequestState  *string                    `json:"requestState"`
 		InputRequests map[string]json.RawMessage `json:"inputRequests"`
 	}
 	if json.Unmarshal(raw, &r) != nil || r.ResultType != "input_required" {
@@ -869,27 +902,34 @@ func parseInputRequired(raw json.RawMessage) (inputRequired, bool) {
 		}
 	}
 	slices.Sort(methods) // stable order, the map iteration order is not
-	return inputRequired{
-		requestState: r.RequestState,
-		keys:         sortedKeySet(r.InputRequests),
-		methods:      methods,
-	}, true
+	state := inputRequired{
+		hasRequestState: r.RequestState != nil,
+		keys:            sortedKeySet(r.InputRequests),
+		methods:         methods,
+	}
+	if r.RequestState != nil {
+		state.requestState = *r.RequestState
+	}
+	return state, true
 }
 
 // retrySignals reads the two things a retry carries that can tie it back to the
 // request it continues.
-func retrySignals(params json.RawMessage) (state, keys string) {
+func retrySignals(params json.RawMessage) (state string, hasState bool, keys string) {
 	if len(params) == 0 {
-		return "", ""
+		return "", false, ""
 	}
 	var p struct {
-		RequestState   string                     `json:"requestState"`
+		RequestState   *string                    `json:"requestState"`
 		InputResponses map[string]json.RawMessage `json:"inputResponses"`
 	}
 	if json.Unmarshal(params, &p) != nil {
-		return "", ""
+		return "", false, ""
 	}
-	return p.RequestState, sortedKeySet(p.InputResponses)
+	if p.RequestState != nil {
+		state, hasState = *p.RequestState, true
+	}
+	return state, hasState, sortedKeySet(p.InputResponses)
 }
 
 // sortedKeySet renders a key set so two of them can be compared as strings.
@@ -926,38 +966,49 @@ func (sess *session) unpark(c *call) {
 // matchRetry finds the operation a request continues, or nil when it is a new
 // one. Because the spec requires the retry to use a different id, the link is
 // inferred. An echoed requestState is opaque and server-minted, so an exact
-// match is conclusive on its own. When the server issued none, the fallback
-// needs the method, the operation name and the full set of answered keys to
-// agree, and gives up when more than one parked operation fits, since a wrong
-// link is worse than no link.
-func (sess *session) matchRetry(msg proxy.RPCMessage) *call {
-	state, keys := retrySignals(msg.Params)
-	if state == "" && keys == "" {
-		return nil
+// match is conclusive on its own. Otherwise the fallback needs the method, the
+// operation name and the full set of answered keys to agree, and gives up when
+// more than one parked operation fits, since a wrong link is worse than no link.
+func (sess *session) matchRetry(msg proxy.RPCMessage) (*call, MRTRStateIssue) {
+	state, hasState, keys := retrySignals(msg.Params)
+	if !hasState && keys == "" {
+		return nil, ""
 	}
+	if hasState {
+		for _, c := range sess.awaiting {
+			if c.state == Pending && c.mrtrHasState && c.mrtrState == state {
+				return c, ""
+			}
+		}
+	}
+
 	name := operationName(msg)
 	var fallback *call
 	matches := 0
 	for _, c := range sess.awaiting {
-		if c.state != Pending {
-			continue
-		}
-		if state != "" {
-			if c.mrtrState == state {
-				return c
-			}
-			continue
-		}
-		if c.mrtrState == "" && c.mrtrKeys != "" && c.mrtrKeys == keys &&
+		if c.state == Pending && c.mrtrKeys != "" && c.mrtrKeys == keys &&
 			c.method == msg.Method && c.opName == name {
 			fallback = c
 			matches++
 		}
 	}
 	if matches == 1 {
-		return fallback
+		return fallback, classifyMRTRState(fallback, state, hasState)
 	}
-	return nil
+	return nil, ""
+}
+
+func classifyMRTRState(c *call, retryState string, retryHasState bool) MRTRStateIssue {
+	switch {
+	case c.mrtrHasState && !retryHasState:
+		return MRTRStateMissing
+	case !c.mrtrHasState && retryHasState:
+		return MRTRStateInvented
+	case c.mrtrHasState && retryHasState && c.mrtrState != retryState:
+		return MRTRStateChanged
+	default:
+		return ""
+	}
 }
 
 func operationName(msg proxy.RPCMessage) string {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1219,6 +1219,111 @@ func TestMRTRRetryContinuesTheSameOperation(t *testing.T) {
 	}
 }
 
+func TestMRTRFlagsRequestStateIntegrityViolations(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	const issued = "server-opaque-state-never-render"
+	const changed = "client-altered-state-never-render"
+
+	tests := []struct {
+		name         string
+		resultState  string
+		retryState   string
+		wantCategory string
+	}{
+		{
+			name:         "changed",
+			resultState:  `,"requestState":"` + issued + `"`,
+			retryState:   `,"requestState":"` + changed + `"`,
+			wantCategory: "changed",
+		},
+		{
+			name:         "missing",
+			resultState:  `,"requestState":"` + issued + `"`,
+			wantCategory: "missing",
+		},
+		{
+			name:         "invented",
+			retryState:   `,"requestState":"` + changed + `"`,
+			wantCategory: "invented",
+		},
+		{
+			name:        "correct",
+			resultState: `,"requestState":"` + issued + `"`,
+			retryState:  `,"requestState":"` + issued + `"`,
+		},
+		{
+			name:        "present empty correct",
+			resultState: `,"requestState":""`,
+			retryState:  `,"requestState":""`,
+		},
+		{
+			name:         "present empty missing",
+			resultState:  `,"requestState":""`,
+			wantCategory: "missing",
+		},
+		{
+			name:         "present empty invented",
+			retryState:   `,"requestState":""`,
+			wantCategory: "invented",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+			s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+				`"result":{"resultType":"input_required","inputRequests":{"login":{"method":"elicitation/create"}}`+tc.resultState+`}`))
+			ev := s.Ingest(req(3, t0.Add(2*time.Second), proxy.ClientToServer, "2", "tools/call",
+				`{"name":"book","inputResponses":{"login":{"action":"accept"}}`+tc.retryState+`}`))
+
+			if ev.MRTRRoot != "1" {
+				t.Fatal("retry with unique MRTR evidence was not linked to its root")
+			}
+			if ev.MRTRStateIssue != MRTRStateIssue(tc.wantCategory) {
+				t.Fatalf("requestState issue = %q, want %q", ev.MRTRStateIssue, tc.wantCategory)
+			}
+			if tc.wantCategory == "" {
+				if strings.Contains(ev.Warning, "requestState") {
+					t.Fatal("a correct requestState echo produced a finding")
+				}
+			} else if !strings.Contains(ev.Warning, "requestState") ||
+				!strings.Contains(ev.Warning, tc.wantCategory) {
+				t.Fatalf("requestState finding did not identify the %s category", tc.wantCategory)
+			}
+			if strings.Contains(ev.Warning, issued) || strings.Contains(ev.Warning, changed) {
+				t.Fatal("requestState finding disclosed an opaque value")
+			}
+			if n := len(s.Calls("s1")); n != 1 {
+				t.Fatalf("linked retry created %d calls, want one logical operation", n)
+			}
+			done := s.Ingest(resp(4, t0.Add(3*time.Second), proxy.ServerToClient, "2", `"result":{"content":[]}`))
+			if done.Call == nil || done.Call.State != Completed || s.Sessions()[0].Pending != 0 {
+				t.Fatal("requestState finding disturbed terminal MRTR completion")
+			}
+		})
+	}
+}
+
+func TestMRTRDoesNotGuessARequestStateViolationBetweenAmbiguousCalls(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	for i, id := range []string{"1", "2"} {
+		s.Ingest(req(uint64(2*i+1), t0, proxy.ClientToServer, id, "tools/call", `{"name":"book"}`))
+		s.Ingest(resp(uint64(2*i+2), t0.Add(time.Second), proxy.ServerToClient, id,
+			fmt.Sprintf(`"result":{"resultType":"input_required","inputRequests":{"login":{"method":"elicitation/create"}},"requestState":"issued-%s"}`, id)))
+	}
+
+	ev := s.Ingest(req(5, t0.Add(2*time.Second), proxy.ClientToServer, "3", "tools/call",
+		`{"name":"book","inputResponses":{"login":{"action":"accept"}},"requestState":"unknown"}`))
+	if ev.MRTRRoot != "" || ev.MRTRStateIssue != "" || strings.Contains(ev.Warning, "requestState") {
+		t.Fatal("ambiguous structural evidence must stay unlinked and unclassified")
+	}
+	if n := len(s.Calls("s1")); n != 3 {
+		t.Fatalf("ambiguous retry produced %d calls, want three unlinked calls", n)
+	}
+}
+
 // A chain can run to any length, and every retry links back to the same root.
 func TestMRTRHandlesAChainLongerThanTwo(t *testing.T) {
 	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1521,3 +1521,40 @@ func TestNestedDeprecationLeavesMRTRCorrelationIntact(t *testing.T) {
 		t.Fatalf("the retry should still link to its root, got %q", ev.MRTRRoot)
 	}
 }
+
+// A server may answer with requestState and no inputRequests, and then a
+// tampered retry has nothing left to link it by: the state matches nothing and
+// there are no answered keys to fall back on. It reads as an unrelated call
+// rather than a violation. This pins that limit so widening the fallback later
+// is a deliberate choice rather than an accident.
+func TestMRTRCannotSeeTamperingOnAStateOnlyExchange(t *testing.T) {
+	t0 := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","requestState":"st-1"}`))
+
+	// The correct echo still links, so the limit is only about tampering.
+	ok := s.Ingest(req(3, t0.Add(2*time.Second), proxy.ClientToServer, "2", "tools/call",
+		`{"name":"book","requestState":"st-1"}`))
+	if ok.MRTRRoot != "1" || ok.MRTRStateIssue != "" {
+		t.Fatalf("a correct echo must still link cleanly, got root=%q issue=%q", ok.MRTRRoot, ok.MRTRStateIssue)
+	}
+
+	s2 := New()
+	s2.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s2.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","requestState":"st-1"}`))
+	tampered := s2.Ingest(req(3, t0.Add(2*time.Second), proxy.ClientToServer, "2", "tools/call",
+		`{"name":"book","requestState":"tampered"}`))
+
+	if tampered.MRTRRoot != "" {
+		t.Fatalf("with nothing to link by, the retry must not be attached, got root=%q", tampered.MRTRRoot)
+	}
+	if tampered.MRTRStateIssue != "" {
+		t.Fatalf("an unlinked retry cannot be classified, got %q", tampered.MRTRStateIssue)
+	}
+	if n := len(s2.Calls("s1")); n != 2 {
+		t.Fatalf("it reads as two independent calls, got %d", n)
+	}
+}

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -87,6 +87,9 @@ type EventView struct {
 	// MRTRRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
 	MRTRRoot string
+	// MRTRStateIssue classifies a changed, missing, or invented requestState on
+	// this retry. It never contains the opaque state itself.
+	MRTRStateIssue MRTRStateIssue
 }
 
 // SessionHeader is a lightweight per-session summary for the left panel.
@@ -186,6 +189,7 @@ func (e *event) view(_ *session) EventView {
 		Deprecated:         e.deprecated,
 		TaskID:             e.taskID,
 		MRTRRoot:           e.mrtrRoot,
+		MRTRStateIssue:     e.mrtrStateIssue,
 	}
 	if e.call != nil {
 		cv := e.call.view()

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -68,6 +68,23 @@ func TestTaskLifecycleFramesCanBeFilteredAndShowTheirParent(t *testing.T) {
 	}
 }
 
+func TestMRTRRequestStateFindingHasDedicatedMarker(t *testing.T) {
+	m := Model{}
+	e := store.EventView{
+		Kind:           store.EventRequest,
+		Warning:        "MRTR retry changed requestState",
+		MRTRRoot:       "1",
+		MRTRStateIssue: store.MRTRStateChanged,
+	}
+	cells := m.streamCells(e)
+	if cells.status != "state!" {
+		t.Fatalf("requestState finding status = %q, want state!", cells.status)
+	}
+	if !strings.Contains(cells.detail, "changed") || !strings.Contains(cells.detail, "continues id 1") {
+		t.Fatalf("requestState finding detail did not include its category and MRTR link: %q", cells.detail)
+	}
+}
+
 func TestStatusFilterSeparatesCancelledFromError(t *testing.T) {
 	m := Model{}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -749,6 +749,9 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = link + " · " + c.detail
 		}
 	}
+	if e.MRTRStateIssue != "" {
+		c.status = "state!"
+	}
 	return c
 }
 


### PR DESCRIPTION
## What and why

MRTR requires a client to echo an optional opaque `requestState` unchanged and
to omit it when the server did not issue one. A changed, missing, or invented
state currently prevents exact retry correlation, so mcpsnoop opens the retry
as an unrelated call and cannot explain the resulting server rejection.

This change preserves whether the field was present, keeps exact state matching
as the primary correlation path, and uses the existing method, operation, and
complete response-key evidence only when it identifies one parked call. The
linked retry is classified as changed, missing, or invented; correct echoes stay
clean, and ambiguous traffic remains unlinked. Findings contain only the
category, never the opaque value, and appear through the existing warning path
with a compact `state!` stream marker.

Fixes #133

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] README / docs are unchanged; the finding uses the existing per-frame warning and status surfaces
