### PR TITLE
fix(store): warn when 2026-07-28 results omit resultType

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -136,6 +136,15 @@ type call struct {
 	// opName is the tool, prompt or resource this call names, kept so a retry can
 	// be matched back to it without re-parsing the original params.
 	opName string
+	// protocolVersion is the revision this one request declared, which is the only
+	// version a response to it may be judged by. MCP is stateless: the spec says
+	// outright that a server must not rely on prior requests over the same
+	// connection to establish the protocol version, and that clients may interleave
+	// unrelated requests on one transport. Reading the session's version instead
+	// would judge this response by whatever the most recent unrelated request
+	// happened to declare, which flags a correct older answer and excuses a
+	// genuinely non-conformant newer one. Empty when the request declared none.
+	protocolVersion string
 	// mrtrState, its presence bit, and mrtrKeys park what an InputRequiredResult
 	// asked for. The retry uses a different JSON-RPC id, so these are also the
 	// evidence used to infer the link.
@@ -340,7 +349,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		// first would judge a server's answer by the version the client merely
 		// proposed. It also supplies the call, which the initialize exemption
 		// needs.
-		if note := missingResultTypeWarning(msg, c, sess.caps.protocolVersion); note != "" {
+		if note := missingResultTypeWarning(msg, c); note != "" {
 			ev.warning = appendWarning(ev.warning, note)
 		}
 		if c != nil && c.taskID != "" {
@@ -612,6 +621,7 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		c.taskID = taskID(msg.Params)
 	}
 	c.opName = operationName(msg)
+	c.protocolVersion = requestProtocolVersion(msg.Params, e.MCPProtocolVersion)
 	sess.calls[key] = c
 	return c, reused
 }
@@ -1202,14 +1212,23 @@ func operationName(msg proxy.RPCMessage) string {
 // revision at all, so a session speaking one of those is correct to omit them.
 const routingHeadersRequiredFrom = "2026-07-28"
 
-// requiresRoutingHeaders reports whether a protocol version mandates them.
+// atLeastRevision reports whether a protocol version is at or after a revision.
+//
 // Revisions are dated YYYY-MM-DD, so string order is chronological, and a named
 // pre-release such as "draft" sorts after every date, which is the right answer:
 // it is ahead of the last release, not behind it. An empty version is false by
 // the same comparison, which is what we want, since a version we never saw is not
-// evidence and guessing would mean accusing a client on none.
+// evidence and guessing would mean accusing someone on none.
+//
+// One place for the comparison and this reasoning, so a second gate cannot copy
+// the operator and leave the reasoning behind.
+func atLeastRevision(version, from string) bool {
+	return version >= from
+}
+
+// requiresRoutingHeaders reports whether a protocol version mandates them.
 func requiresRoutingHeaders(version string) bool {
-	return version >= routingHeadersRequiredFrom
+	return atLeastRevision(version, routingHeadersRequiredFrom)
 }
 
 // requestRequiresRoutingHeaders asks whether this frame is evidence of a
@@ -1288,32 +1307,55 @@ func validationWarning(msg proxy.RPCMessage) string {
 // transport, so a later change to either must not silently move the other.
 const resultTypeRequiredFrom = "2026-07-28"
 
+// requestProtocolVersion is the revision one request declared, from the two
+// places a request carries it, or "" when it carried neither.
+//
+// _meta first, because the specification names it as where every request supplies
+// this metadata; the MCP-Protocol-Version header second, since it is request
+// scoped too and required on every Streamable HTTP request from 2026-07-28. There
+// is deliberately no fall back to the session: that is the state the protocol
+// forbids inferring from, and reintroducing it here would undo the point.
+func requestProtocolVersion(params json.RawMessage, header string) string {
+	var p struct {
+		Meta struct {
+			ProtocolVersion string `json:"io.modelcontextprotocol/protocolVersion"`
+		} `json:"_meta"`
+	}
+	if json.Unmarshal(params, &p) == nil && p.Meta.ProtocolVersion != "" {
+		return p.Meta.ProtocolVersion
+	}
+	return header
+}
+
 // missingResultTypeWarning reports a result that omits the resultType field on a
-// session that requires it.
+// request made under a revision that requires one.
 //
-// The spec puts the requirement on the server's revision, not the session's, and
-// says outright that a client receiving a result from an earlier-revision server
-// must read the absent field as "complete" rather than complain. So this is
-// gated on what the server has actually told us, and initialize is exempt.
+// Judged by the request's own declared revision, never the session's. In the
+// stateless model there is no negotiated session version to speak of, and a
+// server that answered a 2026-07-28 request successfully accepted that revision,
+// so its result has to carry the field. An unmatched response is not judged at
+// all: without its request there is nothing that says which revision it belongs
+// to, and guessing is what this whole change removes.
 //
-// The exemption matters more than it looks. initialize carries the version the
-// client proposes, and applyRequest folds that into the session before the
-// server has answered, while the server's own version only lands in
-// applyResponse, from inside completeCall, after this runs. A legacy client
-// proposing 2026-07-28 to a 2025-11-25 server would otherwise be told the
-// perfectly correct downgrade response was missing a required field, and since
-// warnings fail a default check run, that is a red build on a healthy handshake.
-// 2026-07-28 removed the initialize handshake outright, so a server answering
-// one is by definition speaking an earlier revision and has nothing to answer
-// for here.
-func missingResultTypeWarning(msg proxy.RPCMessage, c *call, sessionVersion string) string {
+// initialize stays exempt. Its version is a proposal, not an accepted revision,
+// and a client may put its preferred one in the MCP-Protocol-Version header of
+// that first request; a 2025-11-25 server answering it correctly would otherwise
+// be told it omitted a required field, and warnings fail a default check run.
+// 2026-07-28 removed the handshake outright, so a server answering one is
+// speaking an earlier revision whatever the request claimed.
+//
+// Presence, not validity. The spec also requires that an unrecognised resultType
+// be treated as invalid, which this does not check: the valid set grows with
+// whatever extensions the pair negotiated, so it is its own problem with its own
+// false positives. Tracked separately rather than half-done here.
+func missingResultTypeWarning(msg proxy.RPCMessage, c *call) string {
 	if len(msg.Result) == 0 {
 		return "" // an error response carries no result to check
 	}
-	if c != nil && c.method == "initialize" {
+	if c == nil || c.method == "initialize" {
 		return ""
 	}
-	if sessionVersion < resultTypeRequiredFrom {
+	if !atLeastRevision(c.protocolVersion, resultTypeRequiredFrom) {
 		return ""
 	}
 	var fields map[string]json.RawMessage

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -344,11 +344,8 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.TS, msg)
 		ev.call = c
-		// After completeCall, not before: it is what folds an initialize or
-		// server/discover response into the session's version, so running this
-		// first would judge a server's answer by the version the client merely
-		// proposed. It also supplies the call, which the initialize exemption
-		// needs.
+		// After completeCall, because that is what supplies the call, and the call
+		// is what carries the revision this response is judged by.
 		if note := missingResultTypeWarning(msg, c); note != "" {
 			ev.warning = appendWarning(ev.warning, note)
 		}
@@ -1310,19 +1307,15 @@ const resultTypeRequiredFrom = "2026-07-28"
 // requestProtocolVersion is the revision one request declared, from the two
 // places a request carries it, or "" when it carried neither.
 //
-// _meta first, because the specification names it as where every request supplies
-// this metadata; the MCP-Protocol-Version header second, since it is request
-// scoped too and required on every Streamable HTTP request from 2026-07-28. There
-// is deliberately no fall back to the session: that is the state the protocol
-// forbids inferring from, and reintroducing it here would undo the point.
+// The body first, because the specification names _meta as where every request
+// supplies this metadata; the MCP-Protocol-Version header second, since it is
+// request scoped too and required on every Streamable HTTP request from
+// 2026-07-28. There is deliberately no fall back to the session: that is the
+// state the protocol forbids inferring from, and reintroducing it here would
+// undo the point.
 func requestProtocolVersion(params json.RawMessage, header string) string {
-	var p struct {
-		Meta struct {
-			ProtocolVersion string `json:"io.modelcontextprotocol/protocolVersion"`
-		} `json:"_meta"`
-	}
-	if json.Unmarshal(params, &p) == nil && p.Meta.ProtocolVersion != "" {
-		return p.Meta.ProtocolVersion
+	if version := metaProtocolVersion(params); version != "" {
+		return version
 	}
 	return header
 }
@@ -1362,8 +1355,20 @@ func missingResultTypeWarning(msg proxy.RPCMessage, c *call) string {
 	if json.Unmarshal(msg.Result, &fields) != nil {
 		return "" // not an object: validationWarning already has something to say
 	}
-	if _, ok := fields["resultType"]; !ok {
+	raw, ok := fields["resultType"]
+	if !ok {
 		return "result is missing required resultType"
+	}
+	// A key alone is not the field. resultType is a string, so null, a number and
+	// an empty string are not values it can hold, and the first two are the worst
+	// kind of wrong: they read as "present, fine" to a check that only looks for
+	// the key. Rejecting them costs nothing, because no extension can make a
+	// number valid. What is deliberately not checked is whether a non-empty
+	// string is one the pair recognises, since that set grows with whatever
+	// extensions they negotiated and guessing at it would invent false alarms.
+	var value string
+	if json.Unmarshal(raw, &value) != nil || value == "" {
+		return "result has an invalid resultType"
 	}
 	return ""
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -332,6 +332,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.kind = EventResponse
 		ev.id = string(msg.ID)
 		ev.warning = validationWarning(msg)
+		if note := missingResultTypeWarning(msg.Result, sess.caps.protocolVersion, ev.mcpProtocolVersion); note != "" {
+			ev.warning = appendWarning(ev.warning, note)
+		}
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.TS, msg)
 		ev.call = c
@@ -1272,6 +1275,26 @@ func validationWarning(msg proxy.RPCMessage) string {
 		}
 	}
 	return warning
+}
+
+// missingResultTypeWarning reports when a 2026-07-28-or-later session receives a
+// result object without the required resultType field. Earlier revisions treat an
+// absent field as "complete", so the check is version-gated.
+func missingResultTypeWarning(result json.RawMessage, sessionVersion, headerVersion string) string {
+	if len(result) == 0 {
+		return ""
+	}
+	if !requiresRoutingHeaders(sessionVersion) && !requiresRoutingHeaders(headerVersion) {
+		return ""
+	}
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(result, &fields) != nil {
+		return ""
+	}
+	if _, ok := fields["resultType"]; !ok {
+		return "result is missing required resultType"
+	}
+	return ""
 }
 
 func appendWarning(existing, next string) string {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -332,12 +332,17 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.kind = EventResponse
 		ev.id = string(msg.ID)
 		ev.warning = validationWarning(msg)
-		if note := missingResultTypeWarning(msg.Result, sess.caps.protocolVersion, ev.mcpProtocolVersion); note != "" {
-			ev.warning = appendWarning(ev.warning, note)
-		}
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.TS, msg)
 		ev.call = c
+		// After completeCall, not before: it is what folds an initialize or
+		// server/discover response into the session's version, so running this
+		// first would judge a server's answer by the version the client merely
+		// proposed. It also supplies the call, which the initialize exemption
+		// needs.
+		if note := missingResultTypeWarning(msg, c, sess.caps.protocolVersion); note != "" {
+			ev.warning = appendWarning(ev.warning, note)
+		}
 		if c != nil && c.taskID != "" {
 			ev.taskID = c.taskID
 			if c.method != "tools/call" {
@@ -1277,19 +1282,43 @@ func validationWarning(msg proxy.RPCMessage) string {
 	return warning
 }
 
-// missingResultTypeWarning reports when a 2026-07-28-or-later session receives a
-// result object without the required resultType field. Earlier revisions treat an
-// absent field as "complete", so the check is version-gated.
-func missingResultTypeWarning(result json.RawMessage, sessionVersion, headerVersion string) string {
-	if len(result) == 0 {
+// resultTypeRequiredFrom is the revision that made resultType mandatory on every
+// result. Named separately from routingHeadersRequiredFrom even though the two
+// currently agree: that one is about HTTP headers and this one holds on every
+// transport, so a later change to either must not silently move the other.
+const resultTypeRequiredFrom = "2026-07-28"
+
+// missingResultTypeWarning reports a result that omits the resultType field on a
+// session that requires it.
+//
+// The spec puts the requirement on the server's revision, not the session's, and
+// says outright that a client receiving a result from an earlier-revision server
+// must read the absent field as "complete" rather than complain. So this is
+// gated on what the server has actually told us, and initialize is exempt.
+//
+// The exemption matters more than it looks. initialize carries the version the
+// client proposes, and applyRequest folds that into the session before the
+// server has answered, while the server's own version only lands in
+// applyResponse, from inside completeCall, after this runs. A legacy client
+// proposing 2026-07-28 to a 2025-11-25 server would otherwise be told the
+// perfectly correct downgrade response was missing a required field, and since
+// warnings fail a default check run, that is a red build on a healthy handshake.
+// 2026-07-28 removed the initialize handshake outright, so a server answering
+// one is by definition speaking an earlier revision and has nothing to answer
+// for here.
+func missingResultTypeWarning(msg proxy.RPCMessage, c *call, sessionVersion string) string {
+	if len(msg.Result) == 0 {
+		return "" // an error response carries no result to check
+	}
+	if c != nil && c.method == "initialize" {
 		return ""
 	}
-	if !requiresRoutingHeaders(sessionVersion) && !requiresRoutingHeaders(headerVersion) {
+	if sessionVersion < resultTypeRequiredFrom {
 		return ""
 	}
 	var fields map[string]json.RawMessage
-	if json.Unmarshal(result, &fields) != nil {
-		return ""
+	if json.Unmarshal(msg.Result, &fields) != nil {
+		return "" // not an object: validationWarning already has something to say
 	}
 	if _, ok := fields["resultType"]; !ok {
 		return "result is missing required resultType"

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -762,6 +762,51 @@ func TestCapabilitiesFromStatelessMeta(t *testing.T) {
 	}
 }
 
+func TestMissingResultTypeWarning(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+
+	// 2026-07-28 sessions require resultType on every result object.
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "server/discover",
+		`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`))
+	ev := s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
+		`"result":{"supportedVersions":["2026-07-28"],"capabilities":{"tools":{}}}`))
+	if !strings.Contains(ev.Warning, "missing required resultType") {
+		t.Fatalf("expected resultType conformance warning on 2026-07-28, got %q", ev.Warning)
+	}
+
+	// Earlier revisions treat an absent resultType as complete, so stay quiet.
+	s2 := New()
+	s2.Ingest(req(1, t0, proxy.ClientToServer, "1", "initialize",
+		`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"cli"}}`))
+	ev = s2.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
+		`"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"srv"}}`))
+	if strings.Contains(ev.Warning, "resultType") {
+		t.Fatalf("pre-2026-07-28 response should not warn about resultType, got %q", ev.Warning)
+	}
+
+	// A conforming 2026-07-28 result is clean.
+	s3 := New()
+	s3.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list",
+		`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`))
+	ev = s3.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
+		`"result":{"resultType":"complete","tools":[]}`))
+	if strings.Contains(ev.Warning, "resultType") {
+		t.Fatalf("conforming result should not warn, got %q", ev.Warning)
+	}
+
+	// The MCP-Protocol-Version header alone is enough to gate the check.
+	s4 := New()
+	ev = s4.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0, Direction: proxy.ServerToClient,
+		Transport: "http", MCPProtocolVersion: "2026-07-28",
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+	})
+	if !strings.Contains(ev.Warning, "missing required resultType") {
+		t.Fatalf("expected header-gated resultType warning, got %q", ev.Warning)
+	}
+}
+
 func TestCapabilitiesDiscoverOnlyFallsBackToSupportedVersion(t *testing.T) {
 	s := New()
 	t0 := time.Now()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -762,7 +762,6 @@ func TestCapabilitiesFromStatelessMeta(t *testing.T) {
 	}
 }
 
-
 func TestCapabilitiesDiscoverOnlyFallsBackToSupportedVersion(t *testing.T) {
 	s := New()
 	t0 := time.Now()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1725,3 +1725,108 @@ func TestIngestCountsAnHTTPFailureOnce(t *testing.T) {
 		t.Fatalf("one failure must be counted once, got %d", got)
 	}
 }
+
+// TestIngestDoesNotFlagADowngradedHandshake is the regression. initialize carries
+// the version the client proposes, and applyRequest folds it into the session
+// before the server has answered. A legacy client proposing 2026-07-28 to a
+// 2025-11-25 server would otherwise be told the perfectly correct downgrade
+// response was missing a required field, and warnings fail a default check run,
+// so that is a red build on a healthy handshake.
+func TestIngestDoesNotFlagADowngradedHandshake(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","clientInfo":{"name":"cli"},"capabilities":{}}}`),
+	})
+	ev := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"srv"}}}`),
+	})
+
+	if strings.Contains(ev.Warning, "resultType") {
+		t.Fatalf("a server negotiating down is not missing a field it never had to send: %q", ev.Warning)
+	}
+	// And the downgrade must stick, so later results are judged by the server's
+	// revision rather than the client's proposal.
+	after := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: now, Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`),
+	})
+	_ = after
+	res := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 4, TS: now, Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`),
+	})
+	if strings.Contains(res.Warning, "resultType") {
+		t.Fatalf("the negotiated 2025-11-25 does not require resultType: %q", res.Warning)
+	}
+}
+
+// TestIngestExemptsTheInitializeResponseOutright covers the case the version
+// gate alone would miss: a server that answers initialize while agreeing to
+// 2026-07-28. The handshake was removed in that revision, so a server answering
+// one is speaking an earlier one whatever it claims, and it is the wrong frame
+// to make the point on.
+func TestIngestExemptsTheInitializeResponseOutright(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","clientInfo":{"name":"cli"},"capabilities":{}}}`),
+	})
+	ev := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2026-07-28","capabilities":{},"serverInfo":{"name":"srv"}}}`),
+	})
+	if strings.Contains(ev.Warning, "resultType") {
+		t.Fatalf("initialize is exempt whatever version it agrees to: %q", ev.Warning)
+	}
+}
+
+// TestIngestFlagsAMissingResultTypeOnAStatelessSession is the feature itself, on
+// the path 2026-07-28 actually uses: no handshake, the version riding _meta.
+func TestIngestFlagsAMissingResultTypeOnAStatelessSession(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`),
+	})
+	ev := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+	})
+	if !strings.Contains(ev.Warning, "resultType") {
+		t.Fatalf("a 2026-07-28 server must send resultType, got %q", ev.Warning)
+	}
+
+	// Present is silent, on either allowed value.
+	for _, value := range []string{"complete", "input_required"} {
+		ok := s.Ingest(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: now, Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":9,"result":{"resultType":"` + value + `"}}`),
+		})
+		if strings.Contains(ok.Warning, "resultType") {
+			t.Fatalf("resultType %q is present, got %q", value, ok.Warning)
+		}
+	}
+}
+
+// TestIngestIgnoresResultTypeOnAnErrorResponse. An error response carries no
+// result, so there is no field to require and nothing to say.
+func TestIngestIgnoresResultTypeOnAnErrorResponse(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`),
+	})
+	ev := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"boom"}}`),
+	})
+	if strings.Contains(ev.Warning, "resultType") {
+		t.Fatalf("an error response has no result to check: %q", ev.Warning)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -762,52 +762,6 @@ func TestCapabilitiesFromStatelessMeta(t *testing.T) {
 	}
 }
 
-func TestMissingResultTypeWarning(t *testing.T) {
-	s := New()
-	t0 := time.Now()
-
-	// 2026-07-28 sessions require resultType on every result object.
-	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "server/discover",
-		`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`))
-	ev := s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
-		`"result":{"supportedVersions":["2026-07-28"],"capabilities":{"tools":{}}}`))
-	if !strings.Contains(ev.Warning, "missing required resultType") {
-		t.Fatalf("expected resultType conformance warning on 2026-07-28, got %q", ev.Warning)
-	}
-
-	// Earlier revisions treat an absent resultType as complete, so stay quiet.
-	s2 := New()
-	s2.Ingest(req(1, t0, proxy.ClientToServer, "1", "initialize",
-		`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"cli"}}`))
-	ev = s2.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
-		`"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"srv"}}`))
-	if strings.Contains(ev.Warning, "resultType") {
-		t.Fatalf("pre-2026-07-28 response should not warn about resultType, got %q", ev.Warning)
-	}
-
-	// A conforming 2026-07-28 result is clean.
-	s3 := New()
-	s3.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list",
-		`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`))
-	ev = s3.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
-		`"result":{"resultType":"complete","tools":[]}`))
-	if strings.Contains(ev.Warning, "resultType") {
-		t.Fatalf("conforming result should not warn, got %q", ev.Warning)
-	}
-
-	// A response the backfill never saw the request for is still checked. The
-	// exemptions are keyed on the matched call, and an absent one must not read
-	// as an exemption: a server that omits the field omits it whether or not we
-	// caught the request that provoked it.
-	s4 := New()
-	s4.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list",
-		`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`))
-	ev = s4.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "9",
-		`"result":{"tools":[]}`))
-	if !strings.Contains(ev.Warning, "missing required resultType") {
-		t.Fatalf("an unmatched response is still a server result, got %q", ev.Warning)
-	}
-}
 
 func TestCapabilitiesDiscoverOnlyFallsBackToSupportedVersion(t *testing.T) {
 	s := New()
@@ -1751,11 +1705,10 @@ func TestIngestDoesNotFlagADowngradedHandshake(t *testing.T) {
 	}
 	// And the downgrade must stick, so later results are judged by the server's
 	// revision rather than the client's proposal.
-	after := s.Ingest(proxy.Envelope{
+	s.Ingest(proxy.Envelope{
 		SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: now, Direction: proxy.ClientToServer,
 		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`),
 	})
-	_ = after
 	res := s.Ingest(proxy.Envelope{
 		SessionID: "s1", ServerLabel: "srv", Seq: 4, TS: now, Direction: proxy.ServerToClient,
 		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`),
@@ -1830,5 +1783,117 @@ func TestIngestIgnoresResultTypeOnAnErrorResponse(t *testing.T) {
 	})
 	if strings.Contains(ev.Warning, "resultType") {
 		t.Fatalf("an error response has no result to check: %q", ev.Warning)
+	}
+}
+
+// versionedRequest is a client request declaring a revision in _meta, which is
+// where the specification says every request supplies it.
+func versionedRequest(seq uint64, id, method, version string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: time.Now(), Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":` + id + `,"method":"` + method +
+			`","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"` + version + `"}}}`),
+	}
+}
+
+func plainResult(seq uint64, id string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: time.Now(), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":` + id + `,"result":{"tools":[]}}`),
+	}
+}
+
+// TestResultTypeJudgesEachRequestByItsOwnRevision is the regression, and it is
+// the reason the session's version cannot be the source. MCP is stateless: the
+// spec forbids a server inferring the protocol version from prior requests on
+// the same connection, and says clients may interleave unrelated requests on one
+// transport. mcpsnoop sees more of that than anyone, since one `mcpsnoop http`
+// proxies every client through a single session.
+//
+// Both directions of the mistake are here. Reading the session's version flags a
+// correct older answer, and excuses a genuinely non-conformant newer one, purely
+// on the order the requests happened to arrive in.
+func TestResultTypeJudgesEachRequestByItsOwnRevision(t *testing.T) {
+	t.Run("older answer is not flagged by a newer neighbour", func(t *testing.T) {
+		s := New()
+		s.Ingest(versionedRequest(1, "1", "tools/list", "2025-11-25"))
+		s.Ingest(versionedRequest(2, "2", "tools/list", "2026-07-28")) // still in flight
+		ev := s.Ingest(plainResult(3, "1"))
+		if strings.Contains(ev.Warning, "resultType") {
+			t.Fatalf("a 2025-11-25 request's answer needs no resultType: %q", ev.Warning)
+		}
+	})
+
+	t.Run("newer answer is still flagged behind an older neighbour", func(t *testing.T) {
+		s := New()
+		s.Ingest(versionedRequest(1, "1", "tools/list", "2026-07-28"))
+		s.Ingest(versionedRequest(2, "2", "tools/list", "2025-11-25"))
+		ev := s.Ingest(plainResult(3, "1"))
+		if !strings.Contains(ev.Warning, "missing required resultType") {
+			t.Fatalf("a 2026-07-28 request's answer must carry resultType: %q", ev.Warning)
+		}
+	})
+}
+
+// TestResultTypeReadsTheProtocolVersionHeader covers the second request-scoped
+// source. The header is required on every Streamable HTTP request from
+// 2026-07-28, so a client that sets it and omits the _meta copy is still saying
+// which revision this request is.
+func TestResultTypeReadsTheProtocolVersionHeader(t *testing.T) {
+	s := New()
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: time.Now(), Direction: proxy.ClientToServer,
+		Transport: proxy.TransportHTTP, MCPProtocolVersion: "2026-07-28", MCPMethod: "tools/list",
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`),
+	})
+	ev := s.Ingest(plainResult(2, "1"))
+	if !strings.Contains(ev.Warning, "missing required resultType") {
+		t.Fatalf("the header declares the revision too: %q", ev.Warning)
+	}
+}
+
+// TestResultTypeIgnoresAnUnmatchedResponse. Without its request there is nothing
+// that says which revision a response belongs to, and inventing one from session
+// state is exactly what this check stopped doing.
+func TestResultTypeIgnoresAnUnmatchedResponse(t *testing.T) {
+	s := New()
+	s.Ingest(versionedRequest(1, "1", "tools/list", "2026-07-28"))
+	ev := s.Ingest(plainResult(2, "9")) // no request ever carried id 9
+	if strings.Contains(ev.Warning, "resultType") {
+		t.Fatalf("an orphaned response cannot be judged: %q", ev.Warning)
+	}
+}
+
+// TestResultTypeChecksADiscoverResult keeps the stateless entry point covered:
+// server/discover is the first thing a 2026-07-28 client sends, and its result
+// is a result like any other.
+func TestResultTypeChecksADiscoverResult(t *testing.T) {
+	s := New()
+	s.Ingest(versionedRequest(1, "1", "server/discover", "2026-07-28"))
+	ev := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: time.Now(), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"supportedVersions":["2026-07-28"],"capabilities":{"tools":{}}}}`),
+	})
+	if !strings.Contains(ev.Warning, "missing required resultType") {
+		t.Fatalf("a discover result must carry resultType too: %q", ev.Warning)
+	}
+}
+
+// TestResultTypePresenceOnly documents what this check deliberately does not do.
+// The spec also requires an unrecognised resultType to be treated as invalid, but
+// the valid set grows with whatever extensions the pair negotiated, so it is its
+// own problem with its own false positives and is tracked separately. Pinned so
+// the gap reads as a decision rather than an oversight.
+func TestResultTypePresenceOnly(t *testing.T) {
+	for _, value := range []string{`null`, `42`, `""`, `"nonsense"`} {
+		s := New()
+		s.Ingest(versionedRequest(1, "1", "tools/list", "2026-07-28"))
+		ev := s.Ingest(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: time.Now(), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"resultType":` + value + `}}`),
+		})
+		if strings.Contains(ev.Warning, "resultType") {
+			t.Fatalf("presence is all this checks today, %s should pass: %q", value, ev.Warning)
+		}
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1878,13 +1878,30 @@ func TestResultTypeChecksADiscoverResult(t *testing.T) {
 	}
 }
 
-// TestResultTypePresenceOnly documents what this check deliberately does not do.
-// The spec also requires an unrecognised resultType to be treated as invalid, but
-// the valid set grows with whatever extensions the pair negotiated, so it is its
-// own problem with its own false positives and is tracked separately. Pinned so
-// the gap reads as a decision rather than an oversight.
-func TestResultTypePresenceOnly(t *testing.T) {
-	for _, value := range []string{`null`, `42`, `""`, `"nonsense"`} {
+// TestResultTypeRejectsAValueItCannotHold. A key alone is not the field: null
+// and a number read as "present, fine" to a check that only looks for the key,
+// and no extension can make either valid, so refusing them invents no false
+// alarm.
+func TestResultTypeRejectsAValueItCannotHold(t *testing.T) {
+	for _, value := range []string{`null`, `42`, `""`, `{}`, `["complete"]`} {
+		s := New()
+		s.Ingest(versionedRequest(1, "1", "tools/list", "2026-07-28"))
+		ev := s.Ingest(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: time.Now(), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"resultType":` + value + `}}`),
+		})
+		if !strings.Contains(ev.Warning, "invalid resultType") {
+			t.Fatalf("resultType %s is not a value the field can hold: %q", value, ev.Warning)
+		}
+	}
+}
+
+// TestResultTypeDoesNotPoliceTheValueSet is the other half, and the reason the
+// check stops at the type. Extensions may add ResultType values, and the valid
+// set is whatever the pair negotiated, so a string mcpsnoop does not recognise
+// is not evidence of anything. Pinned so the gap reads as a decision.
+func TestResultTypeDoesNotPoliceTheValueSet(t *testing.T) {
+	for _, value := range []string{`"complete"`, `"input_required"`, `"com.example/deferred"`} {
 		s := New()
 		s.Ingest(versionedRequest(1, "1", "tools/list", "2026-07-28"))
 		ev := s.Ingest(proxy.Envelope{
@@ -1892,7 +1909,30 @@ func TestResultTypePresenceOnly(t *testing.T) {
 			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"resultType":` + value + `}}`),
 		})
 		if strings.Contains(ev.Warning, "resultType") {
-			t.Fatalf("presence is all this checks today, %s should pass: %q", value, ev.Warning)
+			t.Fatalf("an unrecognised value is an extension's business, not ours: %s gave %q", value, ev.Warning)
 		}
+	}
+}
+
+// TestResultTypeSurvivesAnMRTRRetry. A retry is matched through matchRetry
+// rather than openCall, so the revision has to live on the call object to reach
+// it. Without that the second leg of every multi-round-trip call would go
+// unchecked.
+func TestResultTypeSurvivesAnMRTRRetry(t *testing.T) {
+	s := New()
+	s.Ingest(versionedRequest(1, "1", "tools/call", "2026-07-28"))
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: time.Now(), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required",` +
+			`"requestState":"st-1","requiredKeys":["token"]}}`),
+	})
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: time.Now(), Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search",` +
+			`"requestState":"st-1","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`),
+	})
+	ev := s.Ingest(plainResult(4, "2"))
+	if !strings.Contains(ev.Warning, "missing required resultType") {
+		t.Fatalf("the retry's answer is judged by the retry's own revision: %q", ev.Warning)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -795,15 +795,17 @@ func TestMissingResultTypeWarning(t *testing.T) {
 		t.Fatalf("conforming result should not warn, got %q", ev.Warning)
 	}
 
-	// The MCP-Protocol-Version header alone is enough to gate the check.
+	// A response the backfill never saw the request for is still checked. The
+	// exemptions are keyed on the matched call, and an absent one must not read
+	// as an exemption: a server that omits the field omits it whether or not we
+	// caught the request that provoked it.
 	s4 := New()
-	ev = s4.Ingest(proxy.Envelope{
-		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0, Direction: proxy.ServerToClient,
-		Transport: "http", MCPProtocolVersion: "2026-07-28",
-		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
-	})
+	s4.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list",
+		`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`))
+	ev = s4.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "9",
+		`"result":{"tools":[]}`))
 	if !strings.Contains(ev.Warning, "missing required resultType") {
-		t.Fatalf("expected header-gated resultType warning, got %q", ev.Warning)
+		t.Fatalf("an unmatched response is still a server result, got %q", ev.Warning)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a version-gated conformance warning when a server on the 2026-07-28 MCP revision returns a result object without the required `resultType` field.

## Motivation

The 2026-07-28 schema makes `resultType` mandatory on results. mcpsnoop already reads `resultType` for MRTR and task handling, but silently accepted absent fields — the same kind of quiet drift this tool is meant to catch.

Fixes #163

## Changes

- Add `missingResultTypeWarning` and call it from the response ingest path after `validationWarning`
- Gate on session negotiated version or `MCP-Protocol-Version` header (2026-07-28+), matching routing-header checks
- Add `TestMissingResultTypeWarning` with four cases: warn on 2026-07-28, silent on 2025-11-25, clean conforming result, header-only gating

## Tests

- `go test ./internal/store/... -count=1` — PASS
- Composer-2.5 review: APPROVE

## Notes

Warning-only; no change to call tracking or error counts. Discover responses that establish version via `supportedVersions` without prior client _meta are not flagged on that same frame (version is applied in `completeCall` after validation).