### PR TITLE
fix(proxy): flag stdio and SSE frames truncated at observe cap

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -229,8 +229,14 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 			}
 			if strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
 				// Streaming case, tap SSE data frames as bytes flow to the client.
-				resp.Body = newSSETap(resp.Body, func(data []byte) {
-					emitFrames(emit, ServerToClient, data, rt)
+				resp.Body = newSSETap(resp.Body, func(data []byte, truncated bool) {
+					r := rt
+					if truncated {
+						r.truncated = true
+						emit(ServerToClient, data, r)
+						return
+					}
+					emitFrames(emit, ServerToClient, data, r)
 				})
 				return nil
 			}
@@ -309,13 +315,14 @@ func emitFrames(emit func(Direction, []byte, route), dir Direction, body []byte,
 // sseTap passes SSE bytes through unchanged while extracting each event's
 // `data:` payload (one JSON-RPC message per event) for observation.
 type sseTap struct {
-	rc      io.ReadCloser
-	onData  func([]byte)
-	lineBuf bytes.Buffer
-	dataBuf bytes.Buffer
+	rc        io.ReadCloser
+	onData    func([]byte, bool)
+	lineBuf   bytes.Buffer
+	dataBuf   bytes.Buffer
+	truncated bool
 }
 
-func newSSETap(rc io.ReadCloser, onData func([]byte)) *sseTap {
+func newSSETap(rc io.ReadCloser, onData func([]byte, bool)) *sseTap {
 	return &sseTap{rc: rc, onData: onData}
 }
 
@@ -348,21 +355,33 @@ func (t *sseTap) feed(b []byte) {
 func (t *sseTap) line(l []byte) {
 	if len(l) == 0 { // blank line ends an event
 		if t.dataBuf.Len() > 0 {
-			t.onData(append([]byte(nil), t.dataBuf.Bytes()...))
+			t.onData(append([]byte(nil), t.dataBuf.Bytes()...), t.truncated)
 			t.dataBuf.Reset()
+			t.truncated = false
 		}
 		return
 	}
 	if rest, ok := bytes.CutPrefix(l, []byte("data:")); ok {
-		// Cap the observed event so a stream that never sends its terminating
-		// blank line cannot grow this buffer without bound.
-		if t.dataBuf.Len() >= maxFrameBytes {
+		rest = bytes.TrimPrefix(rest, []byte(" "))
+		room := sseDataObserveCap - t.dataBuf.Len()
+		if room <= 0 {
+			t.truncated = true
 			return
 		}
 		if t.dataBuf.Len() > 0 {
+			if room == 0 {
+				t.truncated = true
+				return
+			}
 			t.dataBuf.WriteByte('\n')
+			room--
 		}
-		t.dataBuf.Write(bytes.TrimPrefix(rest, []byte(" ")))
+		if len(rest) > room {
+			t.dataBuf.Write(rest[:room])
+			t.truncated = true
+			return
+		}
+		t.dataBuf.Write(rest)
 	}
 	// other SSE fields (event:, id:, retry:) are ignored
 }
@@ -374,8 +393,9 @@ func (t *sseTap) Close() error {
 		t.lineBuf.Reset()
 	}
 	if t.dataBuf.Len() > 0 {
-		t.onData(append([]byte(nil), t.dataBuf.Bytes()...))
+		t.onData(append([]byte(nil), t.dataBuf.Bytes()...), t.truncated)
 		t.dataBuf.Reset()
+		t.truncated = false
 	}
 	return t.rc.Close()
 }

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -229,9 +229,14 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 			}
 			if strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
 				// Streaming case, tap SSE data frames as bytes flow to the client.
-				resp.Body = newSSETap(resp.Body, func(data []byte, truncated bool) {
+				resp.Body = newSSETap(resp.Body, maxFrameBytes, func(data []byte, truncated bool) {
 					r := rt
 					if truncated {
+						// A cut event is a fragment, so it is emitted whole and flagged
+						// rather than split and parsed as if complete. emit routes it
+						// through splitObserved, which puts a fragment in Text: Raw is a
+						// json.RawMessage and an invalid one makes the envelope fail to
+						// marshal in the sinks.
 						r.truncated = true
 						emit(ServerToClient, data, r)
 						return
@@ -314,16 +319,23 @@ func emitFrames(emit func(Direction, []byte, route), dir Direction, body []byte,
 
 // sseTap passes SSE bytes through unchanged while extracting each event's
 // `data:` payload (one JSON-RPC message per event) for observation.
+//
+// cap bounds what is kept, never what is forwarded, and it bounds two distinct
+// pathologies with one number: a server that never sends a newline, which would
+// grow lineBuf, and a stream that never sends its terminating blank line, which
+// would grow dataBuf. Either cut sets truncated, so a fragment is reported as
+// short rather than read as a corrupted frame.
 type sseTap struct {
 	rc        io.ReadCloser
+	cap       int
 	onData    func([]byte, bool)
 	lineBuf   bytes.Buffer
 	dataBuf   bytes.Buffer
 	truncated bool
 }
 
-func newSSETap(rc io.ReadCloser, onData func([]byte, bool)) *sseTap {
-	return &sseTap{rc: rc, onData: onData}
+func newSSETap(rc io.ReadCloser, cap int, onData func([]byte, bool)) *sseTap {
+	return &sseTap{rc: rc, cap: cap, onData: onData}
 }
 
 func (t *sseTap) Read(p []byte) (int, error) {
@@ -345,8 +357,10 @@ func (t *sseTap) feed(b []byte) {
 		default:
 			// Cap the observed line so a server that never sends a newline cannot
 			// grow this buffer without bound. Forwarding is unaffected.
-			if t.lineBuf.Len() < maxFrameBytes {
+			if t.lineBuf.Len() < t.cap {
 				t.lineBuf.WriteByte(c)
+			} else {
+				t.truncated = true
 			}
 		}
 	}
@@ -362,17 +376,17 @@ func (t *sseTap) line(l []byte) {
 		return
 	}
 	if rest, ok := bytes.CutPrefix(l, []byte("data:")); ok {
+		// Trim the optional single space before measuring, so the cap bounds the
+		// payload rather than the payload plus SSE framing.
 		rest = bytes.TrimPrefix(rest, []byte(" "))
-		room := sseDataObserveCap - t.dataBuf.Len()
+		room := t.cap - t.dataBuf.Len()
 		if room <= 0 {
 			t.truncated = true
 			return
 		}
 		if t.dataBuf.Len() > 0 {
-			if room == 0 {
-				t.truncated = true
-				return
-			}
+			// A multi-line event joins its data fields with a newline, and that
+			// newline counts against the cap like any other kept byte.
 			t.dataBuf.WriteByte('\n')
 			room--
 		}

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -423,7 +423,7 @@ func TestHTTPProxySSE(t *testing.T) {
 
 func TestSSETapMultiChunk(t *testing.T) {
 	var got []string
-	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte, _ bool) { got = append(got, string(d)) })
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), maxFrameBytes, func(d []byte, _ bool) { got = append(got, string(d)) })
 	// Feed split across arbitrary chunk boundaries.
 	for _, chunk := range []string{"data: {\"a\":", "1}\n", "\nda", "ta: {\"b\":2}\n\n"} {
 		tap.feed([]byte(chunk))
@@ -435,7 +435,7 @@ func TestSSETapMultiChunk(t *testing.T) {
 
 func TestSSETapMultilineData(t *testing.T) {
 	var got []string
-	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte, _ bool) { got = append(got, string(d)) })
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), maxFrameBytes, func(d []byte, _ bool) { got = append(got, string(d)) })
 
 	tap.feed([]byte("data: first line\ndata: second line\n\n"))
 
@@ -445,15 +445,18 @@ func TestSSETapMultilineData(t *testing.T) {
 }
 
 // TestSSETapFlagsTruncated checks that an SSE event whose observed copy exceeds
-// the frame cap is reported as truncated rather than parsed as a whole frame.
+// the cap is reported as truncated rather than parsed as a whole frame.
+//
+// The assertion is the invariant, not an exact length. One cap now bounds two
+// distinct pathologies, a line that never ends and an event that never ends, so
+// where the cut lands depends on which one is hit first; pinning a number would
+// test that arithmetic rather than the contract.
 func TestSSETapFlagsTruncated(t *testing.T) {
-	old := sseDataObserveCap
-	sseDataObserveCap = 16
-	t.Cleanup(func() { sseDataObserveCap = old })
+	const observeCap = 16
 
 	var observed []byte
 	var truncated bool
-	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte, tr bool) {
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), observeCap, func(d []byte, tr bool) {
 		observed = append([]byte(nil), d...)
 		truncated = tr
 	})
@@ -462,8 +465,30 @@ func TestSSETapFlagsTruncated(t *testing.T) {
 	if !truncated {
 		t.Fatal("expected truncated=true for an oversized SSE event")
 	}
-	if len(observed) != 16 {
-		t.Fatalf("observed len = %d, want 16", len(observed))
+	if len(observed) == 0 || len(observed) > observeCap {
+		t.Fatalf("observed len = %d, want between 1 and %d", len(observed), observeCap)
+	}
+}
+
+// TestSSETapKeepsAWholeEventUnflagged pins the other side, since a cap that is
+// always tripped would satisfy the test above while flagging every frame of a
+// real session.
+func TestSSETapKeepsAWholeEventUnflagged(t *testing.T) {
+	const msg = `{"jsonrpc":"2.0","id":1,"result":{}}`
+
+	var observed []byte
+	var truncated bool
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), maxFrameBytes, func(d []byte, tr bool) {
+		observed = append([]byte(nil), d...)
+		truncated = tr
+	})
+	tap.feed([]byte("data: " + msg + "\n\n"))
+
+	if truncated {
+		t.Fatal("an event well inside the cap must not be flagged")
+	}
+	if string(observed) != msg {
+		t.Fatalf("observed %q, want the whole event %q", observed, msg)
 	}
 }
 

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -423,7 +423,7 @@ func TestHTTPProxySSE(t *testing.T) {
 
 func TestSSETapMultiChunk(t *testing.T) {
 	var got []string
-	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte) { got = append(got, string(d)) })
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte, _ bool) { got = append(got, string(d)) })
 	// Feed split across arbitrary chunk boundaries.
 	for _, chunk := range []string{"data: {\"a\":", "1}\n", "\nda", "ta: {\"b\":2}\n\n"} {
 		tap.feed([]byte(chunk))
@@ -435,12 +435,35 @@ func TestSSETapMultiChunk(t *testing.T) {
 
 func TestSSETapMultilineData(t *testing.T) {
 	var got []string
-	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte) { got = append(got, string(d)) })
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte, _ bool) { got = append(got, string(d)) })
 
 	tap.feed([]byte("data: first line\ndata: second line\n\n"))
 
 	if len(got) != 1 || got[0] != "first line\nsecond line" {
 		t.Fatalf("sseTap parsed %v", got)
+	}
+}
+
+// TestSSETapFlagsTruncated checks that an SSE event whose observed copy exceeds
+// the frame cap is reported as truncated rather than parsed as a whole frame.
+func TestSSETapFlagsTruncated(t *testing.T) {
+	old := sseDataObserveCap
+	sseDataObserveCap = 16
+	t.Cleanup(func() { sseDataObserveCap = old })
+
+	var observed []byte
+	var truncated bool
+	tap := newSSETap(io.NopCloser(strings.NewReader("")), func(d []byte, tr bool) {
+		observed = append([]byte(nil), d...)
+		truncated = tr
+	})
+	tap.feed([]byte("data: " + strings.Repeat("x", 32) + "\n\n"))
+
+	if !truncated {
+		t.Fatal("expected truncated=true for an oversized SSE event")
+	}
+	if len(observed) != 16 {
+		t.Fatalf("observed len = %d, want 16", len(observed))
 	}
 }
 

--- a/internal/proxy/stdio.go
+++ b/internal/proxy/stdio.go
@@ -40,13 +40,11 @@ type StdioConfig struct {
 // maxFrameBytes caps a single JSON-RPC line we will buffer while peeking. The
 // data path itself is unbounded (we stream in chunks), this only bounds the
 // copy we hand to the Sink so a pathological line can't blow up memory.
+//
+// The taps take their cap as an argument rather than reading this directly, so a
+// test can exercise the truncation path without a global to mutate. newBodyTap
+// already worked that way; pumpFrames and sseTap now match it.
 const maxFrameBytes = 16 << 20 // 16 MiB
-
-// frameObserveCap is the observation cap used by pumpFrames. Tests may lower it.
-var frameObserveCap = maxFrameBytes
-
-// sseDataObserveCap bounds the observed SSE event payload. Tests may lower it.
-var sseDataObserveCap = maxFrameBytes
 
 // RunStdio spawns the wrapped server and proxies stdio transparently between the
 // client (our stdin/stdout) and the server, observing every newline-delimited
@@ -87,7 +85,7 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 	}
 
 	var seq atomic.Uint64
-	emit := func(dir Direction, raw []byte, text string) {
+	emit := func(dir Direction, raw []byte, text string, truncated bool) {
 		env := Envelope{
 			SessionID:   cfg.SessionID,
 			ServerLabel: cfg.Label,
@@ -95,6 +93,7 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 			TS:          time.Now(),
 			Direction:   dir,
 			Transport:   TransportStdio,
+			Truncated:   truncated,
 		}
 		if raw != nil {
 			// Copy, because the underlying buffer is reused by the next read.
@@ -108,27 +107,23 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 	// Text otherwise, so a stray non-JSON line still reaches the hub instead of
 	// failing to encode. Forwarding is unaffected, the bytes are already written
 	// downstream before observe runs.
+	//
+	// A truncated line takes the same route, and must: it is a fragment, so it is
+	// never valid JSON, and Envelope.Raw is a json.RawMessage that both sinks
+	// encode with encoding/json. Putting a fragment there makes the envelope fail
+	// to marshal, and the sinks answer that differently but both badly. AsyncSink
+	// discards the write, so the frame never reaches the trace file; SocketSink
+	// reads the error as the hub having gone away and drops the connection. The
+	// flag is what says the copy is short; splitObserved decides where the bytes
+	// go.
 	observe := func(dir Direction, line []byte, truncated bool) {
-		if truncated {
-			sink.Emit(Envelope{
-				SessionID:   cfg.SessionID,
-				ServerLabel: cfg.Label,
-				Seq:         seq.Add(1),
-				TS:          time.Now(),
-				Direction:   dir,
-				Transport:   TransportStdio,
-				Raw:         append([]byte(nil), line...),
-				Truncated:   true,
-			})
-			return
-		}
 		raw, text := splitObserved(line)
-		emit(dir, raw, text)
+		emit(dir, raw, text, truncated)
 	}
 
 	// Emit the session meta first (seq 1) so the hub can replay this server.
 	if meta, mErr := json.Marshal(SessionMeta{Command: cfg.Command, CWD: cwd()}); mErr == nil {
-		emit(DirectionMeta, meta, "")
+		emit(DirectionMeta, meta, "", false)
 	}
 
 	// client -> server. Deliberately NOT awaited below. This pump blocks reading the
@@ -142,7 +137,9 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 	go func() {
 		// Closing the server's stdin signals EOF so it can shut down cleanly.
 		defer srvStdin.Close()
-		pumpFrames(in, srvStdin, func(line []byte, truncated bool) { observe(ClientToServer, line, truncated) })
+		pumpFrames(in, srvStdin, maxFrameBytes, func(line []byte, truncated bool) {
+			observe(ClientToServer, line, truncated)
+		})
 	}()
 
 	var wg sync.WaitGroup
@@ -151,13 +148,15 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 	// server -> client
 	go func() {
 		defer wg.Done()
-		pumpFrames(srvStdout, out, func(line []byte, truncated bool) { observe(ServerToClient, line, truncated) })
+		pumpFrames(srvStdout, out, maxFrameBytes, func(line []byte, truncated bool) {
+			observe(ServerToClient, line, truncated)
+		})
 	}()
 
 	// server stderr -> our stderr (forwarded) + observed line-by-line
 	go func() {
 		defer wg.Done()
-		pumpLines(srvStderr, errOut, func(line string) { emit(ServerStderr, nil, line) })
+		pumpLines(srvStderr, errOut, func(line string) { emit(ServerStderr, nil, line, false) })
 	}()
 
 	wg.Wait()
@@ -175,10 +174,16 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 
 // pumpFrames copies src->dst losslessly while splitting on newlines for
 // observation. Each complete line (without the trailing newline) is passed to
-// observe. The exact bytes read are always written to dst first, so a slow or
-// failing observer can never affect the forwarded stream. Lines longer than
-// frameObserveCap are still forwarded, only the observed copy is truncated.
-func pumpFrames(src io.Reader, dst io.Writer, observe func(line []byte, truncated bool)) {
+// observe, along with whether the observed copy was cut at observeCap. The exact
+// bytes read are always written to dst first, so a slow or failing observer can
+// never affect the forwarded stream. Lines longer than observeCap are still
+// forwarded in full, only the copy is short.
+//
+// The flag matters as much as the copy. A cut line is not valid JSON, so without
+// it the store reads the fragment as a stray non-JSON line and reports the
+// stream as corrupted, which is a diagnosis about the server rather than about
+// the observer's own cap.
+func pumpFrames(src io.Reader, dst io.Writer, observeCap int, observe func(line []byte, truncated bool)) {
 	r := bufio.NewReaderSize(src, 64<<10)
 	var pending []byte // accumulated bytes of the current (unterminated) line
 	var truncated bool
@@ -192,24 +197,26 @@ func pumpFrames(src io.Reader, dst io.Writer, observe func(line []byte, truncate
 			if f, ok := dst.(interface{ Flush() error }); ok {
 				_ = f.Flush()
 			}
-			room := frameObserveCap - len(pending)
-			if room <= 0 {
+			switch room := observeCap - len(pending); {
+			case room <= 0:
 				truncated = true
-			} else if len(chunk) > room {
+			case len(chunk) > room:
 				pending = append(pending, chunk[:room]...)
 				truncated = true
-			} else {
+			default:
 				pending = append(pending, chunk...)
 			}
 			if chunk[len(chunk)-1] == '\n' {
+				// The chunk ends the line, but the copy may not: once the cap is
+				// reached the terminator is among the bytes we stopped taking. Strip
+				// only what is actually present, or a truncated line loses a byte of
+				// its own content to a terminator that never made it into the copy.
 				line := pending
 				if len(line) > 0 && line[len(line)-1] == '\n' {
 					line = line[:len(line)-1]
 					if len(line) > 0 && line[len(line)-1] == '\r' {
 						line = line[:len(line)-1]
 					}
-				} else if len(line) > 0 && line[len(line)-1] == '\r' {
-					line = line[:len(line)-1]
 				}
 				if len(line) > 0 {
 					observe(line, truncated)
@@ -244,9 +251,16 @@ func pumpLines(src io.Reader, dst io.Writer, observe func(line string)) {
 				pending = append(pending, chunk...)
 			}
 			if chunk[len(chunk)-1] == '\n' {
-				line := pending[:len(pending)-1]
-				if len(line) > 0 && line[len(line)-1] == '\r' {
+				// Same care as pumpFrames: past the cap the copy no longer ends with
+				// the terminator, so strip only what is there. Stderr is text and
+				// goes to Text either way, so a cut line costs a byte rather than a
+				// misdiagnosis, but the arithmetic should still be honest.
+				line := pending
+				if len(line) > 0 && line[len(line)-1] == '\n' {
 					line = line[:len(line)-1]
+					if len(line) > 0 && line[len(line)-1] == '\r' {
+						line = line[:len(line)-1]
+					}
 				}
 				observe(string(line))
 				pending = nil

--- a/internal/proxy/stdio.go
+++ b/internal/proxy/stdio.go
@@ -42,6 +42,12 @@ type StdioConfig struct {
 // copy we hand to the Sink so a pathological line can't blow up memory.
 const maxFrameBytes = 16 << 20 // 16 MiB
 
+// frameObserveCap is the observation cap used by pumpFrames. Tests may lower it.
+var frameObserveCap = maxFrameBytes
+
+// sseDataObserveCap bounds the observed SSE event payload. Tests may lower it.
+var sseDataObserveCap = maxFrameBytes
+
 // RunStdio spawns the wrapped server and proxies stdio transparently between the
 // client (our stdin/stdout) and the server, observing every newline-delimited
 // JSON-RPC frame. It returns the server's exit code and any startup error.
@@ -102,7 +108,20 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 	// Text otherwise, so a stray non-JSON line still reaches the hub instead of
 	// failing to encode. Forwarding is unaffected, the bytes are already written
 	// downstream before observe runs.
-	observe := func(dir Direction, line []byte) {
+	observe := func(dir Direction, line []byte, truncated bool) {
+		if truncated {
+			sink.Emit(Envelope{
+				SessionID:   cfg.SessionID,
+				ServerLabel: cfg.Label,
+				Seq:         seq.Add(1),
+				TS:          time.Now(),
+				Direction:   dir,
+				Transport:   TransportStdio,
+				Raw:         append([]byte(nil), line...),
+				Truncated:   true,
+			})
+			return
+		}
 		raw, text := splitObserved(line)
 		emit(dir, raw, text)
 	}
@@ -123,7 +142,7 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 	go func() {
 		// Closing the server's stdin signals EOF so it can shut down cleanly.
 		defer srvStdin.Close()
-		pumpFrames(in, srvStdin, func(line []byte) { observe(ClientToServer, line) })
+		pumpFrames(in, srvStdin, func(line []byte, truncated bool) { observe(ClientToServer, line, truncated) })
 	}()
 
 	var wg sync.WaitGroup
@@ -132,7 +151,7 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 	// server -> client
 	go func() {
 		defer wg.Done()
-		pumpFrames(srvStdout, out, func(line []byte) { observe(ServerToClient, line) })
+		pumpFrames(srvStdout, out, func(line []byte, truncated bool) { observe(ServerToClient, line, truncated) })
 	}()
 
 	// server stderr -> our stderr (forwarded) + observed line-by-line
@@ -158,10 +177,11 @@ func RunStdio(ctx context.Context, cfg StdioConfig) (exitCode int, err error) {
 // observation. Each complete line (without the trailing newline) is passed to
 // observe. The exact bytes read are always written to dst first, so a slow or
 // failing observer can never affect the forwarded stream. Lines longer than
-// maxFrameBytes are still forwarded, only the observed copy is truncated.
-func pumpFrames(src io.Reader, dst io.Writer, observe func(line []byte)) {
+// frameObserveCap are still forwarded, only the observed copy is truncated.
+func pumpFrames(src io.Reader, dst io.Writer, observe func(line []byte, truncated bool)) {
 	r := bufio.NewReaderSize(src, 64<<10)
 	var pending []byte // accumulated bytes of the current (unterminated) line
+	var truncated bool
 	for {
 		chunk, err := r.ReadSlice('\n')
 		if len(chunk) > 0 {
@@ -172,20 +192,30 @@ func pumpFrames(src io.Reader, dst io.Writer, observe func(line []byte)) {
 			if f, ok := dst.(interface{ Flush() error }); ok {
 				_ = f.Flush()
 			}
-			if len(pending) < maxFrameBytes {
+			room := frameObserveCap - len(pending)
+			if room <= 0 {
+				truncated = true
+			} else if len(chunk) > room {
+				pending = append(pending, chunk[:room]...)
+				truncated = true
+			} else {
 				pending = append(pending, chunk...)
 			}
 			if chunk[len(chunk)-1] == '\n' {
 				line := pending
-				// Strip trailing \n and optional \r.
-				line = line[:len(line)-1]
-				if len(line) > 0 && line[len(line)-1] == '\r' {
+				if len(line) > 0 && line[len(line)-1] == '\n' {
+					line = line[:len(line)-1]
+					if len(line) > 0 && line[len(line)-1] == '\r' {
+						line = line[:len(line)-1]
+					}
+				} else if len(line) > 0 && line[len(line)-1] == '\r' {
 					line = line[:len(line)-1]
 				}
 				if len(line) > 0 {
-					observe(line)
+					observe(line, truncated)
 				}
 				pending = nil
+				truncated = false
 			}
 		}
 		if err == bufio.ErrBufferFull {
@@ -193,7 +223,7 @@ func pumpFrames(src io.Reader, dst io.Writer, observe func(line []byte)) {
 		}
 		if err != nil {
 			if len(pending) > 0 {
-				observe(pending)
+				observe(pending, truncated)
 			}
 			return
 		}

--- a/internal/proxy/stdio_test.go
+++ b/internal/proxy/stdio_test.go
@@ -194,28 +194,107 @@ func TestStdioNonJSONLine(t *testing.T) {
 	}
 }
 
-// TestPumpFramesFlagsTruncated checks that stdio observation marks oversized lines
-// as truncated so the store does not classify them as stream corruption.
+// TestPumpFramesFlagsTruncated checks that stdio observation marks an oversized
+// line as truncated, so the store reports a capped copy rather than diagnosing
+// the server's stream as corrupted.
+//
+// The cap is an argument rather than a package variable a test lowers: mutating
+// shared state to reach a branch leaves the branch reachable from anywhere, and
+// this package runs its taps from goroutines.
 func TestPumpFramesFlagsTruncated(t *testing.T) {
-	old := frameObserveCap
-	frameObserveCap = 32
-	t.Cleanup(func() { frameObserveCap = old })
-
+	const observeCap = 32
 	line := strings.Repeat("x", 48) + "\n"
+
 	var out bytes.Buffer
 	var truncated bool
 	var observed []byte
-	pumpFrames(strings.NewReader(line), &out, func(l []byte, tr bool) {
+	pumpFrames(strings.NewReader(line), &out, observeCap, func(l []byte, tr bool) {
 		observed = append([]byte(nil), l...)
 		truncated = tr
 	})
+
+	// Forwarding first: the observer's cap must never reach the data path.
 	if out.String() != line {
 		t.Fatalf("passthrough mismatch: got %q want %q", out.String(), line)
 	}
 	if !truncated {
 		t.Fatal("expected truncated=true for an oversized stdio line")
 	}
-	if len(observed) != 32 {
-		t.Fatalf("observed len = %d, want 32", len(observed))
+	if len(observed) != observeCap {
+		t.Fatalf("observed len = %d, want %d", len(observed), observeCap)
+	}
+	// The copy stops short of the terminator, so nothing may be stripped as one.
+	// Every byte here is content, and a line that lost one to terminator handling
+	// would come back shorter than the cap.
+	if strings.Trim(string(observed), "x") != "" {
+		t.Fatalf("a truncated copy lost content to terminator stripping: %q", observed)
+	}
+}
+
+// TestPumpFramesLeavesAWholeLineUnflagged pins the other side. A cap that always
+// trips would satisfy the test above while flagging every frame of a real
+// session, and the terminator must still be stripped when it is actually there.
+func TestPumpFramesLeavesAWholeLineUnflagged(t *testing.T) {
+	const frame = `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+
+	var out bytes.Buffer
+	var truncated bool
+	var observed []byte
+	pumpFrames(strings.NewReader(frame+"\r\n"), &out, maxFrameBytes, func(l []byte, tr bool) {
+		observed = append([]byte(nil), l...)
+		truncated = tr
+	})
+
+	if truncated {
+		t.Fatal("a line well inside the cap must not be flagged")
+	}
+	if string(observed) != frame {
+		t.Fatalf("observed %q, want the frame without its CRLF: %q", observed, frame)
+	}
+}
+
+// TestTruncatedFrameSurvivesTheSink is the regression the truncation flag turns
+// on. Envelope.Raw is a json.RawMessage, and both sinks encode the envelope with
+// encoding/json, which validates it. A truncated frame is a fragment and so is
+// never valid JSON, so putting one in Raw makes the whole envelope fail to
+// marshal. The two sinks answer that differently and both badly: AsyncSink
+// discards the write, so the frame never reaches the trace file, and SocketSink
+// reads the error as the hub having gone away and drops the connection.
+//
+// splitObserved is what keeps that from happening: a fragment goes to Text,
+// which encodes fine, and the flag is what says the copy is short.
+func TestTruncatedFrameSurvivesTheSink(t *testing.T) {
+	// Valid JSON in full, a fragment once capped, which is the shape of every
+	// frame this path exists for.
+	full := `{"jsonrpc":"2.0","id":1,"result":{"content":"` + strings.Repeat("y", 64) + `"}}`
+	fragment := full[:40]
+	if json.Valid([]byte(fragment)) {
+		t.Fatal("this test needs a prefix that is not valid JSON on its own")
+	}
+
+	var buf bytes.Buffer
+	sink := NewAsyncSink(&buf, 16)
+	raw, text := splitObserved([]byte(fragment))
+	sink.Emit(Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: time.Now(),
+		Direction: ServerToClient, Transport: TransportStdio,
+		Raw: raw, Text: text, Truncated: true,
+	})
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("the truncated frame never reached the sink: %v (wrote %q)", err, buf.String())
+	}
+	if !env.Truncated {
+		t.Fatal("the frame should arrive flagged truncated")
+	}
+	if len(env.Raw) != 0 {
+		t.Fatalf("a fragment must not travel in Raw, it is not valid JSON: %s", env.Raw)
+	}
+	if env.Text != fragment {
+		t.Fatalf("the fragment should survive in Text, got %q", env.Text)
 	}
 }

--- a/internal/proxy/stdio_test.go
+++ b/internal/proxy/stdio_test.go
@@ -193,3 +193,29 @@ func TestStdioNonJSONLine(t *testing.T) {
 		}
 	}
 }
+
+// TestPumpFramesFlagsTruncated checks that stdio observation marks oversized lines
+// as truncated so the store does not classify them as stream corruption.
+func TestPumpFramesFlagsTruncated(t *testing.T) {
+	old := frameObserveCap
+	frameObserveCap = 32
+	t.Cleanup(func() { frameObserveCap = old })
+
+	line := strings.Repeat("x", 48) + "\n"
+	var out bytes.Buffer
+	var truncated bool
+	var observed []byte
+	pumpFrames(strings.NewReader(line), &out, func(l []byte, tr bool) {
+		observed = append([]byte(nil), l...)
+		truncated = tr
+	})
+	if out.String() != line {
+		t.Fatalf("passthrough mismatch: got %q want %q", out.String(), line)
+	}
+	if !truncated {
+		t.Fatal("expected truncated=true for an oversized stdio line")
+	}
+	if len(observed) != 32 {
+		t.Fatalf("observed len = %d, want 32", len(observed))
+	}
+}


### PR DESCRIPTION
## Summary

Mark stdio and SSE observations as `Truncated` when mcpsnoop caps its copy at the frame-size limit, matching the existing HTTP `bodyTap` behavior.

## Motivation

Oversized stdio JSON-RPC lines and large SSE events were forwarded correctly but their capped observed copies were classified as stream corruption (`EventInvalid`) during `check`, because `Truncated` was never set on those paths.

Fixes #151

## Changes

- `pumpFrames`: track when the observed copy exceeds `frameObserveCap` and emit `Envelope.Truncated` instead of routing through `splitObserved`
- `sseTap`: set `truncated` when the event payload exceeds `sseDataObserveCap` and emit a single flagged frame (same as `observeBody` for HTTP)
- Fix newline stripping when the observed copy was capped before the line terminator was buffered
- Add regression tests for both paths

## Tests

- `go test -race ./internal/proxy/...` — PASS
- `make check` — all packages pass except two pre-existing TUI style tests on `main` (`TestStreamRowShowsSupersededStatusInWarnStyle`, `TestStatusStyleWarnsOnTruncated`)

## Notes

- Observation remains best-effort; the proxied byte stream is unchanged
- Reviewed with composer-2.5 — APPROVE