### PR TITLE
feat(export): preserve W3C trace context in OTLP spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,13 @@ mcpsnoop export -T json|html|text|har|otlp [-o file|-] [session-id|log.jsonl|-]
 | `html` | a self-contained browser file with search and collapsible JSON |
 | `text` | a pretty plain-text dump |
 | `har` | one entry per correlated call, openable in browser devtools and anything else that reads HAR |
-| `otlp` | OTLP JSON with a trace per session and a span per correlated call |
+| `otlp` | OTLP JSON with a span per correlated call; W3C trace context joins caller traces, otherwise one trace is used per session |
 
 MCP is not HTTP, so a HAR entry's URL, status code, and timings are a deliberate
 mapping of each call rather than a wire transcript.
+
+For OTLP, a request's `_meta.traceparent` supplies that call's trace and parent
+span IDs. When it is absent or invalid, mcpsnoop keeps the session-derived trace.
 
 ```bash
 mcpsnoop export -T html -o out.html                    # an HTML file to open in a browser

--- a/README.md
+++ b/README.md
@@ -259,7 +259,10 @@ MCP is not HTTP, so a HAR entry's URL, status code, and timings are a deliberate
 mapping of each call rather than a wire transcript.
 
 For OTLP, a request's `_meta.traceparent` supplies that call's trace and parent
-span IDs. When it is absent or invalid, mcpsnoop keeps the session-derived trace.
+span IDs, and `_meta.tracestate` rides along on the span. When the traceparent is
+absent or invalid, mcpsnoop keeps the session-derived trace and carries no state.
+mcpsnoop observes rather than participates, so it adds no vendor entry of its own
+and passes the caller's state through unchanged.
 
 ```bash
 mcpsnoop export -T html -o out.html                    # an HTML file to open in a browser

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -411,6 +411,7 @@ type otlpScope struct {
 type otlpSpan struct {
 	TraceID           string          `json:"traceId"`
 	SpanID            string          `json:"spanId"`
+	ParentSpanID      string          `json:"parentSpanId,omitempty"`
 	Name              string          `json:"name"`
 	Kind              string          `json:"kind"`
 	StartTimeUnixNano string          `json:"startTimeUnixNano"`
@@ -436,9 +437,15 @@ type otlpAnyValue struct {
 
 // WriteOTLP writes data using the OTLP JSON encoding.
 func WriteOTLP(w io.Writer, data SessionExport) error {
-	traceID := otlpID(16, "trace", data.Session.ID)
+	sessionTraceID := otlpID(16, "trace", data.Session.ID)
 	spans := make([]otlpSpan, 0, len(data.Calls))
 	for _, call := range data.Calls {
+		traceID := sessionTraceID
+		parentSpanID := ""
+		if propagatedTraceID, propagatedParentSpanID, ok := traceContext(call.Params); ok {
+			traceID = propagatedTraceID
+			parentSpanID = propagatedParentSpanID
+		}
 		end := call.StartedAt
 		if call.EndedAt != nil {
 			end = *call.EndedAt
@@ -473,6 +480,7 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 		spans = append(spans, otlpSpan{
 			TraceID:           traceID,
 			SpanID:            otlpID(8, "span", data.Session.ID, call.ID, string(call.Direction)),
+			ParentSpanID:      parentSpanID,
 			Name:              call.Method,
 			Kind:              kind,
 			StartTimeUnixNano: fmt.Sprint(call.StartedAt.UnixNano()),
@@ -492,6 +500,77 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(payload)
+}
+
+func traceContext(params json.RawMessage) (traceID, parentSpanID string, ok bool) {
+	// Maps keep the SEP carrier keys exact; struct decoding also matches keys
+	// case-insensitively, which would accept a different carrier by accident.
+	var request map[string]json.RawMessage
+	if err := json.Unmarshal(params, &request); err != nil {
+		return "", "", false
+	}
+	rawMeta, ok := request["_meta"]
+	if !ok {
+		return "", "", false
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(rawMeta, &meta); err != nil {
+		return "", "", false
+	}
+	rawTraceparent, ok := meta["traceparent"]
+	if !ok {
+		return "", "", false
+	}
+	var traceparent string
+	if err := json.Unmarshal(rawTraceparent, &traceparent); err != nil {
+		return "", "", false
+	}
+	return parseTraceparent(traceparent)
+}
+
+func parseTraceparent(value string) (traceID, parentSpanID string, ok bool) {
+	const fixedLength = 55
+	if len(value) < fixedLength || value[2] != '-' || value[35] != '-' || value[52] != '-' {
+		return "", "", false
+	}
+
+	version := value[:2]
+	traceID = value[3:35]
+	parentSpanID = value[36:52]
+	flags := value[53:55]
+	if !lowerHex(version) || version == "ff" ||
+		!lowerHex(traceID) || allZero(traceID) ||
+		!lowerHex(parentSpanID) || allZero(parentSpanID) ||
+		!lowerHex(flags) {
+		return "", "", false
+	}
+	if version == "00" && len(value) != fixedLength {
+		return "", "", false
+	}
+	// Later versions may append fields. Their fixed prefix remains usable, but
+	// the first unknown field still has to begin at a field boundary.
+	if len(value) > fixedLength && value[fixedLength] != '-' {
+		return "", "", false
+	}
+	return traceID, parentSpanID, true
+}
+
+func lowerHex(value string) bool {
+	for _, c := range value {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func allZero(value string) bool {
+	for _, c := range value {
+		if c != '0' {
+			return false
+		}
+	}
+	return true
 }
 
 func otlpID(length int, parts ...string) string {

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -383,8 +383,14 @@ func Write(w io.Writer, data SessionExport, opts Options) error {
 	}
 }
 
-// otlpExport follows the OTLP JSON encoding. Each correlated MCP call becomes
-// a span in one trace, making a session importable into tracing backends.
+// otlpExport follows the OTLP JSON encoding. Each correlated MCP call becomes a
+// span, making a session importable into tracing backends.
+//
+// A call whose request carried a traceparent joins the caller's trace, so the
+// spans of one session can legitimately span several traces. The rest share a
+// trace derived from the session id, so a session with no propagation still
+// reads as one unit. Either way mcpsnoop.session.id is a resource attribute
+// rather than a span one, so the tie back to the capture survives the split.
 type otlpExport struct {
 	ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
 }
@@ -412,6 +418,7 @@ type otlpSpan struct {
 	TraceID           string          `json:"traceId"`
 	SpanID            string          `json:"spanId"`
 	ParentSpanID      string          `json:"parentSpanId,omitempty"`
+	TraceState        string          `json:"traceState,omitempty"`
 	Name              string          `json:"name"`
 	Kind              string          `json:"kind"`
 	StartTimeUnixNano string          `json:"startTimeUnixNano"`
@@ -440,11 +447,11 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 	sessionTraceID := otlpID(16, "trace", data.Session.ID)
 	spans := make([]otlpSpan, 0, len(data.Calls))
 	for _, call := range data.Calls {
-		traceID := sessionTraceID
-		parentSpanID := ""
-		if propagatedTraceID, propagatedParentSpanID, ok := traceContext(call.Params); ok {
-			traceID = propagatedTraceID
-			parentSpanID = propagatedParentSpanID
+		traceID, parentSpanID, traceState := sessionTraceID, "", ""
+		if propagated, ok := traceContext(call.Params); ok {
+			traceID = propagated.TraceID
+			parentSpanID = propagated.ParentSpanID
+			traceState = propagated.TraceState
 		}
 		end := call.StartedAt
 		if call.EndedAt != nil {
@@ -481,6 +488,7 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 			TraceID:           traceID,
 			SpanID:            otlpID(8, "span", data.Session.ID, call.ID, string(call.Direction)),
 			ParentSpanID:      parentSpanID,
+			TraceState:        traceState,
 			Name:              call.Method,
 			Kind:              kind,
 			StartTimeUnixNano: fmt.Sprint(call.StartedAt.UnixNano()),
@@ -502,30 +510,100 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 	return enc.Encode(payload)
 }
 
-func traceContext(params json.RawMessage) (traceID, parentSpanID string, ok bool) {
+// propagatedContext is the W3C trace context a request carried. TraceState is
+// empty when the caller sent none, or sent one this cannot make sense of.
+type propagatedContext struct {
+	TraceID      string
+	ParentSpanID string
+	TraceState   string
+}
+
+// traceContext reads the trace context from a request's params.
+//
+// The keys are deliberately unprefixed. Every other _meta key in MCP is
+// reverse-DNS namespaced, but the specification carves out traceparent,
+// tracestate and baggage by name so that trace context stays wire-compatible
+// with OpenTelemetry; namespacing them is called out as the thing that would
+// break traces. baggage is not read here: it is propagation state, not part of
+// a span.
+func traceContext(params json.RawMessage) (propagatedContext, bool) {
 	// Maps keep the SEP carrier keys exact; struct decoding also matches keys
 	// case-insensitively, which would accept a different carrier by accident.
 	var request map[string]json.RawMessage
 	if err := json.Unmarshal(params, &request); err != nil {
-		return "", "", false
+		return propagatedContext{}, false
 	}
 	rawMeta, ok := request["_meta"]
 	if !ok {
-		return "", "", false
+		return propagatedContext{}, false
 	}
 	var meta map[string]json.RawMessage
 	if err := json.Unmarshal(rawMeta, &meta); err != nil {
-		return "", "", false
+		return propagatedContext{}, false
 	}
-	rawTraceparent, ok := meta["traceparent"]
+	traceID, parentSpanID, ok := parseTraceparent(metaString(meta, "traceparent"))
 	if !ok {
-		return "", "", false
+		return propagatedContext{}, false
 	}
-	var traceparent string
-	if err := json.Unmarshal(rawTraceparent, &traceparent); err != nil {
-		return "", "", false
+	// Only once traceparent is valid: W3C requires tracestate to be discarded
+	// when the traceparent it belongs to cannot be trusted, since the state
+	// describes a trace we would otherwise be unable to name.
+	return propagatedContext{
+		TraceID:      traceID,
+		ParentSpanID: parentSpanID,
+		TraceState:   validTraceState(metaString(meta, "tracestate")),
+	}, true
+}
+
+// metaString returns a string-valued _meta entry, or "" when it is absent or is
+// some other JSON type. A carrier of the wrong type is treated as no carrier,
+// because a number where a traceparent belongs says nothing about the trace.
+func metaString(meta map[string]json.RawMessage, key string) string {
+	raw, ok := meta[key]
+	if !ok {
+		return ""
 	}
-	return parseTraceparent(traceparent)
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return value
+}
+
+// maxTraceStateMembers is the W3C limit. A list longer than this is to be
+// discarded rather than truncated, since dropping members silently would change
+// which vendor's state survives.
+const maxTraceStateMembers = 32
+
+// validTraceState returns a tracestate worth carrying, or "".
+//
+// The grammar is checked only as far as it has to be. mcpsnoop observes rather
+// than participates: it adds no member of its own and mutates nothing, so the
+// value it emits is the caller's, and a backend that rejects it would have
+// rejected the caller's request identically. Parsing each member's key and value
+// against the full grammar would mostly create ways to drop a valid header,
+// which is the failure that would be silent. What is checked is what cannot be
+// passed on meaningfully: an empty list, a member that is not a key=value pair,
+// and a list past the limit at which the spec says to discard rather than trim.
+func validTraceState(value string) string {
+	if value == "" {
+		return ""
+	}
+	members := strings.Split(value, ",")
+	if len(members) > maxTraceStateMembers {
+		return ""
+	}
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		if member == "" {
+			continue // OWS between members is allowed, and so is a trailing comma
+		}
+		key, _, ok := strings.Cut(member, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return ""
+		}
+	}
+	return value
 }
 
 func parseTraceparent(value string) (traceID, parentSpanID string, ok bool) {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -391,6 +391,7 @@ func TestWriteOTLP(t *testing.T) {
 				Spans []struct {
 					TraceID           string `json:"traceId"`
 					SpanID            string `json:"spanId"`
+					ParentSpanID      string `json:"parentSpanId"`
 					Name              string `json:"name"`
 					StartTimeUnixNano string `json:"startTimeUnixNano"`
 					EndTimeUnixNano   string `json:"endTimeUnixNano"`
@@ -418,6 +419,22 @@ func TestWriteOTLP(t *testing.T) {
 	if span.Name != "tools/call" || len(span.TraceID) != 32 || len(span.SpanID) != 16 || span.StartTimeUnixNano == "" || span.EndTimeUnixNano == "" || span.Status.Code != "STATUS_CODE_OK" {
 		t.Fatalf("bad OTLP span: %+v", span)
 	}
+	if span.ParentSpanID != "" {
+		t.Fatalf("span without trace context has parentSpanId %q", span.ParentSpanID)
+	}
+	var rawPayload struct {
+		ResourceSpans []struct {
+			ScopeSpans []struct {
+				Spans []map[string]json.RawMessage `json:"spans"`
+			} `json:"scopeSpans"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &rawPayload); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := rawPayload.ResourceSpans[0].ScopeSpans[0].Spans[0]["parentSpanId"]; ok {
+		t.Fatalf("span without trace context must omit parentSpanId: %s", buf.String())
+	}
 	keys := make(map[string]bool, len(span.Attributes))
 	for _, attr := range span.Attributes {
 		keys[attr.Key] = true
@@ -427,6 +444,152 @@ func TestWriteOTLP(t *testing.T) {
 			t.Errorf("OTLP span missing %q", key)
 		}
 	}
+}
+
+func TestWriteOTLPAcceptsFutureTraceparentVersions(t *testing.T) {
+	const (
+		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
+		parentSpanID = "00f067aa0ba902b7"
+	)
+	cases := map[string]string{
+		"fixed fields": "01-" + traceID + "-" + parentSpanID + "-01",
+		"extension":    "01-" + traceID + "-" + parentSpanID + "-01-vendor-data",
+	}
+	for name, traceparent := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := SessionExport{
+				Session: SessionSummary{ID: "s1"},
+				Calls: []CallExport{{
+					ID:        "call-1",
+					Method:    "tools/call",
+					StartedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+					Params:    json.RawMessage(`{"_meta":{"traceparent":"` + traceparent + `"}}`),
+				}},
+			}
+			spans := writeOTLPTraceFields(t, data)
+			if len(spans) != 1 {
+				t.Fatalf("spans = %d, want 1", len(spans))
+			}
+			if spans[0].TraceID != traceID || spans[0].ParentSpanID != parentSpanID {
+				t.Fatalf("future-version trace context = %q/%q, want %q/%q", spans[0].TraceID, spans[0].ParentSpanID, traceID, parentSpanID)
+			}
+		})
+	}
+}
+
+func TestWriteOTLPUsesPerCallTraceparent(t *testing.T) {
+	const (
+		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
+		parentSpanID = "00f067aa0ba902b7"
+		traceparent  = "00-" + traceID + "-" + parentSpanID + "-01"
+	)
+	started := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	data := SessionExport{
+		Session: SessionSummary{ID: "s1"},
+		Calls: []CallExport{
+			{
+				ID:        "with-context",
+				Method:    "tools/call",
+				StartedAt: started,
+				Params:    json.RawMessage(`{"_meta":{"traceparent":"` + traceparent + `"}}`),
+			},
+			{
+				ID:        "without-context",
+				Method:    "tools/call",
+				StartedAt: started,
+				Params:    json.RawMessage(`{"name":"lookup"}`),
+			},
+		},
+	}
+
+	spans := writeOTLPTraceFields(t, data)
+	if len(spans) != 2 {
+		t.Fatalf("spans = %d, want 2", len(spans))
+	}
+	if spans[0].TraceID != traceID || spans[0].ParentSpanID != parentSpanID {
+		t.Fatalf("propagated span context = %q/%q, want %q/%q", spans[0].TraceID, spans[0].ParentSpanID, traceID, parentSpanID)
+	}
+	syntheticTraceID := otlpID(16, "trace", data.Session.ID)
+	if spans[1].TraceID != syntheticTraceID || spans[1].ParentSpanID != "" {
+		t.Fatalf("context leaked to next span: traceId %q parentSpanId %q, want %q/empty", spans[1].TraceID, spans[1].ParentSpanID, syntheticTraceID)
+	}
+}
+
+func TestWriteOTLPRejectsInvalidTraceparent(t *testing.T) {
+	const (
+		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
+		parentSpanID = "00f067aa0ba902b7"
+		traceparent  = "00-" + traceID + "-" + parentSpanID + "-01"
+	)
+	cases := map[string]json.RawMessage{
+		"malformed value":     json.RawMessage(`{"_meta":{"traceparent":"not-a-traceparent"}}`),
+		"malformed params":    json.RawMessage(`{"_meta":`),
+		"meta is not object":  json.RawMessage(`{"_meta":"nope"}`),
+		"value is not string": json.RawMessage(`{"_meta":{"traceparent":42}}`),
+		"uppercase meta key":  json.RawMessage(`{"_META":{"traceparent":"` + traceparent + `"}}`),
+		"uppercase value key": json.RawMessage(`{"_meta":{"TraceParent":"` + traceparent + `"}}`),
+		"zero trace id":       json.RawMessage(`{"_meta":{"traceparent":"00-00000000000000000000000000000000-` + parentSpanID + `-01"}}`),
+		"zero parent span id": json.RawMessage(`{"_meta":{"traceparent":"00-` + traceID + `-0000000000000000-01"}}`),
+		"uppercase trace id":  json.RawMessage(`{"_meta":{"traceparent":"00-4BF92F3577B34DA6A3CE929D0E0E4736-` + parentSpanID + `-01"}}`),
+		"uppercase version":   json.RawMessage(`{"_meta":{"traceparent":"0A-` + traceID + `-` + parentSpanID + `-01"}}`),
+		"uppercase parent id": json.RawMessage(`{"_meta":{"traceparent":"00-` + traceID + `-00F067AA0BA902B7-01"}}`),
+		"uppercase flags":     json.RawMessage(`{"_meta":{"traceparent":"00-` + traceID + `-` + parentSpanID + `-0A"}}`),
+		"forbidden version":   json.RawMessage(`{"_meta":{"traceparent":"ff-` + traceID + `-` + parentSpanID + `-01"}}`),
+		"invalid flags":       json.RawMessage(`{"_meta":{"traceparent":"00-` + traceID + `-` + parentSpanID + `-0g"}}`),
+		"version 00 suffix":   json.RawMessage(`{"_meta":{"traceparent":"00-` + traceID + `-` + parentSpanID + `-01-extra"}}`),
+		"version separator":   json.RawMessage(`{"_meta":{"traceparent":"00_` + traceID + `-` + parentSpanID + `-01"}}`),
+		"trace id separator":  json.RawMessage(`{"_meta":{"traceparent":"00-` + traceID + `_` + parentSpanID + `-01"}}`),
+		"parent id separator": json.RawMessage(`{"_meta":{"traceparent":"00-` + traceID + `-` + parentSpanID + `_01"}}`),
+		"extension separator": json.RawMessage(`{"_meta":{"traceparent":"01-` + traceID + `-` + parentSpanID + `-01extra"}}`),
+	}
+	for name, params := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := SessionExport{
+				Session: SessionSummary{ID: "s1"},
+				Calls: []CallExport{{
+					ID:        "call-1",
+					Method:    "tools/call",
+					StartedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+					Params:    params,
+				}},
+			}
+			spans := writeOTLPTraceFields(t, data)
+			if len(spans) != 1 {
+				t.Fatalf("spans = %d, want 1", len(spans))
+			}
+			wantTraceID := otlpID(16, "trace", data.Session.ID)
+			if spans[0].TraceID != wantTraceID || spans[0].ParentSpanID != "" {
+				t.Fatalf("invalid traceparent produced context %q/%q, want %q/empty", spans[0].TraceID, spans[0].ParentSpanID, wantTraceID)
+			}
+		})
+	}
+}
+
+type otlpTraceFields struct {
+	TraceID      string `json:"traceId"`
+	ParentSpanID string `json:"parentSpanId"`
+}
+
+func writeOTLPTraceFields(t *testing.T, data SessionExport) []otlpTraceFields {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteOTLP(&buf, data); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		ResourceSpans []struct {
+			ScopeSpans []struct {
+				Spans []otlpTraceFields `json:"spans"`
+			} `json:"scopeSpans"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid OTLP JSON: %v\n%s", err, buf.String())
+	}
+	if len(payload.ResourceSpans) != 1 || len(payload.ResourceSpans[0].ScopeSpans) != 1 {
+		t.Fatalf("unexpected OTLP hierarchy: %s", buf.String())
+	}
+	return payload.ResourceSpans[0].ScopeSpans[0].Spans
 }
 
 func TestDefaultOutputPathExtensions(t *testing.T) {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -568,6 +568,7 @@ func TestWriteOTLPRejectsInvalidTraceparent(t *testing.T) {
 type otlpTraceFields struct {
 	TraceID      string `json:"traceId"`
 	ParentSpanID string `json:"parentSpanId"`
+	TraceState   string `json:"traceState"`
 }
 
 func writeOTLPTraceFields(t *testing.T, data SessionExport) []otlpTraceFields {
@@ -705,5 +706,148 @@ func TestExportNamesASpecDefinedErrorCode(t *testing.T) {
 		if out.Calls[0].Error == nil || out.Calls[0].Error.Code != tc.code {
 			t.Fatalf("the wire error object must stay intact, got %+v", out.Calls[0].Error)
 		}
+	}
+}
+
+// TestWriteOTLPCarriesTraceState covers the second half of the carrier. W3C
+// expects a participant continuing a trace to pass tracestate along, and an OTLP
+// span has a field for it, so dropping it strands whatever vendor state the
+// caller was routing or sampling on.
+func TestWriteOTLPCarriesTraceState(t *testing.T) {
+	const (
+		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
+		parentSpanID = "00f067aa0ba902b7"
+		traceparent  = "00-" + traceID + "-" + parentSpanID + "-01"
+		tracestate   = "vendorname1=opaqueValue1,vendorname2=opaqueValue2"
+	)
+	data := SessionExport{
+		Session: SessionSummary{ID: "s1"},
+		Calls: []CallExport{{
+			ID:        "call-1",
+			Method:    "tools/call",
+			StartedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+			Params: json.RawMessage(`{"_meta":{"traceparent":"` + traceparent +
+				`","tracestate":"` + tracestate + `"}}`),
+		}},
+	}
+
+	spans := writeOTLPTraceFields(t, data)
+	if len(spans) != 1 {
+		t.Fatalf("spans = %d, want 1", len(spans))
+	}
+	if spans[0].TraceState != tracestate {
+		t.Fatalf("traceState = %q, want the caller's %q", spans[0].TraceState, tracestate)
+	}
+	// mcpsnoop observes rather than participates, so it adds no member of its own
+	// and the value must arrive byte for byte as the caller sent it.
+	if spans[0].TraceID != traceID || spans[0].ParentSpanID != parentSpanID {
+		t.Fatalf("trace context = %q/%q, want %q/%q", spans[0].TraceID, spans[0].ParentSpanID, traceID, parentSpanID)
+	}
+}
+
+// TestWriteOTLPOmitsUnusableTraceState checks the cases where carrying the value
+// on would be worse than dropping it, including the one W3C is explicit about:
+// tracestate belonging to a traceparent that did not parse describes a trace we
+// cannot name, so it goes with it.
+func TestWriteOTLPOmitsUnusableTraceState(t *testing.T) {
+	const (
+		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
+		parentSpanID = "00f067aa0ba902b7"
+		traceparent  = "00-" + traceID + "-" + parentSpanID + "-01"
+	)
+	tooMany := make([]string, 33)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("vendor%d=value", i)
+	}
+
+	cases := map[string]json.RawMessage{
+		"absent":            json.RawMessage(`{"_meta":{"traceparent":"` + traceparent + `"}}`),
+		"empty":             json.RawMessage(`{"_meta":{"traceparent":"` + traceparent + `","tracestate":""}}`),
+		"not a string":      json.RawMessage(`{"_meta":{"traceparent":"` + traceparent + `","tracestate":42}}`),
+		"member has no key": json.RawMessage(`{"_meta":{"traceparent":"` + traceparent + `","tracestate":"=value"}}`),
+		"member is not a pair": json.RawMessage(`{"_meta":{"traceparent":"` + traceparent +
+			`","tracestate":"vendorname1=value1,garbage"}}`),
+		"past the 32-member limit": json.RawMessage(`{"_meta":{"traceparent":"` + traceparent +
+			`","tracestate":"` + strings.Join(tooMany, ",") + `"}}`),
+	}
+	for name, params := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := SessionExport{
+				Session: SessionSummary{ID: "s1"},
+				Calls: []CallExport{{
+					ID:        "call-1",
+					Method:    "tools/call",
+					StartedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+					Params:    params,
+				}},
+			}
+			spans := writeOTLPTraceFields(t, data)
+			if len(spans) != 1 {
+				t.Fatalf("spans = %d, want 1", len(spans))
+			}
+			if spans[0].TraceState != "" {
+				t.Fatalf("traceState = %q, want it dropped", spans[0].TraceState)
+			}
+			// Dropping the state must not cost the parenting: the traceparent is
+			// valid in every one of these cases.
+			if spans[0].TraceID != traceID || spans[0].ParentSpanID != parentSpanID {
+				t.Fatalf("an unusable tracestate cost the trace context: %q/%q", spans[0].TraceID, spans[0].ParentSpanID)
+			}
+		})
+	}
+}
+
+// TestWriteOTLPDiscardsTraceStateWithAnInvalidTraceparent is the rule W3C states
+// outright: state without a trustworthy traceparent goes nowhere.
+func TestWriteOTLPDiscardsTraceStateWithAnInvalidTraceparent(t *testing.T) {
+	data := SessionExport{
+		Session: SessionSummary{ID: "s1"},
+		Calls: []CallExport{{
+			ID:        "call-1",
+			Method:    "tools/call",
+			StartedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+			Params:    json.RawMessage(`{"_meta":{"traceparent":"nope","tracestate":"vendorname1=value1"}}`),
+		}},
+	}
+
+	spans := writeOTLPTraceFields(t, data)
+	if len(spans) != 1 {
+		t.Fatalf("spans = %d, want 1", len(spans))
+	}
+	if spans[0].TraceState != "" || spans[0].ParentSpanID != "" {
+		t.Fatalf("nothing should be carried from an invalid traceparent: %q/%q", spans[0].TraceState, spans[0].ParentSpanID)
+	}
+	if want := otlpID(16, "trace", data.Session.ID); spans[0].TraceID != want {
+		t.Fatalf("traceId = %q, want the session-derived %q", spans[0].TraceID, want)
+	}
+}
+
+// TestWriteOTLPOmitsTraceStateFieldWhenAbsent keeps the payload clean for the
+// ordinary session, where no caller propagated anything.
+func TestWriteOTLPOmitsTraceStateFieldWhenAbsent(t *testing.T) {
+	data := SessionExport{
+		Session: SessionSummary{ID: "s1"},
+		Calls: []CallExport{{
+			ID:        "call-1",
+			Method:    "tools/list",
+			StartedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+	var buf bytes.Buffer
+	if err := WriteOTLP(&buf, data); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		ResourceSpans []struct {
+			ScopeSpans []struct {
+				Spans []map[string]json.RawMessage `json:"spans"`
+			} `json:"scopeSpans"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := payload.ResourceSpans[0].ScopeSpans[0].Spans[0]["traceState"]; ok {
+		t.Fatalf("a span with no propagated state must omit traceState: %s", buf.String())
 	}
 }

--- a/internal/otlpsink/sink_test.go
+++ b/internal/otlpsink/sink_test.go
@@ -85,6 +85,49 @@ func TestSinkPostsCompletedCallAsOTLP(t *testing.T) {
 	}
 }
 
+func TestSinkPostsRequestTraceContext(t *testing.T) {
+	const (
+		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
+		parentSpanID = "00f067aa0ba902b7"
+		traceparent  = "00-" + traceID + "-" + parentSpanID + "-01"
+	)
+	received := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode OTLP payload: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		received <- payload
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink := New(Config{Endpoint: server.URL})
+	defer sink.Close()
+	request, response := callEnvelopes("session-1", 1, time.Unix(1_700_000_000, 0))
+	request.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lookup","_meta":{"traceparent":"` + traceparent + `"}}}`)
+	sink.Emit(request)
+	sink.Emit(response)
+
+	select {
+	case payload := <-received:
+		resourceSpans := payload["resourceSpans"].([]any)
+		scopeSpans := resourceSpans[0].(map[string]any)["scopeSpans"].([]any)
+		spans := scopeSpans[0].(map[string]any)["spans"].([]any)
+		if len(spans) != 1 {
+			t.Fatalf("posted %d spans, want 1", len(spans))
+		}
+		span := spans[0].(map[string]any)
+		if span["traceId"] != traceID || span["parentSpanId"] != parentSpanID {
+			t.Fatalf("posted trace context = %v/%v, want %s/%s", span["traceId"], span["parentSpanId"], traceID, parentSpanID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OTLP payload")
+	}
+}
+
 func TestSinkPostsDuplicateResponseOnlyOnce(t *testing.T) {
 	var posts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## What and why

Use W3C Trace Context from each request's `_meta.traceparent` when exporting correlated calls as OTLP. Valid context now supplies the trace ID and parent span ID for both `mcpsnoop export -T otlp` and the live `--otlp-endpoint` sink; missing or invalid context keeps the existing session-derived trace and omits the parent.

The parser validates the fixed W3C fields per call, preserves forward compatibility for later versions, and leaves `tracestate` and `baggage` out of scope.

Closes https://github.com/kerlenton/mcpsnoop/issues/158

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed