### PR TITLE
fix(cmd): give every run a unique session id, not a per-PID one

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,11 @@ MCP is not HTTP, so a HAR entry's URL, status code, and timings are a deliberate
 mapping of each call rather than a wire transcript.
 
 ```bash
-mcpsnoop export -T html -o out.html       # an HTML file to open in a browser
-mcpsnoop export -T text server.py-48213   # a specific session, as text
-mcpsnoop export -T json | jq              # the newest session, piped to jq
-mcpsnoop export -T har -o session.har     # a HAR file to open in browser devtools
-mcpsnoop export -T otlp -o trace.json     # import into an OTLP-compatible tracing backend
+mcpsnoop export -T html -o out.html              # an HTML file to open in a browser
+mcpsnoop export -T text server.py-48213-7f3a1c   # a specific session, as text
+mcpsnoop export -T json | jq                     # the newest session, piped to jq
+mcpsnoop export -T har -o session.har            # a HAR file to open in browser devtools
+mcpsnoop export -T otlp -o trace.json            # import into an OTLP-compatible tracing backend
 ```
 
 Omit `-o` to write to stdout, and omit the session to take the newest, or pass

--- a/cmd/mcpsnoop/demo.go
+++ b/cmd/mcpsnoop/demo.go
@@ -79,7 +79,11 @@ func playDemo(ctx context.Context, socket string) {
 	sink := proxy.NewSocketSink(socket, 0)
 	defer sink.Close()
 
-	session := fmt.Sprintf("demo-%d", os.Getpid())
+	// Unique per run for the same reason the shim's id is: two demos sharing a
+	// PID would have the second one's frames dropped by the hub's dedup, and an
+	// empty demo is a bad first impression of a tool whose whole pitch is that
+	// it shows you the traffic.
+	session := newSessionID("demo")
 	var seq uint64
 
 	// Give the hub a moment to bind. The socket sink also retries on its own.

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -11,6 +11,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -364,6 +366,36 @@ func labelFor(command []string) string {
 	return pick
 }
 
+// newSessionID names one proxy run: its log file, and the session the TUI and
+// the export commands address.
+//
+// The PID is not enough on its own. A PID is unique only among live processes,
+// and the kernel is free to reuse it the moment the old one is reaped, which
+// happens fast wherever the PID space is small: containers, CI runners, and
+// anything that starts a fresh server per job. Two runs that land on the same
+// id then collide twice over. They append into one log file, and the hub, which
+// deduplicates on a per-session high-water mark of Seq, sees the second run
+// restart at Seq 1 and discards every frame of it as already seen. The live
+// view stays empty for a server that is plainly running, and nothing reports
+// the loss: the gap detector only notices Seq jumping forward, never back.
+//
+// The suffix is random rather than a start timestamp because the guarantee must
+// not rest on the clock. Container clocks are coarse and can jump, and two
+// shims can start inside the same tick. The PID stays in the id because it is
+// the part a person uses to match a session to a process they can see.
+func newSessionID(label string) string {
+	return fmt.Sprintf("%s-%d-%s", label, os.Getpid(), sessionNonce())
+}
+
+// sessionNonce is the short random tag that tells apart two runs sharing a PID.
+// crypto/rand.Read has no error path worth handling here: on every supported
+// platform it either succeeds or panics, so there is nothing to degrade into.
+func sessionNonce() string {
+	var b [3]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
 // newExportCmd reads a persisted JSONL session and writes a portable export.
 func newExportCmd() *cobra.Command {
 	var formatFlag, outFlag string
@@ -433,7 +465,7 @@ func runShim(command []string, label, traceFile string, noTrace bool, redaction 
 	if label == "" {
 		label = labelFor(command)
 	}
-	sessionID := fmt.Sprintf("%s-%d", label, os.Getpid())
+	sessionID := newSessionID(label)
 
 	sink := traceSink(sessionID, traceFile, noTrace, redaction, trace)
 	defer func() {
@@ -542,7 +574,7 @@ func newHTTPCmd() *cobra.Command {
 					lbl = "http"
 				}
 			}
-			sessionID := fmt.Sprintf("%s-%d", lbl, os.Getpid())
+			sessionID := newSessionID(lbl)
 
 			sink := traceSink(sessionID, "", noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths), trace)
 			defer sink.Close()

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -39,6 +39,53 @@ func TestLabelFor(t *testing.T) {
 	}
 }
 
+// TestNewSessionIDIsUniquePerRun is the regression for a reused PID silently
+// discarding a whole session. The hub deduplicates on a per-session high-water
+// mark of Seq, so two runs sharing an id lose the second one entirely, with no
+// gap reported and nothing on screen. Uniqueness therefore has to hold per run,
+// which the PID cannot give, since it repeats.
+func TestNewSessionIDIsUniquePerRun(t *testing.T) {
+	const runs = 1000
+	seen := make(map[string]bool, runs)
+	for range runs {
+		id := newSessionID("server.py")
+		if seen[id] {
+			t.Fatalf("two runs produced the same session id %q; a repeat here is the bug", id)
+		}
+		seen[id] = true
+	}
+}
+
+// TestNewSessionIDGivesEachRunItsOwnLog covers the other half of the collision:
+// the id is also the log file name, so two runs sharing one would append into a
+// single file and leave one capture holding two sessions whose Seq both start
+// at 1.
+func TestNewSessionIDGivesEachRunItsOwnLog(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	first, second := newSessionID("server.py"), newSessionID("server.py")
+	if paths.SessionLogPath(first) == paths.SessionLogPath(second) {
+		t.Fatalf("two runs must not share a log file: %s", paths.SessionLogPath(first))
+	}
+}
+
+// TestNewSessionIDStaysReadable keeps the id greppable and matchable to a
+// process. It is what a person types into `mcpsnoop open` and what the shim
+// prints on startup, so the label has to lead and the PID has to survive.
+func TestNewSessionIDStaysReadable(t *testing.T) {
+	id := newSessionID("server.py")
+	if !strings.HasPrefix(id, "server.py-") {
+		t.Fatalf("session id %q should start with the label", id)
+	}
+	if !strings.Contains(id, fmt.Sprintf("-%d-", os.Getpid())) {
+		t.Fatalf("session id %q should still carry the pid", id)
+	}
+	// The id becomes a file name under the sessions directory, so the suffix
+	// must not introduce a separator. (A label that does is issue #155.)
+	if strings.ContainsAny(id, `/\`) {
+		t.Fatalf("session id %q must be usable as a file name", id)
+	}
+}
+
 // stubShim replaces the shim runner so routing tests can capture the wrapped
 // command without spawning a process, and returns a restore func.
 func stubShim(capture *[]string) func() {

--- a/docs/POST_MORTEM.md
+++ b/docs/POST_MORTEM.md
@@ -41,7 +41,7 @@ If you omit the session, `open` uses the newest saved log, matching `export`.
 
 ```bash
 mcpsnoop open
-mcpsnoop open server.py-48213
+mcpsnoop open server.py-48213-7f3a1c
 mcpsnoop open ./session.jsonl
 ```
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -226,6 +226,12 @@ func (h *Hub) replayFile(path string) {
 }
 
 // emit deduplicates by per-session high-water-mark on Seq, then forwards.
+//
+// This rests on a session id naming exactly one run. Given that, a Seq at or
+// below the mark can only be a frame already seen, from a log replayed on top of
+// the live stream, and dropping it is right. If two runs ever shared an id the
+// second would restart at Seq 1 and be discarded whole, which is why the shim
+// mints a unique id per run rather than trusting the PID to be unique.
 func (h *Hub) emit(env proxy.Envelope) {
 	h.mu.Lock()
 	if env.Seq <= h.seen[env.SessionID].seq {


### PR DESCRIPTION
Closes #153