### PR TITLE
fix(check): report dropped frames in check and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ the spec has deprecated, or `incomplete` to gate on captures with dropped frames
 Pass a comma-separated subset to select only the
 conditions relevant to a job. Omit the session to check the newest capture, or use
 `-` to read JSONL from stdin.
+The dropped-frame count travels with the artifacts too, so a capture that
+understates itself says so wherever it is opened: `missing_frames` in the JSON
+export, `log.comment` in HAR, and the `mcpsnoop.session.missing_frames` resource
+attribute in OTLP.
 A name or resource URI that will not fit in an HTTP field value travels Base64 in
 a `=?base64?…?=` sentinel; it is decoded before the comparison, so a client that
 encodes correctly is never flagged.

--- a/README.md
+++ b/README.md
@@ -321,18 +321,20 @@ regression too. Improvements (added tools, fixed calls, speedups) still exit zer
 ## Checking sessions in CI
 
 Gate a recorded agent run on errors, stream corruption, protocol warnings,
-routing-header mismatches, calls that never got a response, tool-definition
-drift, or use of deprecated protocol features.
+routing-header mismatches, calls that never got a response, dropped frames that
+leave the capture incomplete, tool-definition drift, or use of deprecated
+protocol features.
 
 ```bash
-mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending,drift,deprecated] [session-id|log.jsonl|-]
+mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending,drift,deprecated,incomplete] [session-id|log.jsonl|-]
 ```
 
 The three default signals (error, invalid, warn) fail the check. Add `pending`
 to gate on calls that never got a response, `mismatch` to gate specifically on a
 routing header (Mcp-Method or Mcp-Name) disagreeing with the body, `drift` to gate
-on tool definitions changing after approval, or `deprecated` to gate on features
-the spec has deprecated. Pass a comma-separated subset to select only the
+on tool definitions changing after approval, `deprecated` to gate on features
+the spec has deprecated, or `incomplete` to gate on captures with dropped frames.
+Pass a comma-separated subset to select only the
 conditions relevant to a job. Omit the session to check the newest capture, or use
 `-` to read JSONL from stdin.
 A name or resource URI that will not fit in an HTTP field value travels Base64 in

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -22,9 +22,10 @@ const (
 	checkPending    checkSignal = "pending"
 	checkDrift      checkSignal = "drift"
 	checkDeprecated checkSignal = "deprecated"
+	checkIncomplete checkSignal = "incomplete"
 )
 
-var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated}
+var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated, checkIncomplete}
 
 type checkOutputFormat string
 
@@ -41,6 +42,7 @@ type checkSummary struct {
 	mismatches      int
 	pending         int
 	deprecated      int
+	missingFrames   uint64
 	drift           store.ToolDrift
 	baselineCreated bool
 }
@@ -52,7 +54,7 @@ func newCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check [session-id|log.jsonl|-]",
 		Short: "Fail when a captured session violates a signal or an assertion",
-		Long:  "Check a captured session against signals (errors, invalid frames, warnings, routing-header mismatches, calls that never got a response, tool-definition drift) and assertions (a tool-call latency budget, and tools that must or must not have been called). With no session, the newest session log is checked. Use - to read from stdin.",
+		Long:  "Check a captured session against signals (errors, invalid frames, warnings, routing-header mismatches, calls that never got a response, dropped frames that leave the capture incomplete, tool-definition drift) and assertions (a tool-call latency budget, and tools that must or must not have been called). With no session, the newest session log is checked. Use - to read from stdin.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			signals, err := parseCheckSignals(failOn)
@@ -100,8 +102,8 @@ func newCheckCmd() *cobra.Command {
 				}
 			} else {
 				for i, summary := range summaries {
-					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d deprecated=%d\n",
-						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.deprecated)
+					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d deprecated=%d missing_frames=%d\n",
+						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.deprecated, summary.missingFrames)
 					if summary.baselineCreated {
 						// No baseline existed, so this run trusted the current definitions
 						// rather than verifying them. Say so, or an ephemeral CI reads green
@@ -135,7 +137,7 @@ func newCheckCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().SortFlags = false
-	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift, deprecated")
+	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift, deprecated, incomplete")
 	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text or junit")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
 	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
@@ -216,10 +218,10 @@ func parseCheckSignals(value string) (map[checkSignal]bool, error) {
 	for _, part := range strings.Split(value, ",") {
 		signal := checkSignal(strings.TrimSpace(part))
 		switch signal {
-		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated:
+		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated, checkIncomplete:
 			signals[signal] = true
 		default:
-			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, drift, or deprecated, got %q", part)
+			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, drift, deprecated, or incomplete, got %q", part)
 		}
 	}
 	return signals, nil
@@ -253,7 +255,7 @@ func loadCheckSession(cmd *cobra.Command, arg string) (*store.Store, string, err
 func summarizeCheck(st *store.Store, baselines *toolbaseline.Manager) []checkSummary {
 	var summaries []checkSummary
 	for _, header := range st.Sessions() {
-		summary := checkSummary{sessionID: header.ID, errors: header.Errors, pending: header.Pending}
+		summary := checkSummary{sessionID: header.ID, errors: header.Errors, pending: header.Pending, missingFrames: header.MissingFrames}
 		if _, ok := st.ToolDefinitions(header.ID); ok {
 			report, created, err := toolbaseline.ObserveSession(baselines, st, header.ID)
 			if err != nil {
@@ -316,6 +318,8 @@ func (s checkSummary) count(signal checkSignal) int {
 		return n
 	case checkDeprecated:
 		return s.deprecated
+	case checkIncomplete:
+		return int(s.missingFrames)
 	default:
 		return 0
 	}

--- a/cmd/mcpsnoop/check_junit.go
+++ b/cmd/mcpsnoop/check_junit.go
@@ -126,6 +126,8 @@ func checkSignalFailureReason(sessionID string, signal checkSignal, count int) s
 		singular, plural = "tool definition change", "tool definition changes"
 	case checkDeprecated:
 		singular, plural = "deprecated protocol feature", "deprecated protocol features"
+	case checkIncomplete:
+		singular, plural = "dropped frame", "dropped frames"
 	default:
 		singular, plural = "signal", "signals"
 	}

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -22,7 +22,7 @@ func TestCheckFailsOnSelectedSessionSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0\ncheck failed: error,invalid,warn\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0 missing_frames=0\ncheck failed: error,invalid,warn\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -38,7 +38,7 @@ func TestCheckFailsOnlyOnSelectedSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 because the fixture contains an invalid frame", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0\ncheck failed: invalid\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0 missing_frames=0\ncheck failed: invalid\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -53,7 +53,7 @@ func TestCheckIgnoresUnselectedSignals(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0\ncheck passed\n" {
+	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0 missing_frames=0\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -72,7 +72,7 @@ func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
+	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0 missing_frames=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -91,8 +91,8 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	const want = `<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="mcpsnoop check" tests="8" failures="3" errors="0" skipped="0" time="0">
-  <testsuite name="s1" tests="8" failures="3" errors="0" skipped="0" time="0">
+<testsuites name="mcpsnoop check" tests="9" failures="3" errors="0" skipped="0" time="0">
+  <testsuite name="s1" tests="9" failures="3" errors="0" skipped="0" time="0">
     <testcase classname="mcpsnoop.check" name="s1/error" time="0">
       <failure message="session s1 has 2 errors" type="mcpsnoop.check.error">session s1 has 2 errors</failure>
     </testcase>
@@ -106,6 +106,7 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
     <testcase classname="mcpsnoop.check" name="s1/pending" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/drift" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/deprecated" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/incomplete" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/assertions" time="0"></testcase>
   </testsuite>
 </testsuites>
@@ -126,7 +127,7 @@ func TestCheckJUnitHonorsFailOn(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 because errors are not selected", code)
 	}
-	for _, want := range []string{`tests="8"`, `failures="0"`, `name="s1/error"`} {
+	for _, want := range []string{`tests="9"`, `failures="0"`, `name="s1/error"`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}
@@ -205,6 +206,46 @@ func TestCheckGatesEverySessionNotJustTheFirst(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}
+	}
+}
+
+func TestCheckReportsMissingFramesWithoutFailingByDefault(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`),
+		// Seq 3 and 4 were dropped upstream.
+		checkEnvelope(5, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+	)
+
+	code, stdout, stderr := executeCheck(t, []string{"-"}, log)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 because incomplete is opt-in", code)
+	}
+	if !strings.Contains(stdout, "missing_frames=2") {
+		t.Fatalf("stdout = %q, want missing_frames=2", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckFailsOnIncompleteCapture(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(5, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+	)
+
+	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "incomplete", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for a lossy capture", code)
+	}
+	if !strings.Contains(stdout, "missing_frames=3") || !strings.Contains(stdout, "check failed: incomplete") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
 	}
 }
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -395,8 +396,10 @@ func Write(w io.Writer, data SessionExport, opts Options) error {
 // trace derived from the session id, so a session with no propagation still
 // reads as one unit. Either way mcpsnoop.session.id is a resource attribute
 // rather than a span one, so the tie back to the capture survives the split.
-// When Session.MissingFrames is non-zero the capture is incomplete and the span
-// count understates what actually happened on the wire.
+// When a capture is incomplete the span count understates what happened on the
+// wire, so the dropped-frame count rides the payload as the resource attribute
+// mcpsnoop.session.missing_frames. It belongs there rather than in this comment:
+// the person who needs it is importing the trace, not reading this file.
 type otlpExport struct {
 	ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
 }
@@ -446,6 +449,10 @@ type otlpAnyValue struct {
 	StringValue *string  `json:"stringValue,omitempty"`
 	BoolValue   *bool    `json:"boolValue,omitempty"`
 	DoubleValue *float64 `json:"doubleValue,omitempty"`
+	// IntValue is a string because proto3 JSON encodes int64 that way, and OTLP
+	// receivers parse it back. Writing a bare number here is the mistake that
+	// makes a payload look right and get rejected at the collector.
+	IntValue *string `json:"intValue,omitempty"`
 }
 
 // WriteOTLP writes data using the OTLP JSON encoding.
@@ -508,6 +515,11 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 			otlpString("service.name", "mcpsnoop"),
 			otlpString("mcpsnoop.session.id", data.Session.ID),
 			otlpString("mcpsnoop.session.label", data.Session.Label),
+			// Emitted even when zero. Absence would be ambiguous between a capture
+			// that dropped nothing and one exported before this attribute existed,
+			// and the whole point of the count is that the span total can be
+			// trusted, which only an explicit claim supports.
+			otlpInt("mcpsnoop.session.missing_frames", int64(data.Session.MissingFrames)),
 		}},
 		ScopeSpans: []otlpScopeSpans{{Scope: otlpScope{Name: "mcpsnoop"}, Spans: spans}},
 	}}}
@@ -675,6 +687,11 @@ func otlpBool(key string, value bool) otlpAttribute {
 
 func otlpDouble(key string, value float64) otlpAttribute {
 	return otlpAttribute{Key: key, Value: otlpAnyValue{DoubleValue: &value}}
+}
+
+func otlpInt(key string, value int64) otlpAttribute {
+	encoded := strconv.FormatInt(value, 10)
+	return otlpAttribute{Key: key, Value: otlpAnyValue{IntValue: &encoded}}
 }
 
 func ExportFile(inputPath string, w io.Writer, opts Options) error {

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -97,6 +97,9 @@ type SessionSummary struct {
 	Notifications int       `json:"notifications"`
 	Errors        int       `json:"errors"`
 	Pending       int       `json:"pending"`
+	// MissingFrames counts envelopes dropped upstream, inferred from Seq gaps.
+	// A non-zero value means the capture is incomplete.
+	MissingFrames uint64 `json:"missing_frames"`
 }
 
 type CapabilitiesExport struct {
@@ -291,6 +294,7 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 			Notifications: header.Notifications,
 			Errors:        header.Errors,
 			Pending:       header.Pending,
+			MissingFrames: header.MissingFrames,
 		},
 		Calls:  outCalls,
 		Events: outEvents,
@@ -391,6 +395,8 @@ func Write(w io.Writer, data SessionExport, opts Options) error {
 // trace derived from the session id, so a session with no propagation still
 // reads as one unit. Either way mcpsnoop.session.id is a resource attribute
 // rather than a span one, so the tie back to the capture survives the split.
+// When Session.MissingFrames is non-zero the capture is incomplete and the span
+// count understates what actually happened on the wire.
 type otlpExport struct {
 	ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
 }

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -90,6 +90,45 @@ func TestBuildCorrelatedExport(t *testing.T) {
 	}
 }
 
+func TestBuildExportsMissingFrames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gap.jsonl")
+	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+	})
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 4, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+	})
+
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Session.MissingFrames != 2 {
+		t.Fatalf("missing_frames = %d, want 2", out.Session.MissingFrames)
+	}
+
+	var buf bytes.Buffer
+	if err := Write(&buf, out, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Session SessionSummary `json:"session"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Session.MissingFrames != 2 {
+		t.Fatalf("json export missing_frames = %d, want 2", payload.Session.MissingFrames)
+	}
+}
+
 func TestBuildExportsSupersededCallNotAsOk(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "reuse.jsonl")
 	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -890,3 +890,143 @@ func TestWriteOTLPOmitsTraceStateFieldWhenAbsent(t *testing.T) {
 		t.Fatalf("a span with no propagated state must omit traceState: %s", buf.String())
 	}
 }
+
+// incompleteSession is a one-call export with a stated number of dropped frames,
+// so the artifact tests differ only in the thing under test.
+func incompleteSession(missing uint64) SessionExport {
+	return SessionExport{
+		Session: SessionSummary{ID: "s1", Label: "demo", MissingFrames: missing},
+		Calls: []CallExport{{
+			ID:        "call-1",
+			Method:    "tools/list",
+			Direction: proxy.ClientToServer,
+			StartedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+}
+
+// TestWriteHARFlagsAnIncompleteCapture. The count already reaches the JSON
+// export and the check gate, but a HAR is opened somewhere else entirely, and a
+// call whose frames never reached the log is simply absent from it. Absence
+// reads as "it never happened", so the file has to say otherwise itself.
+func TestWriteHARFlagsAnIncompleteCapture(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteHAR(&buf, incompleteSession(3)); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Log struct {
+			Comment string `json:"comment"`
+			Entries []struct {
+				Time float64 `json:"time"`
+			} `json:"entries"`
+		} `json:"log"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid HAR JSON: %v\n%s", err, buf.String())
+	}
+	if payload.Log.Comment == "" {
+		t.Fatalf("an incomplete capture must say so in log.comment:\n%s", buf.String())
+	}
+	if !strings.Contains(payload.Log.Comment, "3 frames") {
+		t.Fatalf("the comment should name the count, got %q", payload.Log.Comment)
+	}
+	// The warning must not come at the cost of the entries themselves.
+	if len(payload.Log.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(payload.Log.Entries))
+	}
+}
+
+// TestWriteHARCommentIsSingularForOneFrame keeps the prose readable, since this
+// field is rendered to a person rather than parsed.
+func TestWriteHARCommentIsSingularForOneFrame(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteHAR(&buf, incompleteSession(1)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "1 frame were") && !strings.Contains(buf.String(), "1 frame was") {
+		t.Fatalf("expected singular wording for a single dropped frame:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), "1 frames") {
+		t.Fatalf("plural used for a single frame:\n%s", buf.String())
+	}
+}
+
+// TestWriteHAROmitsCommentWhenComplete. log.comment is prose for a reader, and a
+// remark on every export saying nothing was dropped is noise in a field devtools
+// surface as a note.
+func TestWriteHAROmitsCommentWhenComplete(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteHAR(&buf, incompleteSession(0)); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Log map[string]json.RawMessage `json:"log"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := payload.Log["comment"]; ok {
+		t.Fatalf("a complete capture should carry no comment:\n%s", buf.String())
+	}
+}
+
+// otlpResourceAttrs pulls the resource attributes out of an OTLP payload.
+func otlpResourceAttrs(t *testing.T, data SessionExport) map[string]otlpAnyValue {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteOTLP(&buf, data); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		ResourceSpans []struct {
+			Resource struct {
+				Attributes []otlpAttribute `json:"attributes"`
+			} `json:"resource"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid OTLP JSON: %v\n%s", err, buf.String())
+	}
+	if len(payload.ResourceSpans) != 1 {
+		t.Fatalf("unexpected OTLP hierarchy: %s", buf.String())
+	}
+	attrs := map[string]otlpAnyValue{}
+	for _, attr := range payload.ResourceSpans[0].Resource.Attributes {
+		attrs[attr.Key] = attr.Value
+	}
+	return attrs
+}
+
+// TestWriteOTLPCarriesMissingFrames. A resource attribute rather than a span one,
+// because incompleteness is a property of the capture, and resource attributes
+// survive the spans of one session landing in several traces.
+func TestWriteOTLPCarriesMissingFrames(t *testing.T) {
+	attrs := otlpResourceAttrs(t, incompleteSession(3))
+	value, ok := attrs["mcpsnoop.session.missing_frames"]
+	if !ok {
+		t.Fatalf("the dropped-frame count must reach the payload, got keys %v", attrs)
+	}
+	if value.IntValue == nil {
+		t.Fatalf("a count belongs in intValue so a backend can filter on it, got %+v", value)
+	}
+	// proto3 JSON encodes int64 as a string; a bare number is what a collector
+	// rejects after the payload has looked right all the way to the wire.
+	if *value.IntValue != "3" {
+		t.Fatalf("intValue = %q, want \"3\"", *value.IntValue)
+	}
+}
+
+// TestWriteOTLPStatesZeroMissingFrames. Absence would be ambiguous between a
+// capture that dropped nothing and one exported before the attribute existed,
+// and the point of the count is that the span total can be trusted.
+func TestWriteOTLPStatesZeroMissingFrames(t *testing.T) {
+	attrs := otlpResourceAttrs(t, incompleteSession(0))
+	value, ok := attrs["mcpsnoop.session.missing_frames"]
+	if !ok {
+		t.Fatal("a complete capture should claim zero rather than say nothing")
+	}
+	if value.IntValue == nil || *value.IntValue != "0" {
+		t.Fatalf("intValue = %+v, want \"0\"", value)
+	}
+}

--- a/internal/exporter/har.go
+++ b/internal/exporter/har.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 )
@@ -24,6 +25,12 @@ type harLog struct {
 	Version string     `json:"version"`
 	Creator harCreator `json:"creator"`
 	Entries []harEntry `json:"entries"`
+	// Comment is optional on log in HAR 1.2 and is where an incomplete capture
+	// says so. Unlike the OTLP attribute this is prose for a person reading the
+	// file, so it appears only when there is something to say; a note reading
+	// "nothing was dropped" on every export would be noise in a field that
+	// devtools render as a remark.
+	Comment string `json:"comment,omitempty"`
 }
 
 type harCreator struct {
@@ -106,8 +113,10 @@ const harHTTPVersion = "JSON-RPC/2.0"
 
 // WriteHAR renders a session as HAR 1.2, one entry per correlated call, so a
 // capture can be opened in the browser devtools and other tools that read HAR.
-// When Session.MissingFrames is non-zero the capture is incomplete and the
-// entry count understates what actually happened on the wire.
+//
+// When a capture is incomplete the entry count understates what happened on the
+// wire, so the file says so in log.comment. It belongs there rather than in this
+// doc comment: the person who needs it opened the HAR, not this file.
 func WriteHAR(w io.Writer, data SessionExport) error {
 	label := data.Session.Label
 	if label == "" {
@@ -164,6 +173,7 @@ func WriteHAR(w io.Writer, data SessionExport) error {
 		Version: "1.2",
 		Creator: harCreator{Name: "mcpsnoop", Version: Version},
 		Entries: entries,
+		Comment: harIncompleteComment(data.Session.MissingFrames),
 	}}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -212,4 +222,25 @@ func harResponseBody(call CallExport) string {
 		}
 	}
 	return ""
+}
+
+// harIncompleteComment describes a lossy capture for whoever opens the file, or
+// returns "" when nothing was dropped.
+//
+// The wording says what the reader can and cannot conclude, because the risk
+// here is not that entries look wrong but that they look complete: a call whose
+// frames never reached the log is simply absent, and absence reads as "it never
+// happened" rather than "we did not see it".
+func harIncompleteComment(missing uint64) string {
+	if missing == 0 {
+		return ""
+	}
+	frames := "frames"
+	if missing == 1 {
+		frames = "frame"
+	}
+	return fmt.Sprintf(
+		"mcpsnoop: capture incomplete, %d %s were dropped before being recorded. "+
+			"The entry count is a lower bound, and a call missing from this file may "+
+			"have happened on the wire.", missing, frames)
 }

--- a/internal/exporter/har.go
+++ b/internal/exporter/har.go
@@ -106,6 +106,8 @@ const harHTTPVersion = "JSON-RPC/2.0"
 
 // WriteHAR renders a session as HAR 1.2, one entry per correlated call, so a
 // capture can be opened in the browser devtools and other tools that read HAR.
+// When Session.MissingFrames is non-zero the capture is incomplete and the
+// entry count understates what actually happened on the wire.
 func WriteHAR(w io.Writer, data SessionExport) error {
 	label := data.Session.Label
 	if label == "" {


### PR DESCRIPTION
## Summary

Expose `SessionHeader.MissingFrames` in JSON export `SessionSummary` and surface `missing_frames` in `mcpsnoop check` output. Add an opt-in `incomplete` signal to `--fail-on` so CI can reject lossy captures.

## Motivation

The store already infers dropped envelopes from Seq gaps and shows the count in the TUI, but `check` and `export` omitted it. A gate that reads green on a capture known to be missing frames is worse than one that reads red.

Fixes #165

## Changes

- Add `missing_frames` to exported `SessionSummary` JSON
- Report `missing_frames=N` in `mcpsnoop check` text output
- Add opt-in `incomplete` signal to `--fail-on` (JUnit testcase included)
- Note incomplete-capture caveat in HAR/OTLP export comments
- Update README `--fail-on` documentation

## Tests

- `go test ./cmd/mcpsnoop/... ./internal/exporter/... -count=1` — PASS
- Added tests for default reporting, `--fail-on incomplete`, and JSON export round-trip

## Notes

`incomplete` is opt-in like `drift` and `pending`, so default CI gates are unchanged. Composer-2.5 review: APPROVE.