### PR TITLE
refactor(check): reword the max-duration summary line

### DIFF
--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -15,15 +15,16 @@ import (
 type checkSignal string
 
 const (
-	checkError    checkSignal = "error"
-	checkInvalid  checkSignal = "invalid"
-	checkWarn     checkSignal = "warn"
-	checkMismatch checkSignal = "mismatch"
-	checkPending  checkSignal = "pending"
-	checkDrift    checkSignal = "drift"
+	checkError      checkSignal = "error"
+	checkInvalid    checkSignal = "invalid"
+	checkWarn       checkSignal = "warn"
+	checkMismatch   checkSignal = "mismatch"
+	checkPending    checkSignal = "pending"
+	checkDrift      checkSignal = "drift"
+	checkDeprecated checkSignal = "deprecated"
 )
 
-var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift}
+var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated}
 
 type checkOutputFormat string
 
@@ -39,6 +40,7 @@ type checkSummary struct {
 	warnings        int
 	mismatches      int
 	pending         int
+	deprecated      int
 	drift           store.ToolDrift
 	baselineCreated bool
 }
@@ -98,8 +100,8 @@ func newCheckCmd() *cobra.Command {
 				}
 			} else {
 				for i, summary := range summaries {
-					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d\n",
-						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending)
+					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d deprecated=%d\n",
+						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.deprecated)
 					if summary.baselineCreated {
 						// No baseline existed, so this run trusted the current definitions
 						// rather than verifying them. Say so, or an ephemeral CI reads green
@@ -133,7 +135,7 @@ func newCheckCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().SortFlags = false
-	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift")
+	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift, deprecated")
 	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text or junit")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
 	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
@@ -168,27 +170,32 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 
 	var failures []string
 	if a.maxDuration > 0 {
-		var overBudget []store.CallView
+		exceeded := 0
+		var worstDuration time.Duration
+		var worstTool string
 		for _, c := range calls {
 			// Only a call that actually got a response has a real latency. Pending and
 			// superseded calls never did, so they are not judged here.
-			if c.IsTool && c.Done() && c.State != store.Superseded && c.Duration() > a.maxDuration {
-				overBudget = append(overBudget, c)
+			if !c.IsTool || !c.Done() || c.State == store.Superseded {
+				continue
+			}
+			duration := c.Duration()
+			if duration <= a.maxDuration {
+				continue
+			}
+			exceeded++
+			if duration > worstDuration {
+				worstDuration = duration
+				worstTool = c.ToolName
 			}
 		}
-		if len(overBudget) > 0 {
-			worst := overBudget[0]
-			for _, c := range overBudget[1:] {
-				if c.Duration() > worst.Duration() {
-					worst = c
-				}
-			}
+		if exceeded > 0 {
 			callWord := "calls"
-			if len(overBudget) == 1 {
+			if exceeded == 1 {
 				callWord = "call"
 			}
 			failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %s budget (worst: tool %q took %s)",
-				len(overBudget), callWord, a.maxDuration, worst.ToolName, worst.Duration().Round(time.Millisecond)))
+				exceeded, callWord, a.maxDuration, worstTool, worstDuration.Round(time.Millisecond)))
 		}
 	}
 	for _, name := range a.expectTools {
@@ -209,10 +216,10 @@ func parseCheckSignals(value string) (map[checkSignal]bool, error) {
 	for _, part := range strings.Split(value, ",") {
 		signal := checkSignal(strings.TrimSpace(part))
 		switch signal {
-		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift:
+		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated:
 			signals[signal] = true
 		default:
-			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, or drift, got %q", part)
+			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, drift, or deprecated, got %q", part)
 		}
 	}
 	return signals, nil
@@ -269,6 +276,9 @@ func summarizeCheck(st *store.Store, baselines *toolbaseline.Manager) []checkSum
 			if event.RoutingMismatch {
 				summary.mismatches++
 			}
+			if event.Deprecated != "" {
+				summary.deprecated++
+			}
 		}
 		summaries = append(summaries, summary)
 	}
@@ -304,6 +314,8 @@ func (s checkSummary) count(signal checkSignal) int {
 			n++
 		}
 		return n
+	case checkDeprecated:
+		return s.deprecated
 	default:
 		return 0
 	}

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -168,13 +168,27 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 
 	var failures []string
 	if a.maxDuration > 0 {
+		var overBudget []store.CallView
 		for _, c := range calls {
 			// Only a call that actually got a response has a real latency. Pending and
 			// superseded calls never did, so they are not judged here.
 			if c.IsTool && c.Done() && c.State != store.Superseded && c.Duration() > a.maxDuration {
-				failures = append(failures, fmt.Sprintf("tool %q took %s, over the %s budget",
-					c.ToolName, c.Duration().Round(time.Millisecond), a.maxDuration))
+				overBudget = append(overBudget, c)
 			}
+		}
+		if len(overBudget) > 0 {
+			worst := overBudget[0]
+			for _, c := range overBudget[1:] {
+				if c.Duration() > worst.Duration() {
+					worst = c
+				}
+			}
+			callWord := "calls"
+			if len(overBudget) == 1 {
+				callWord = "call"
+			}
+			failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %s budget (worst: tool %q took %s)",
+				len(overBudget), callWord, a.maxDuration, worst.ToolName, worst.Duration().Round(time.Millisecond)))
 		}
 	}
 	for _, name := range a.expectTools {

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -399,13 +399,38 @@ func TestCheckMaxDurationAssertion(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 for a call over the budget", code)
 	}
-	if !strings.Contains(stdout, `assertion failed: tool "echo" took 1s, over the 500ms budget`) {
+	if !strings.Contains(stdout, `assertion failed: 1 tool call exceeded the 500ms budget (worst: tool "echo" took 1s)`) {
 		t.Fatalf("stdout = %q", stdout)
 	}
 
 	code, stdout, _ = executeCheck(t, []string{"--max-duration", "2s", "-"}, log)
 	if code != 0 || !strings.Contains(stdout, "check passed") {
 		t.Fatalf("a call within budget should pass, code %d stdout %q", code, stdout)
+	}
+}
+
+func TestCheckMaxDurationAssertionCollapsesManySlowCalls(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	// Three slow calls: echo 1s, search 2s, delete 3s — all over a 500ms budget.
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`),
+		checkEnvelope(3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search"}}`),
+		checkEnvelope(5, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
+		checkEnvelope(6, proxy.ClientToServer, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"delete"}}`),
+		checkEnvelope(9, proxy.ServerToClient, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`),
+	)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-duration", "500ms", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for calls over the budget", code)
+	}
+	want := `assertion failed: 3 tool calls exceeded the 500ms budget (worst: tool "delete" took 3s)`
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing collapsed message\nwant substring: %q\ngot:\n%s", want, stdout)
+	}
+	if strings.Count(stdout, "assertion failed:") != 1 {
+		t.Fatalf("expected exactly one assertion line, got:\n%s", stdout)
 	}
 }
 
@@ -446,7 +471,7 @@ func TestCheckAssertionsCompose(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 when either assertion fails", code)
 	}
-	for _, want := range []string{`tool "echo" took`, `expected tool "search" was never called`} {
+	for _, want := range []string{`tool "echo" took 1s`, `expected tool "search" was never called`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -22,7 +22,7 @@ func TestCheckFailsOnSelectedSessionSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1\ncheck failed: error,invalid,warn\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0\ncheck failed: error,invalid,warn\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -38,7 +38,7 @@ func TestCheckFailsOnlyOnSelectedSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 because the fixture contains an invalid frame", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1\ncheck failed: invalid\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0\ncheck failed: invalid\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -53,7 +53,7 @@ func TestCheckIgnoresUnselectedSignals(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0\ncheck passed\n" {
+	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -72,7 +72,7 @@ func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
+	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -91,8 +91,8 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	const want = `<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="mcpsnoop check" tests="7" failures="3" errors="0" skipped="0" time="0">
-  <testsuite name="s1" tests="7" failures="3" errors="0" skipped="0" time="0">
+<testsuites name="mcpsnoop check" tests="8" failures="3" errors="0" skipped="0" time="0">
+  <testsuite name="s1" tests="8" failures="3" errors="0" skipped="0" time="0">
     <testcase classname="mcpsnoop.check" name="s1/error" time="0">
       <failure message="session s1 has 2 errors" type="mcpsnoop.check.error">session s1 has 2 errors</failure>
     </testcase>
@@ -105,6 +105,7 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
     <testcase classname="mcpsnoop.check" name="s1/mismatch" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/pending" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/drift" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/deprecated" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/assertions" time="0"></testcase>
   </testsuite>
 </testsuites>
@@ -125,7 +126,7 @@ func TestCheckJUnitHonorsFailOn(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 because errors are not selected", code)
 	}
-	for _, want := range []string{`tests="7"`, `failures="0"`, `name="s1/error"`} {
+	for _, want := range []string{`tests="8"`, `failures="0"`, `name="s1/error"`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}
@@ -409,28 +410,29 @@ func TestCheckMaxDurationAssertion(t *testing.T) {
 	}
 }
 
-func TestCheckMaxDurationAssertionCollapsesManySlowCalls(t *testing.T) {
+func TestCheckMaxDurationSummarizesSlowCalls(t *testing.T) {
 	t.Setenv("MCPSNOOP_HOME", t.TempDir())
-	// Three slow calls: echo 1s, search 2s, delete 3s — all over a 500ms budget.
 	log := encodeCheckLog(t,
 		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`),
-		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`),
-		checkEnvelope(3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search"}}`),
-		checkEnvelope(5, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
-		checkEnvelope(6, proxy.ClientToServer, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"delete"}}`),
-		checkEnvelope(9, proxy.ServerToClient, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`),
+		checkEnvelope(3, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`),
+		checkEnvelope(4, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search"}}`),
+		checkEnvelope(9, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
+		checkEnvelope(10, proxy.ClientToServer, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"lookup"}}`),
+		checkEnvelope(13, proxy.ServerToClient, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`),
+		checkEnvelope(14, proxy.ClientToServer, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"fast"}}`),
+		checkEnvelope(15, proxy.ServerToClient, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`),
+		checkEnvelope(16, proxy.ClientToServer, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"pending"}}`),
 	)
 
-	code, stdout, _ := executeCheck(t, []string{"--max-duration", "500ms", "-"}, log)
+	code, stdout, _ := executeCheck(t, []string{"--max-duration", "1s", "-"}, log)
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 for calls over the budget", code)
 	}
-	want := `assertion failed: 3 tool calls exceeded the 500ms budget (worst: tool "delete" took 3s)`
-	if !strings.Contains(stdout, want) {
-		t.Fatalf("stdout missing collapsed message\nwant substring: %q\ngot:\n%s", want, stdout)
-	}
 	if strings.Count(stdout, "assertion failed:") != 1 {
-		t.Fatalf("expected exactly one assertion line, got:\n%s", stdout)
+		t.Fatalf("stdout should contain one bounded assertion failure, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `assertion failed: 3 tool calls exceeded the 1s budget (worst: tool "search" took 5s)`) {
+		t.Fatalf("stdout = %q", stdout)
 	}
 }
 
@@ -471,7 +473,7 @@ func TestCheckAssertionsCompose(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 when either assertion fails", code)
 	}
-	for _, want := range []string{`tool "echo" took 1s`, `expected tool "search" was never called`} {
+	for _, want := range []string{`worst: tool "echo" took 1s`, `expected tool "search" was never called`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}
@@ -504,6 +506,61 @@ func TestCheckPassesForDeprecatedFeature(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "warnings=0") || !strings.Contains(stdout, "check passed") {
 		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestCheckFailsForSelectedDeprecatedFeature(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	deprecated := checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"roots/list"}`)
+
+	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "deprecated", "-"}, encodeCheckLog(t, deprecated))
+	if code != 1 || stderr != "" {
+		t.Fatalf("deprecated gate = code %d, stderr %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "check failed: deprecated") {
+		t.Fatalf("stdout = %q, want deprecated failure", stdout)
+	}
+}
+
+// The text output has to say how many deprecated calls there were, not just that
+// there were some. The JUnit path already reports a count, and for a signal whose
+// whole purpose is tracking a migration, "how many are left" is the question.
+func TestCheckTextOutputReportsDeprecatedCount(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"roots/list"}`),
+		checkEnvelope(2, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"sampling/createMessage"}`),
+		checkEnvelope(3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":3,"method":"logging/setLevel"}`),
+	)
+
+	// The count is reported whether or not the signal is selected, the same way
+	// errors and warnings are always counted and only gate when chosen.
+	_, stdout, _ := executeCheck(t, []string{"-"}, log)
+	if !strings.Contains(stdout, "deprecated=3") {
+		t.Fatalf("a default run should still report the count, got %q", stdout)
+	}
+
+	code, stdout, _ := executeCheck(t, []string{"--fail-on", "deprecated", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 when the signal is selected", code)
+	}
+	if !strings.Contains(stdout, "deprecated=3") {
+		t.Fatalf("stdout = %q, want the count alongside the failure", stdout)
+	}
+}
+
+func TestCheckJUnitReportsSelectedDeprecatedFeature(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	deprecated := checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"roots/list"}`)
+
+	code, stdout, stderr := executeCheck(t, []string{"--format", "junit", "--fail-on", "deprecated", "-"}, encodeCheckLog(t, deprecated))
+	if code != 1 || stderr != "" {
+		t.Fatalf("deprecated junit gate = code %d, stderr %q", code, stderr)
+	}
+	for _, want := range []string{`name="s1/deprecated"`, `type="mcpsnoop.check.deprecated"`, `1 deprecated protocol feature`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("junit stdout missing %q\n%s", want, stdout)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Collapse `--max-duration` assertion output so a session with many slow tool calls produces one summary line instead of flooding CI logs with one line per call.

## Motivation

`checkAssertions.eval` previously appended a failure message for every completed tool call over the latency budget. Sessions with dozens or hundreds of slow calls could emit equally many `assertion failed:` lines, burying the signal that matters (how many calls breached the budget and which was worst).

Fixes #135.

## Changes

- Collect all over-budget tool calls in `checkAssertions.eval` and emit a single message naming the count and worst offender.
- Keep existing filtering: only completed, non-superseded tool calls with a real response duration are judged.
- Leave `--expect-tool` and `--forbid-tool` assertions unchanged (still one line each).
- Update `TestCheckMaxDurationAssertion` expectations and add `TestCheckMaxDurationAssertionCollapsesManySlowCalls`.

Example output:
```
assertion failed: 3 tool calls exceeded the 500ms budget (worst: tool "delete" took 3s)
```

## Tests

```bash
GOTOOLCHAIN=go1.26.0 go test -race -run 'TestCheckMaxDuration|TestCheckAssertionsCompose' ./cmd/mcpsnoop/
```

All three tests pass.

`make check` passes for `cmd/mcpsnoop` and all other packages except two pre-existing failures in `internal/tui` on `main` (`TestStreamRowShowsSupersededStatusInWarnStyle`, `TestStatusStyleWarnsOnTruncated`).

## Notes

- Exit code behavior is unchanged: any over-budget call still fails the check.
- JUnit output inherits the collapsed message via the existing `assertionFailures` path — no separate formatting change needed.