### PR TITLE
feat(store): flag a request that omits a required routing header

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,11 @@ conditions relevant to a job. Omit the session to check the newest capture, or u
 A name or resource URI that will not fit in an HTTP field value travels Base64 in
 a `=?base64?…?=` sentinel; it is decoded before the comparison, so a client that
 encodes correctly is never flagged.
+The same signal covers a required routing header that is missing entirely, which
+2026-07-28 made a validation failure a compliant server rejects with `400` and
+`-32020`. It is raised only once the session is known to speak that revision or
+later: earlier revisions do not define these headers, so omitting them there is
+correct.
 Use `--format junit` to write one JUnit `<testcase>` per signal and session;
 failures follow the same `--fail-on` selection as the text output.
 

--- a/README.md
+++ b/README.md
@@ -332,11 +332,11 @@ conditions relevant to a job. Omit the session to check the newest capture, or u
 A name or resource URI that will not fit in an HTTP field value travels Base64 in
 a `=?base64?…?=` sentinel; it is decoded before the comparison, so a client that
 encodes correctly is never flagged.
-The same signal covers a required routing header that is missing entirely, which
-2026-07-28 made a validation failure a compliant server rejects with `400` and
-`-32020`. It is raised only once the session is known to speak that revision or
-later: earlier revisions do not define these headers, so omitting them there is
-correct.
+The same signal covers a required routing header that is missing entirely. In
+2026-07-28 that is a validation failure, and a compliant server rejects the
+request with `400` and `-32020`. mcpsnoop raises it only once the session is
+known to speak that revision or later: earlier revisions do not define these
+headers at all, so omitting them there is correct.
 Use `--format junit` to write one JUnit `<testcase>` per signal and session;
 failures follow the same `--fail-on` selection as the text output.
 

--- a/cmd/mcpsnoop/demo.go
+++ b/cmd/mcpsnoop/demo.go
@@ -113,7 +113,7 @@ func demoEnvelope(session string, seq uint64, f demoFrame) proxy.Envelope {
 		Seq:         seq,
 		TS:          time.Now(),
 		Direction:   f.dir,
-		Transport:   "stdio",
+		Transport:   proxy.TransportStdio,
 	}
 	switch {
 	case f.text != "":

--- a/internal/proxy/frame.go
+++ b/internal/proxy/frame.go
@@ -23,6 +23,13 @@ const (
 	DirectionMeta Direction = "meta"
 )
 
+// Transport names the channel an envelope was observed on. The store gates its
+// header checks on this, since only Streamable HTTP has headers to check.
+const (
+	TransportStdio = "stdio"
+	TransportHTTP  = "http"
+)
+
 // SessionMeta describes a proxied session so it can be replayed later (even from
 // a backfilled log). It travels as the first envelope of a session.
 type SessionMeta struct {

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -98,7 +98,7 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 			Seq:                seq.Add(1),
 			TS:                 time.Now(),
 			Direction:          dir,
-			Transport:          "http",
+			Transport:          TransportHTTP,
 			Text:               text,
 			MCPMethod:          r.method,
 			MCPName:            r.name,

--- a/internal/proxy/stdio.go
+++ b/internal/proxy/stdio.go
@@ -88,7 +88,7 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 			Seq:         seq.Add(1),
 			TS:          time.Now(),
 			Direction:   dir,
-			Transport:   "stdio",
+			Transport:   TransportStdio,
 		}
 		if raw != nil {
 			// Copy, because the underlying buffer is reused by the next read.

--- a/internal/store/header_test.go
+++ b/internal/store/header_test.go
@@ -122,3 +122,169 @@ func TestIngestQuotesAControlCharacterInADecodedName(t *testing.T) {
 		t.Fatalf("the newline should be escaped, not dropped, got %q", ev.Warning)
 	}
 }
+
+// httpRequest builds a client frame as it would arrive over Streamable HTTP,
+// with whatever headers the case chose to send.
+func httpRequest(seq uint64, raw string, method, name, version string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: time.Now(),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+		MCPMethod: method, MCPName: name, MCPProtocolVersion: version,
+		Raw: json.RawMessage(raw),
+	}
+}
+
+// call2026 is a tools/call whose _meta declares the revision that made the
+// routing headers mandatory, which is what opens the check.
+const call2026 = `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search",` +
+	`"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`
+
+// TestIngestFlagsMissingRoutingHeaders is the feature: all three are REQUIRED in
+// 2026-07-28, and a compliant server rejects the request with 400 and -32020.
+func TestIngestFlagsMissingRoutingHeaders(t *testing.T) {
+	s := New()
+	ev := s.Ingest(httpRequest(1, call2026, "", "", ""))
+
+	for _, want := range []string{"MCP-Protocol-Version", "Mcp-Method", "Mcp-Name"} {
+		if !strings.Contains(ev.Warning, want) {
+			t.Fatalf("missing %s should be reported, got %q", want, ev.Warning)
+		}
+	}
+	if !ev.RoutingMismatch {
+		t.Fatal("an omitted required header is the same signal as a disagreeing one")
+	}
+}
+
+// TestIngestDemandsMcpNameOnlyWhereTheSpecDoes. The spec names three methods;
+// operationName maps more than that, and demanding the header on the extras
+// would flag a client that is doing nothing wrong.
+func TestIngestDemandsMcpNameOnlyWhereTheSpecDoes(t *testing.T) {
+	for _, tc := range []struct {
+		method, params string
+		wantName       bool
+	}{
+		{"tools/call", `{"name":"search"}`, true},
+		{"resources/read", `{"uri":"file:///a"}`, true},
+		{"prompts/get", `{"name":"p"}`, true},
+		{"tools/list", `{}`, false},
+		{"resources/subscribe", `{"uri":"file:///a"}`, false},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			s := New()
+			raw := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":%q,"params":%s}`, tc.method, tc.params)
+			// Every header but Mcp-Name is present, so Mcp-Name is the only variable.
+			ev := s.Ingest(httpRequest(1, raw, tc.method, "", "2026-07-28"))
+			if got := strings.Contains(ev.Warning, "Mcp-Name"); got != tc.wantName {
+				t.Fatalf("Mcp-Name demanded = %v, want %v (warning %q)", got, tc.wantName, ev.Warning)
+			}
+		})
+	}
+}
+
+// TestIngestDoesNotDemandRoutingHeadersBeforeTheyExisted is the guard that
+// matters most. The headers appear in no revision before 2026-07-28, so a
+// 2025-11-25 client omitting them is correct, and flagging it would fail a
+// default check run on traffic that is doing everything right.
+func TestIngestDoesNotDemandRoutingHeadersBeforeTheyExisted(t *testing.T) {
+	s := New()
+	raw := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search",` +
+		`"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}}`
+	if ev := s.Ingest(httpRequest(1, raw, "", "", "")); ev.Warning != "" || ev.RoutingMismatch {
+		t.Fatalf("a pre-2026-07-28 session must stay clean, got %q", ev.Warning)
+	}
+}
+
+// TestIngestStaysSilentOnAnUnknownVersion. No handshake, no _meta, no header:
+// nothing here says which revision this is, and accusing a client on no evidence
+// is worse than saying nothing.
+func TestIngestStaysSilentOnAnUnknownVersion(t *testing.T) {
+	s := New()
+	raw := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search"}}`
+	if ev := s.Ingest(httpRequest(1, raw, "", "", "")); ev.Warning != "" {
+		t.Fatalf("an unknown protocol version is not evidence, got %q", ev.Warning)
+	}
+}
+
+// TestIngestDoesNotDemandHeadersOnStdio. There are no HTTP headers on stdio, so
+// every stdio frame would be flagged if the transport gate were missing.
+func TestIngestDoesNotDemandHeadersOnStdio(t *testing.T) {
+	s := New()
+	ev := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: time.Now(),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+		Raw: json.RawMessage(call2026),
+	})
+	if ev.Warning != "" || ev.RoutingMismatch {
+		t.Fatalf("stdio has no headers to require, got %q", ev.Warning)
+	}
+}
+
+// TestIngestDoesNotDemandHeadersPerBatchElement. A routing header addresses one
+// operation, so it cannot describe a batch; the store already says so once, and
+// demanding one per element would bury that under noise.
+func TestIngestDoesNotDemandHeadersPerBatchElement(t *testing.T) {
+	s := New()
+	// The session is on the revision that requires the headers, so only the batch
+	// guard stands between this frame and three accusations.
+	s.Ingest(httpRequest(1, call2026, "tools/call", "search", "2026-07-28"))
+	el := httpRequest(2, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search"}}`, "", "", "")
+	el.Batch = true
+	if ev := s.Ingest(el); strings.Contains(ev.Warning, "is missing") {
+		t.Fatalf("a batch element must not be asked for a header that cannot address it, got %q", ev.Warning)
+	}
+}
+
+// TestIngestDemandsHeadersOnANotification is the interpretation this reads into
+// "All requests": a notification carries a method, which is the Source Field the
+// gateway routes on, and a compliant server rejects it the same way. The narrow
+// reading would restrict the check to frames with an id.
+func TestIngestDemandsHeadersOnANotification(t *testing.T) {
+	s := New()
+	s.Ingest(httpRequest(1, call2026, "tools/call", "search", "2026-07-28"))
+	ntf := httpRequest(2, `{"jsonrpc":"2.0","method":"notifications/cancelled"}`, "", "", "")
+	ev := s.Ingest(ntf)
+	if !strings.Contains(ev.Warning, "Mcp-Method") {
+		t.Fatalf("a notification routes on its method too, got %q", ev.Warning)
+	}
+	if strings.Contains(ev.Warning, "Mcp-Name") {
+		t.Fatalf("a notification names no operation, so Mcp-Name is not required, got %q", ev.Warning)
+	}
+}
+
+// TestIngestAcceptsACompliantRequest closes the loop: everything present, on the
+// revision that requires it, is silent.
+func TestIngestAcceptsACompliantRequest(t *testing.T) {
+	s := New()
+	ev := s.Ingest(httpRequest(1, call2026, "tools/call", "search", "2026-07-28"))
+	if ev.Warning != "" || ev.RoutingMismatch {
+		t.Fatalf("a compliant request must stay clean, got %q", ev.Warning)
+	}
+}
+
+// TestIngestDoesNotJudgeAHandshakeByItsOwnProposal is the false positive this
+// check is one condition away from producing. A client proposes the newest
+// revision it supports and the server negotiates down; the store folds the
+// proposal into the session as it reads the request, so the handshake frame
+// would be accused on the strength of a version that was then rejected, and one
+// warning fails a default check run on a wholly correct session.
+func TestIngestDoesNotJudgeAHandshakeByItsOwnProposal(t *testing.T) {
+	s := New()
+	init := httpRequest(1, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":`+
+		`{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"cli"}}}`, "", "", "")
+	if ev := s.Ingest(init); ev.Warning != "" || ev.RoutingMismatch {
+		t.Fatalf("a proposal is not an agreement, got %q", ev.Warning)
+	}
+
+	// The server settles on a revision that has no routing headers at all, so
+	// everything after the handshake stays clean too.
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: time.Now(),
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP, Status: 200,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25",` +
+			`"capabilities":{},"serverInfo":{"name":"old"}}}`),
+	})
+	call := httpRequest(3, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search"}}`, "", "", "")
+	if ev := s.Ingest(call); ev.Warning != "" || ev.RoutingMismatch {
+		t.Fatalf("a session negotiated down to 2025-11-25 must stay clean, got %q", ev.Warning)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -159,6 +159,7 @@ type event struct {
 	mcpName            string // Mcp-Name routing header
 	mcpProtocolVersion string // MCP-Protocol-Version request header
 	batch              bool   // one element of a JSON-RPC batch (routing headers cannot address it)
+	transport          string // the channel this frame was observed on (proxy.TransportHTTP, …)
 	status             int    // HTTP status of the response this frame arrived on (zero on stdio)
 	authChallenge      string // WWW-Authenticate on that response
 	mismatch           bool   // a routing header disagrees with the body (structured flag for warning)
@@ -282,7 +283,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		return EventView{Kind: EventOther} // control frame, not shown in the stream
 	}
 
-	ev := &event{seq: e.Seq, ts: e.TS, dir: e.Direction, raw: e.Raw, text: e.Text, mcpMethod: e.MCPMethod, mcpName: e.MCPName, mcpProtocolVersion: e.MCPProtocolVersion, batch: e.Batch, status: e.Status, authChallenge: e.AuthChallenge}
+	ev := &event{seq: e.Seq, ts: e.TS, dir: e.Direction, raw: e.Raw, text: e.Text, mcpMethod: e.MCPMethod, mcpName: e.MCPName, mcpProtocolVersion: e.MCPProtocolVersion, batch: e.Batch, transport: e.Transport, status: e.Status, authChallenge: e.AuthChallenge}
 
 	if e.Direction == proxy.ServerStderr {
 		ev.kind = EventStderr
@@ -490,6 +491,27 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			ev.warning = appendWarning(ev.warning,
 				"MCP-Protocol-Version header "+ev.mcpProtocolVersion+
 					" disagrees with _meta protocolVersion "+mv)
+			ev.mismatch = true
+		}
+	}
+
+	// Absent headers, as opposed to disagreeing ones. A compliant server rejects
+	// both with 400 and -32020, so they share a signal, but they are different
+	// questions and the guards are not the same: a disagreement needs the header
+	// to be there, this needs to know it should have been.
+	//
+	// initialize is exempt. Its params carry the version the client proposes, not
+	// one anything has agreed to, and the store folds that proposal into the
+	// session before this runs, so judging the handshake by its own opening bid
+	// accuses a client whose server then negotiates down to a revision where these
+	// headers do not exist. The exemption costs nothing on the revision that
+	// requires them: 2026-07-28 removed the initialize handshake (SEP-2575), so a
+	// session genuinely speaking it has no initialize to skip.
+	if ev.transport == proxy.TransportHTTP && e.Direction == proxy.ClientToServer &&
+		!ev.batch && msg.Method != "" && msg.Method != "initialize" &&
+		requestRequiresRoutingHeaders(sess, ev) {
+		for _, h := range missingRoutingHeaders(ev, msg.Method) {
+			ev.warning = appendWarning(ev.warning, "required routing header "+h+" is missing")
 			ev.mismatch = true
 		}
 	}
@@ -1149,6 +1171,54 @@ func operationName(msg proxy.RPCMessage) string {
 	default:
 		return ""
 	}
+}
+
+// routingHeadersRequiredFrom is the revision that introduced the Streamable HTTP
+// routing headers and made them REQUIRED. They do not appear in any earlier
+// revision at all, so a session speaking one of those is correct to omit them.
+const routingHeadersRequiredFrom = "2026-07-28"
+
+// requiresRoutingHeaders reports whether a protocol version mandates them.
+// Revisions are dated YYYY-MM-DD, so string order is chronological, and a named
+// pre-release such as "draft" sorts after every date, which is the right answer:
+// it is ahead of the last release, not behind it. An empty version is false by
+// the same comparison, which is what we want, since a version we never saw is not
+// evidence and guessing would mean accusing a client on none.
+func requiresRoutingHeaders(version string) bool {
+	return version >= routingHeadersRequiredFrom
+}
+
+// requestRequiresRoutingHeaders asks whether this frame is evidence of a
+// revision that mandates the headers. Either source counts on its own: the
+// session may have settled a version through the handshake or through _meta,
+// and a client can also state one in this very request's header without the
+// session having settled anything yet.
+func requestRequiresRoutingHeaders(sess *session, ev *event) bool {
+	return requiresRoutingHeaders(sess.caps.protocolVersion) ||
+		requiresRoutingHeaders(ev.mcpProtocolVersion)
+}
+
+// namedOperationMethods are the three methods whose target Mcp-Name must carry.
+// Deliberately narrower than operationName, which also maps resources/subscribe
+// and resources/unsubscribe: those are not in the spec's table, and demanding a
+// header there would flag a client the spec does not oblige. (They are also gone
+// from 2026-07-28, replaced by subscriptions/listen.)
+var namedOperationMethods = []string{"tools/call", "resources/read", "prompts/get"}
+
+// missingRoutingHeaders lists the standard headers this request had to carry and
+// did not, in the order the spec tabulates them.
+func missingRoutingHeaders(ev *event, method string) []string {
+	var missing []string
+	if ev.mcpProtocolVersion == "" {
+		missing = append(missing, "MCP-Protocol-Version")
+	}
+	if ev.mcpMethod == "" {
+		missing = append(missing, "Mcp-Method")
+	}
+	if ev.mcpName == "" && slices.Contains(namedOperationMethods, method) {
+		missing = append(missing, "Mcp-Name")
+	}
+	return missing
 }
 
 // metaProtocolVersion returns the protocol version a request repeats in its

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -113,9 +113,12 @@ func TestIngestProtocolVersionMismatch(t *testing.T) {
 	// The MCP-Protocol-Version header says 2026-07-28 but the version the request
 	// repeats in its _meta says otherwise. A gateway routes on the header while the
 	// server reads the body, so flag the disagreement.
+	// The routing headers are filled in on every frame here so the version
+	// disagreement stays the only variable: on 2026-07-28 they are REQUIRED, and a
+	// frame omitting them would carry a second, unrelated warning.
 	bad := proxy.Envelope{
 		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
-		Transport: "http", MCPProtocolVersion: "2026-07-28",
+		Transport: "http", MCPProtocolVersion: "2026-07-28", MCPMethod: "tools/call", MCPName: "echo",
 		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}}`),
 	}
 	ev := s.Ingest(bad)
@@ -129,7 +132,7 @@ func TestIngestProtocolVersionMismatch(t *testing.T) {
 	// Header agreeing with the _meta version is clean.
 	good := proxy.Envelope{
 		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ClientToServer,
-		Transport: "http", MCPProtocolVersion: "2026-07-28",
+		Transport: "http", MCPProtocolVersion: "2026-07-28", MCPMethod: "tools/call", MCPName: "echo",
 		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`),
 	}
 	if g := s.Ingest(good); g.RoutingMismatch || strings.Contains(g.Warning, "disagrees") {
@@ -139,7 +142,7 @@ func TestIngestProtocolVersionMismatch(t *testing.T) {
 	// Header present but no _meta version means nothing to disagree with.
 	noMeta := proxy.Envelope{
 		SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: now, Direction: proxy.ClientToServer,
-		Transport: "http", MCPProtocolVersion: "2026-07-28",
+		Transport: "http", MCPProtocolVersion: "2026-07-28", MCPMethod: "tools/list",
 		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":3,"method":"tools/list"}`),
 	}
 	if g := s.Ingest(noMeta); g.RoutingMismatch {


### PR DESCRIPTION
Closes #156 