### PR TITLE
feat(store): name the spec-defined error codes and flag the retired ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,9 @@ The same signal covers a required routing header that is missing entirely. In
 request with `400` and `-32020`. mcpsnoop raises it only once the session is
 known to speak that revision or later: earlier revisions do not define these
 headers at all, so omitting them there is correct.
+A server's own `-32020` rejection counts as the same signal. The server validates
+`Mcp-Param-{Name}` values and header encodings that mcpsnoop never sees, so its
+verdict is sometimes the only evidence a mismatch happened.
 Use `--format junit` to write one JUnit `<testcase>` per signal and session;
 failures follow the same `--fail-on` selection as the text output.
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -127,6 +127,10 @@ type CallExport struct {
 	Params     json.RawMessage `json:"params,omitempty"`
 	Result     json.RawMessage `json:"result,omitempty"`
 	Error      *proxy.RPCError `json:"error,omitempty"`
+	// ErrorName is the specification's name for Error.Code, absent when the code
+	// is one the spec leaves to implementations. A sibling rather than a field
+	// inside Error, so the error object stays the wire shape.
+	ErrorName string `json:"error_name,omitempty"`
 }
 
 type EventExport struct {
@@ -565,6 +569,7 @@ func exportCall(index int, c store.CallView) CallExport {
 		Params:     c.Params,
 		Result:     c.Result,
 		Error:      c.Err,
+		ErrorName:  errorName(c.Err),
 	}
 	// A superseded call was never answered; its stored end is the moment the id was
 	// reused, not a latency, so omit the duration the way a pending call does.
@@ -672,6 +677,15 @@ func writeHTML(w io.Writer, data SessionExport) error {
 		Title: "mcpsnoop " + data.Session.Label,
 		Data:  template.JS(payload),
 	})
+}
+
+// errorName is ErrorCodeName over a possibly absent error, kept next to the
+// call export so the nil case is answered once rather than at each caller.
+func errorName(err *proxy.RPCError) string {
+	if err == nil {
+		return ""
+	}
+	return store.ErrorCodeName(err.Code)
 }
 
 func eventKind(k store.EventKind) string {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -510,5 +511,36 @@ func TestExportCarriesTheTransportEvent(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "transport") {
 		t.Fatalf("the text export should name the kind, got %q", buf.String())
+	}
+}
+
+// TestExportNamesASpecDefinedErrorCode. The export is what a script reads, so
+// the name rides alongside the wire error rather than inside it, and a code the
+// spec leaves to implementations carries no name at all.
+func TestExportNamesASpecDefinedErrorCode(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want string
+	}{
+		{-32020, "header mismatch"},
+		{-32001, ""},
+	} {
+		st := store.New()
+		ingest(t, st,
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`,
+			fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"error":{"code":%d,"message":"nope"}}`, tc.code))
+		out, err := Build(st, "s1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Calls) != 1 {
+			t.Fatalf("expected one call, got %d", len(out.Calls))
+		}
+		if out.Calls[0].ErrorName != tc.want {
+			t.Fatalf("code %d exported name %q, want %q", tc.code, out.Calls[0].ErrorName, tc.want)
+		}
+		if out.Calls[0].Error == nil || out.Calls[0].Error.Code != tc.code {
+			t.Fatalf("the wire error object must stay intact, got %+v", out.Calls[0].Error)
+		}
 	}
 }

--- a/internal/store/deprecation.go
+++ b/internal/store/deprecation.go
@@ -56,3 +56,17 @@ func deprecatedNestedNote(methods []string) string {
 	}
 	return strings.Join(notes, "; ")
 }
+
+// deprecatedErrorCodeNote reports a code an earlier revision defined and this
+// one retired. Both are reserved and will never be reused, so seeing one is
+// unambiguous evidence that the server is speaking an older revision, the same
+// class of heads-up as a deprecated method, and like those it never fails check.
+func deprecatedErrorCodeNote(code int) string {
+	switch code {
+	case -32002:
+		return "error code -32002 (resource not found) is retired (2026-07-28); use -32602 invalid params instead"
+	case -32042:
+		return "error code -32042 (URL elicitation required) was defined only in 2025-11-25 and is retired"
+	}
+	return ""
+}

--- a/internal/store/errorcode.go
+++ b/internal/store/errorcode.go
@@ -1,0 +1,56 @@
+package store
+
+import "strconv"
+
+// JSON-RPC 2.0 reserves -32000 to -32099 for implementation-defined server
+// errors, and 2026-07-28 partitions that range: -32000 to -32019 stays
+// implementation-defined and the specification will never allocate there, while
+// -32020 to -32099 is reserved for spec-defined codes, allocated sequentially
+// from -32020.
+//
+// That partition is why this file names some codes and refuses to name others.
+// A code in the implementation-defined sub-range means whatever the server that
+// sent it decided, and the spec is explicit that receivers must not assign
+// cross-implementation semantics to them. Naming one would put words in the
+// sender's mouth, which is the opposite of what a wire debugger is for.
+
+// ErrorCodeName returns the name the specification gives an error code, or ""
+// when it gives none. The four JSON-RPC codes are named alongside the MCP ones
+// because a reader looking at -32602 is helped as much as one looking at -32020.
+func ErrorCodeName(code int) string {
+	switch code {
+	case -32700:
+		return "parse error"
+	case -32600:
+		return "invalid request"
+	case -32601:
+		return "method not found"
+	case -32602:
+		return "invalid params"
+	case -32603:
+		return "internal error"
+	case -32020:
+		return "header mismatch"
+	case -32021:
+		return "missing required client capability"
+	case -32022:
+		return "unsupported protocol version"
+	}
+	return ""
+}
+
+// ErrorCodeHeaderMismatch is the server's verdict that a request's headers did
+// not match its body, or that a required one was missing or malformed. It is
+// the same condition mcpsnoop checks itself, reported by the party that is
+// authoritative about it and that also validates what mcpsnoop cannot see.
+const ErrorCodeHeaderMismatch = -32020
+
+// ErrorCodeText renders a code with its name for a one-line preview: the number
+// leads, because that is what a reader matches against the spec and against a
+// server's own documentation, and the name follows when there is one.
+func ErrorCodeText(code int) string {
+	if name := ErrorCodeName(code); name != "" {
+		return strconv.Itoa(code) + " " + name
+	}
+	return strconv.Itoa(code)
+}

--- a/internal/store/errorcode_test.go
+++ b/internal/store/errorcode_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// TestErrorCodeNameRefusesTheImplementationDefinedRange is the half that is easy
+// to get wrong by being helpful. -32000 to -32019 belongs to whoever sent it,
+// and the spec forbids receivers assigning cross-implementation meaning there,
+// so naming one would be inventing a claim the server never made.
+func TestErrorCodeNameRefusesTheImplementationDefinedRange(t *testing.T) {
+	for code := -32019; code <= -32000; code++ {
+		if name := ErrorCodeName(code); name != "" {
+			t.Fatalf("code %d is implementation-defined and must stay unnamed, got %q", code, name)
+		}
+	}
+	// The retired codes live in that range and are named only as deprecations,
+	// never as a current meaning.
+	if ErrorCodeName(-32002) != "" || ErrorCodeName(-32042) != "" {
+		t.Fatal("a retired code is not a current one")
+	}
+}
+
+// TestErrorCodeNameCoversTheAllocatedCodes pins the table against the schema.
+func TestErrorCodeNameCoversTheAllocatedCodes(t *testing.T) {
+	for code, want := range map[int]string{
+		-32700: "parse error",
+		-32600: "invalid request",
+		-32601: "method not found",
+		-32602: "invalid params",
+		-32603: "internal error",
+		-32020: "header mismatch",
+		-32021: "missing required client capability",
+		-32022: "unsupported protocol version",
+	} {
+		if got := ErrorCodeName(code); got != want {
+			t.Fatalf("ErrorCodeName(%d) = %q, want %q", code, got, want)
+		}
+	}
+}
+
+// TestErrorCodeTextLeadsWithTheNumber. The number is what a reader matches
+// against the spec and against a server's own documentation, and it is all
+// there is when the code is implementation-defined.
+func TestErrorCodeTextLeadsWithTheNumber(t *testing.T) {
+	if got := ErrorCodeText(-32020); got != "-32020 header mismatch" {
+		t.Fatalf("ErrorCodeText(-32020) = %q", got)
+	}
+	if got := ErrorCodeText(-32001); got != "-32001" {
+		t.Fatalf("an unnamed code should render bare, got %q", got)
+	}
+}
+
+// errorResponse is a server frame answering id with a JSON-RPC error.
+func errorResponse(seq uint64, id, code int, message string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: time.Now(),
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP, Status: 200,
+		Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"error":{"code":%d,"message":%q}}`,
+			id, code, message)),
+	}
+}
+
+// TestIngestFlagsAHeaderMismatchRejection. The server validates Mcp-Param values
+// and encodings that mcpsnoop never sees, so -32020 is sometimes the only
+// evidence a routing mismatch happened, and it has to reach the same filter.
+func TestIngestFlagsAHeaderMismatchRejection(t *testing.T) {
+	s := New()
+	s.Ingest(httpRequest(1, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search"}}`,
+		"tools/call", "search", "2026-07-28"))
+	ev := s.Ingest(errorResponse(2, 1, -32020, "Header mismatch"))
+	if !ev.RoutingMismatch {
+		t.Fatal("a -32020 rejection is a routing mismatch as the server saw it")
+	}
+
+	// An ordinary failure is not one, or the filter stops meaning anything.
+	s.Ingest(httpRequest(3, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search"}}`,
+		"tools/call", "search", "2026-07-28"))
+	if other := s.Ingest(errorResponse(4, 2, -32603, "boom")); other.RoutingMismatch {
+		t.Fatal("only -32020 is a routing verdict, got a mismatch on -32603")
+	}
+}
+
+// TestIngestMarksARetiredErrorCode. Both codes are reserved and never reused, so
+// one is unambiguous evidence of an older revision. It rides the deprecated
+// marker, which never fails check.
+func TestIngestMarksARetiredErrorCode(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want string
+	}{
+		{-32002, "resource not found"},
+		{-32042, "URL elicitation required"},
+	} {
+		t.Run(ErrorCodeText(tc.code), func(t *testing.T) {
+			s := New()
+			s.Ingest(httpRequest(1, `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///a"}}`,
+				"resources/read", "file:///a", "2026-07-28"))
+			ev := s.Ingest(errorResponse(2, 1, tc.code, "gone"))
+			if !strings.Contains(ev.Deprecated, tc.want) {
+				t.Fatalf("a retired code should be marked deprecated, got %q", ev.Deprecated)
+			}
+			if ev.Warning != "" {
+				t.Fatalf("a retired code is a heads-up, not a protocol warning, got %q", ev.Warning)
+			}
+		})
+	}
+
+	// A current code is not a deprecation, or the marker stops meaning anything.
+	s := New()
+	s.Ingest(httpRequest(1, `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///a"}}`,
+		"resources/read", "file:///a", "2026-07-28"))
+	if ev := s.Ingest(errorResponse(2, 1, -32602, "bad params")); ev.Deprecated != "" {
+		t.Fatalf("-32602 is current, got %q", ev.Deprecated)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -526,6 +526,22 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		if note := deprecatedNestedNote(state.methods); note != "" {
 			ev.deprecated = note
 		}
+	} else if msg.Error != nil {
+		// An error response has no method and no result, so neither branch above
+		// can see it. Its code is the one place a retired feature still shows.
+		if note := deprecatedErrorCodeNote(msg.Error.Code); note != "" {
+			ev.deprecated = note
+		}
+	}
+
+	// The server's own verdict on the header checks mcpsnoop performs itself.
+	// Flagged structurally rather than as a warning: the frame is already an
+	// error and already counted, and what this adds is that the failure was a
+	// routing one. It matters because the server validates more than mcpsnoop
+	// can (Mcp-Param-{Name} values, malformed encodings), so its rejection is
+	// sometimes the only evidence a mismatch happened at all.
+	if msg.Error != nil && msg.Error.Code == ErrorCodeHeaderMismatch {
+		ev.mismatch = true
 	}
 
 	sess.events = append(sess.events, ev)

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -77,8 +77,11 @@ type EventView struct {
 	AuthChallenge string
 	// RoutingMismatch is true when a routing header (Mcp-Method/Mcp-Name) or the
 	// MCP-Protocol-Version header disagrees with the body, or a routing header rides
-	// a batch. It is a structured handle for the same condition the warning
-	// describes, so filters and exporters need not match warning text.
+	// a batch, or a required one is missing. It is also true on a server's -32020
+	// response, which is that same condition as the server saw it: it validates
+	// values mcpsnoop cannot check, so its rejection is sometimes the only
+	// evidence. A structured handle for the condition the warning describes, so
+	// filters and exporters need not match warning text.
 	RoutingMismatch bool
 	// Truncated is true when mcpsnoop capped its own observed copy of a large body.
 	// It is a structured marker, not a protocol warning, so it never fails check.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1691,3 +1691,36 @@ func TestInspectorHeaderHeightFollowsTheStatusLine(t *testing.T) {
 		t.Fatal("a stdio frame has no transport chrome line")
 	}
 }
+
+// TestStreamRowNamesAnErrorCode. The row carried only the message, so a
+// spec-defined -32601 was indistinguishable from whatever number a server chose
+// for itself, and the code a reader needs to look up was nowhere on screen.
+func TestStreamRowNamesAnErrorCode(t *testing.T) {
+	st := store.New()
+	st.Ingest(env(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"nope"}}`))
+	st.Ingest(env(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"no such tool"}}`))
+
+	m := ready(t, st)
+	var detail string
+	for _, e := range st.Timeline("s1") {
+		if e.Kind == store.EventResponse {
+			detail = m.streamCells(e).detail
+		}
+	}
+	if !strings.Contains(detail, "-32601") || !strings.Contains(detail, "method not found") {
+		t.Fatalf("the row should carry the code and its name, got %q", detail)
+	}
+	if !strings.Contains(detail, "no such tool") {
+		t.Fatalf("the server's own message must survive, got %q", detail)
+	}
+}
+
+// TestStreamRowLeavesAnImplementationCodeUnnamed. -32000 to -32019 means
+// whatever the sender decided, so the row shows the number and the sender's
+// message and invents nothing.
+func TestStreamRowLeavesAnImplementationCodeUnnamed(t *testing.T) {
+	got := rpcErrorText(proxy.RPCError{Code: -32001, Message: "rate limited"})
+	if got != "-32001: rate limited" {
+		t.Fatalf("an implementation-defined code should render bare, got %q", got)
+	}
+}

--- a/internal/tui/replay.go
+++ b/internal/tui/replay.go
@@ -41,7 +41,7 @@ func (m Model) replayContent(msg replayDoneMsg) string {
 	dur := msg.res.Duration.Round(time.Millisecond)
 	switch {
 	case msg.res.Err != nil:
-		b.WriteString(m.styles.respErr.Render(fmt.Sprintf("ERROR %d: %s  (%s)", msg.res.Err.Code, msg.res.Err.Message, dur)) + "\n\n")
+		b.WriteString(m.styles.respErr.Render(fmt.Sprintf("ERROR %s  (%s)", rpcErrorText(*msg.res.Err), dur)) + "\n\n")
 	default:
 		b.WriteString(m.styles.resp.Render(fmt.Sprintf("ok  (%s)", dur)) + "\n\n")
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -662,7 +662,7 @@ func (m Model) streamCells(e store.EventView) streamCell {
 				c.detail = compactJSON(e.Call.Result)
 			case e.Call.Err != nil:
 				c.status = "err"
-				c.detail = e.Call.Err.Message
+				c.detail = rpcErrorText(*e.Call.Err)
 			case e.Call.ToolErr:
 				c.status = "err"
 				c.detail = toolErrorText(e.Call.Result)
@@ -832,6 +832,17 @@ func transportBody(e store.EventView) string {
 		}
 	}
 	return b.String()
+}
+
+// rpcErrorText renders a JSON-RPC error for a one-line preview. The code was
+// missing from this row entirely, so a reader could not tell a spec-defined
+// -32601 from whatever number a server picked for itself.
+func rpcErrorText(err proxy.RPCError) string {
+	head := store.ErrorCodeText(err.Code)
+	if err.Message == "" {
+		return head
+	}
+	return head + ": " + err.Message
 }
 
 // compactJSON renders raw JSON on a single line for the DETAIL preview column.


### PR DESCRIPTION
Closes #161 