### PR TITLE
fix(store): treat subscriptions/listen as streaming, not pending

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -723,6 +723,8 @@ func exportCall(index int, c store.CallView) CallExport {
 	switch {
 	case c.State == store.Pending:
 		status = "pending"
+	case c.State == store.Streaming:
+		status = "streaming"
 	case c.State == store.Superseded:
 		status = "superseded"
 	case c.TaskStatus == "cancelled":

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,9 @@ const (
 	// Superseded means the request's id was reused by a later in-flight request, so
 	// this one can never be matched to a response. It is no longer pending.
 	Superseded
+	// Streaming means a long-lived stream request (subscriptions/listen) whose
+	// response arrives only when the stream ends. It is open but not pending.
+	Streaming
 )
 
 func (s CallState) String() string {
@@ -44,6 +47,8 @@ func (s CallState) String() string {
 		return "failed"
 	case Superseded:
 		return "superseded"
+	case Streaming:
+		return "streaming"
 	default:
 		return "pending"
 	}
@@ -402,7 +407,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.requests++
 		if reused {
 			ev.warning = appendWarning(ev.warning, "request reuses an id already in flight")
-		} else {
+		} else if ev.call.state != Streaming {
 			sess.pending++
 		}
 		if msg.Method == "initialize" {
@@ -413,6 +418,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.method = msg.Method
 		ev.warning = validationWarning(msg)
 		sess.notifications++
+		if msg.Method == "notifications/cancelled" {
+			if id := cancelledRequestID(msg.Params); id != "" {
+				sess.closeStreamingCall(id, e.TS)
+			}
+		}
 		if msg.Method == "notifications/tasks" {
 			if state, ok := parseTaskState(msg.Params); ok {
 				ev.taskID = state.TaskID
@@ -578,7 +588,7 @@ func (s *Store) sessionFor(e proxy.Envelope) *session {
 func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope) (*call, bool) {
 	key := callKey{dir: e.Direction, id: id}
 	prev, ok := sess.calls[key]
-	reused := ok && prev.state == Pending
+	reused := ok && (prev.state == Pending || prev.state == Streaming)
 	if reused {
 		// The earlier in-flight call keeps this id, so it will never be matched now.
 		// Mark it superseded (not pending) so the timeline stops rendering it as a
@@ -595,6 +605,9 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		params: msg.Params,
 		start:  e.TS,
 		state:  Pending,
+	}
+	if isStreamOpeningMethod(msg.Method) {
+		c.state = Streaming
 	}
 	if msg.Method == "tools/call" {
 		c.isTool = true
@@ -616,7 +629,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 	if c == nil {
 		return nil, false // unmatched response (request missed or before backfill)
 	}
-	if c.state != Pending {
+	if c.state != Pending && c.state != Streaming {
 		return c, false // already answered, a duplicate or late response must not recount
 	}
 	if c.method == "tools/call" && c.taskID != "" {
@@ -645,6 +658,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 	c.end = ts
 	c.result = msg.Result
 	c.err = msg.Error
+	wasPending := c.state == Pending
 	switch {
 	case msg.Error != nil:
 		c.state = Failed // JSON-RPC / protocol error
@@ -656,7 +670,9 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 	default:
 		c.state = Completed
 	}
-	sess.pending--
+	if wasPending {
+		sess.pending--
+	}
 	switch c.method {
 	case "initialize":
 		sess.caps.applyResponse(msg.Result)
@@ -1174,6 +1190,39 @@ func classifyMRTRState(c *call, retryState string, retryHasState bool) MRTRState
 		return MRTRStateChanged
 	default:
 		return ""
+	}
+}
+
+func isStreamOpeningMethod(method string) bool {
+	return method == "subscriptions/listen"
+}
+
+func cancelledRequestID(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var p struct {
+		RequestID json.RawMessage `json:"requestId"`
+	}
+	if json.Unmarshal(params, &p) != nil || len(p.RequestID) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(p.RequestID, &s) == nil {
+		return s
+	}
+	return strings.Trim(string(p.RequestID), `"`)
+}
+
+func (sess *session) closeStreamingCall(id string, ts time.Time) {
+	for _, dir := range []proxy.Direction{proxy.ClientToServer, proxy.ServerToClient} {
+		key := callKey{dir: dir, id: id}
+		c := sess.calls[key]
+		if c != nil && c.state == Streaming {
+			c.end = ts
+			c.state = Completed
+			return
+		}
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -407,7 +407,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.requests++
 		if reused {
 			ev.warning = appendWarning(ev.warning, "request reuses an id already in flight")
-		} else if ev.call.state != Streaming {
+		}
+		// Counted on what this call is, independently of the reuse. openCall has
+		// already released the superseded call's slot if it held one, so the two
+		// decisions no longer have to agree about who owns the accounting.
+		if ev.call.state == Pending {
 			sess.pending++
 		}
 		if msg.Method == "initialize" {
@@ -592,9 +596,16 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 	if reused {
 		// The earlier in-flight call keeps this id, so it will never be matched now.
 		// Mark it superseded (not pending) so the timeline stops rendering it as a
-		// hanging request and agrees with the pending counter, which Ingest leaves
-		// unchanged on a reuse. The "reuses an id already in flight" warning on the
-		// new request is the explanation.
+		// hanging request. The "reuses an id already in flight" warning on the new
+		// request is the explanation.
+		//
+		// It gives up its pending slot here, where the transition happens, and only
+		// when it actually held one. A Streaming call never did, so transferring a
+		// slot it never took would drive the counter negative once the new call is
+		// answered.
+		if prev.state == Pending {
+			sess.pending--
+		}
 		prev.state = Superseded
 		prev.end = e.TS
 	}
@@ -1197,6 +1208,11 @@ func isStreamOpeningMethod(method string) bool {
 	return method == "subscriptions/listen"
 }
 
+// cancelledRequestID is the id a notifications/cancelled names, in the form the
+// store keys calls by. That form is the raw JSON text of the id, because Ingest
+// keys a call on string(msg.ID), so a string id keeps its quotes. Decoding into a
+// Go string here would strip them and never match the key, and a string id is
+// what the specification's own cancellation example uses.
 func cancelledRequestID(params json.RawMessage) string {
 	if len(params) == 0 {
 		return ""
@@ -1204,14 +1220,10 @@ func cancelledRequestID(params json.RawMessage) string {
 	var p struct {
 		RequestID json.RawMessage `json:"requestId"`
 	}
-	if json.Unmarshal(params, &p) != nil || len(p.RequestID) == 0 {
+	if json.Unmarshal(params, &p) != nil {
 		return ""
 	}
-	var s string
-	if json.Unmarshal(p.RequestID, &s) == nil {
-		return s
-	}
-	return strings.Trim(string(p.RequestID), `"`)
+	return string(bytes.TrimSpace(p.RequestID))
 }
 
 func (sess *session) closeStreamingCall(id string, ts time.Time) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1680,3 +1680,47 @@ func TestIngestCountsAnHTTPFailureOnce(t *testing.T) {
 		t.Fatalf("one failure must be counted once, got %d", got)
 	}
 }
+
+func TestSubscriptionsListenDoesNotCountAsPending(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	ev := s.Ingest(req(1, t0, proxy.ClientToServer, "5", "subscriptions/listen", `{}`))
+	if ev.Call == nil || ev.Call.State != Streaming {
+		t.Fatalf("listen call state = %v, want streaming", ev.Call.State)
+	}
+	if h := s.Sessions()[0]; h.Pending != 0 {
+		t.Fatalf("pending = %d, want 0 for an open listen stream", h.Pending)
+	}
+}
+
+func TestSubscriptionsListenCompletesWithoutPendingLeak(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "5", "subscriptions/listen", `{}`))
+	done := s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "5", `"result":{}`))
+	if done.Call == nil || done.Call.State != Completed {
+		t.Fatalf("completed listen state = %v, want completed", done.Call.State)
+	}
+	if h := s.Sessions()[0]; h.Pending != 0 {
+		t.Fatalf("pending = %d, want 0 after the stream ends", h.Pending)
+	}
+}
+
+func TestSubscriptionsListenClosesOnCancelledNotification(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "5", "subscriptions/listen", `{}`))
+	cancel := proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(500 * time.Millisecond),
+		Direction: proxy.ServerToClient,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":5}}`),
+	}
+	s.Ingest(cancel)
+	if h := s.Sessions()[0]; h.Pending != 0 {
+		t.Fatalf("pending = %d, want 0 after the server closes the stream", h.Pending)
+	}
+	events := s.Timeline("s1")
+	if events[0].Call == nil || events[0].Call.State != Completed {
+		t.Fatalf("listen call should be completed after notifications/cancelled, got %v", events[0].Call.State)
+	}
+}

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -43,7 +43,7 @@ type CallView struct {
 func (c CallView) Failed() bool { return c.Err != nil || c.ToolErr || c.State == Failed }
 
 // Done reports whether a response has arrived.
-func (c CallView) Done() bool { return c.State != Pending }
+func (c CallView) Done() bool { return c.State != Pending && c.State != Streaming }
 
 // Duration is the request→response latency, or elapsed-so-far if still pending.
 func (c CallView) Duration() time.Duration {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1,2206 +1,648 @@
-package tui
+package store
 
 import (
-	"bytes"
+	"cmp"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"os"
+	"math"
 	"slices"
-	"strings"
+	"sort"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/ansi"
-
-	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
-	"github.com/kerlenton/mcpsnoop/internal/store"
 )
 
-func (m Model) View() string {
-	if !m.ready {
-		return "starting mcpsnoop…"
-	}
-	if m.showHelp {
-		return m.renderHelp()
-	}
-	if m.overlay != overlayNone {
-		return m.renderOverlay()
-	}
-
-	bodyH := m.bodyHeight()
-	body := m.renderTablePanel(bodyH)
-	// A 1-line header, a spacer that carries the filter input when active, the
-	// framed table, a toast line one row above the footer, then the 1-line footer.
-	return strings.Join([]string{m.renderHeader(), m.renderInputLine(), body, m.toastLine(), m.renderStatus()}, "\n")
+// CallView is an immutable snapshot of a correlated request/response pair.
+type CallView struct {
+	ID       string
+	Method   string
+	ReqDir   proxy.Direction
+	IsTool   bool
+	ToolName string
+	Params   json.RawMessage
+	Result   json.RawMessage
+	Err      *proxy.RPCError
+	ToolErr  bool // result.isError == true
+	// Errored is the "something went wrong" axis, distinct from Failed(): a
+	// cancelled task is Failed() (it delivered nothing) but not Errored (the user
+	// stopped it on purpose). The session error counter and the CI gate read this.
+	Errored    bool
+	Start      time.Time
+	End        time.Time
+	State      CallState
+	TaskID     string
+	TaskStatus string
 }
 
-// renderTablePanel frames the active table in a rounded panel, the title and any
-// stats embedded in the top border.
-func (m Model) renderTablePanel(bodyH int) string {
-	// First run, no sessions captured yet, show the standalone onboarding card
-	// centered on its own, not wrapped in the sessions panel.
-	if m.view == viewSessions && len(m.allSessions) == 0 {
-		return lipgloss.Place(m.width, bodyH, lipgloss.Center, lipgloss.Center, m.onboardingCard())
+// Failed reports a protocol error, a tool-level error (result.isError), or any
+// call the store already settled as Failed. The last clause matters for a task
+// that ends in a terminal failure carrying no error object, where the state would
+// otherwise say Failed while this predicate said otherwise, and everything that
+// judges an outcome through here (the exporter, the stream, status:err) reads it.
+// On the synchronous path it changes nothing, since Failed is only ever set there
+// alongside an error or a tool error.
+func (c CallView) Failed() bool { return c.Err != nil || c.ToolErr || c.State == Failed }
+
+// Done reports whether a response has arrived.
+func (c CallView) Done() bool { return c.State != Pending && c.State != Streaming }
+
+// Duration is the request→response latency, or elapsed-so-far while the call is
+// still open, which covers both a pending request and a live stream.
+func (c CallView) Duration() time.Duration {
+	if c.Done() {
+		return c.End.Sub(c.Start)
 	}
-	innerW := max(m.width-2, 1)
-	innerH := max(bodyH-2, 1)
-	var table, title, rightTitle string
-	if m.view == viewStream {
-		table = m.renderStreamTable(innerW, innerH)
-		title = "stream · " + m.streamLabel
-		if m.streamCalls > 0 {
-			noun := "calls"
-			if m.streamCalls == 1 {
-				noun = "call"
-			}
-			rightTitle = fmt.Sprintf("%d %s · p50 %s · p95 %s", m.streamCalls, noun, shortDur(m.streamP50), shortDur(m.streamP95))
+	return time.Since(c.Start)
+}
+
+// EventView is an immutable snapshot of one timeline entry.
+type EventView struct {
+	Seq     uint64
+	TS      time.Time
+	Dir     proxy.Direction
+	Kind    EventKind
+	Method  string
+	ID      string
+	Raw     json.RawMessage
+	Text    string
+	Warning string
+	// MCPMethod and MCPName are the HTTP routing headers (Mcp-Method, Mcp-Name),
+	// set on request frames captured over the streamable-HTTP transport.
+	MCPMethod string
+	MCPName   string
+	// MCPProtocolVersion is the MCP-Protocol-Version request header.
+	MCPProtocolVersion string
+	// HTTPStatus is the status of the response this frame arrived on, zero on
+	// stdio and on client frames. AuthChallenge is that response's
+	// WWW-Authenticate header.
+	HTTPStatus    int
+	AuthChallenge string
+	// RoutingMismatch is true when a routing header (Mcp-Method/Mcp-Name) or the
+	// MCP-Protocol-Version header disagrees with the body, or a routing header rides
+	// a batch, or a required one is missing. It is also true on a server's -32020
+	// response, which is that same condition as the server saw it: it validates
+	// values mcpsnoop cannot check, so its rejection is sometimes the only
+	// evidence. A structured handle for the condition the warning describes, so
+	// filters and exporters need not match warning text.
+	RoutingMismatch bool
+	// Truncated is true when mcpsnoop capped its own observed copy of a large body.
+	// It is a structured marker, not a protocol warning, so it never fails check.
+	Truncated bool
+	// Deprecated carries a heads-up when a frame uses a feature deprecated in the
+	// 2026-07-28 MCP release. It is structured like Truncated and never fails check.
+	Deprecated string
+	Call       *CallView // set for request/response events
+	TaskCall   *CallView // originating call for a tasks/* lifecycle frame
+	TaskID     string
+	// MRTRRoot is the id of the request this one continues, set when a multi
+	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
+	MRTRRoot string
+	// MRTRStateIssue classifies a changed, missing, or invented requestState on
+	// this retry. It never contains the opaque state itself.
+	MRTRStateIssue MRTRStateIssue
+}
+
+// SessionHeader is a lightweight per-session summary for the left panel.
+type SessionHeader struct {
+	ID                   string
+	Label                string
+	First                time.Time
+	Last                 time.Time
+	Requests             int
+	Responses            int
+	Notifications        int
+	Errors               int
+	Pending              int
+	HasCaps              bool
+	HasToolDrift         bool
+	HasToolBaselineError bool
+	MissingFrames        uint64 // envelopes dropped upstream, inferred from Seq gaps
+}
+
+// ToolDefinition is the contract a server advertised for one MCP tool.
+type ToolDefinition struct {
+	Name        string
+	Description string
+	InputSchema json.RawMessage
+	Findings    []SchemaFinding
+	// Cost is what advertising this tool weighs, measured once at ingest.
+	Cost ToolCost
+}
+
+// ToolCost is the measured weight of one advertised tool definition, in bytes.
+// Bytes and not tokens: a token count is model specific, so measuring one would
+// mean shipping a tokeniser and choosing whose. Bytes are exact, stable across
+// captures, and let a reader apply whatever ratio their own model implies. Every
+// figure is measured on one basis, the JSON with insignificant whitespace
+// removed, so two servers stay comparable regardless of how either formats its
+// tools/list.
+type ToolCost struct {
+	// Name duplicates ToolDefinition.Name so a cost can travel on its own, into
+	// a sorted breakdown or an export, without carrying the whole definition.
+	Name string
+	// Bytes is the definition object with insignificant whitespace removed, so it
+	// covers the name, description, schema, any annotations, and the JSON around
+	// them, and stays comparable between servers. This is the number that sums to
+	// the fixed cost of the tool list.
+	Bytes int
+	// DescriptionBytes is the description JSON encoded, quotes and escaping
+	// included, and SchemaBytes is the inputSchema with whitespace removed. Both
+	// are measured on the same basis as Bytes and point at where it went, but
+	// deliberately do not sum to it: the remainder is the name, the annotations
+	// and the structural punctuation, and pretending otherwise would invite
+	// reading the gap as a bug.
+	DescriptionBytes int
+	SchemaBytes      int
+}
+
+// ToolListCost is the fixed context cost of a session's advertised tool list,
+// the price paid on every conversation with that server before a single call is
+// made. PerTool is sorted heaviest first, since the question a reader has is
+// which two or three tools account for most of it.
+type ToolListCost struct {
+	Tools   int
+	Bytes   int
+	PerTool []ToolCost
+	// Complete is false while tools/list is still paginating, or never finished.
+	// Bytes then covers only the pages seen, which makes it a floor rather than
+	// the total, and it must not be presented as one.
+	Complete bool
+}
+
+// ToolDrift is the difference between the current complete tool list and the
+// persisted trust-on-first-use baseline for the session's server label.
+type ToolDrift struct {
+	AddedTools          []string
+	RemovedTools        []string
+	ChangedDescriptions []string
+	ChangedSchemas      []string
+	BaselineError       string
+}
+
+func (d ToolDrift) Empty() bool { return d.Count() == 0 && d.BaselineError == "" }
+
+func (d ToolDrift) Count() int {
+	return len(d.AddedTools) + len(d.RemovedTools) + len(d.ChangedDescriptions) + len(d.ChangedSchemas)
+}
+
+// CapsView is an immutable snapshot of the negotiated capabilities.
+type CapsView struct {
+	ProtocolVersion string
+	ClientInfo      json.RawMessage
+	ServerInfo      json.RawMessage
+	Client          json.RawMessage
+	Server          json.RawMessage
+	Instructions    string
+	// Extensions is the union of the extension ids each side advertised in its
+	// capabilities `extensions` map (SEP-2133), sorted by id and carrying which
+	// sides advertised each. Nil when neither side advertised any, so a session
+	// without extensions is indistinguishable from one before the field existed.
+	Extensions []ExtensionView
+}
+
+// ExtensionView is one extension id and which sides advertised it. Extensions
+// are negotiated through a map on both ClientCapabilities and
+// ServerCapabilities, so presence on one side alone means nothing is in play.
+type ExtensionView struct {
+	ID     string
+	Client bool
+	Server bool
+}
+
+// Agreed reports whether both sides advertised the extension, which is the only
+// case in which it is actually in play.
+func (e ExtensionView) Agreed() bool { return e.Client && e.Server }
+
+// ToolStats summarizes calls to one MCP tool within a session.
+type ToolStats struct {
+	Name    string
+	Calls   int
+	Errors  int
+	Pending int
+	P50     time.Duration
+	P95     time.Duration
+	P99     time.Duration
+	// ResultBytes totals this tool's results and MaxResultBytes is the largest
+	// single one, both as observed on the wire. Unlike the definition cost this
+	// half is paid per call, so a tool that is cheap to advertise can still be
+	// the expensive one. A call answered with a JSON-RPC error carries no result
+	// and so contributes nothing; a tool-level failure (result.isError) does.
+	//
+	// These are the bytes as they arrived, not normalised the way ToolCost is.
+	// A definition is a stable contract worth measuring canonically so two
+	// captures compare; a result is a one-off payload, and compacting every one
+	// of them to count it would allocate a second copy of a megabyte answer on
+	// a path that already holds the write lock.
+	ResultBytes    int64
+	MaxResultBytes int
+}
+
+// SlowToolCall identifies one of a session's slowest completed tool calls.
+type SlowToolCall struct {
+	CallIndex int
+	ID        string
+	ToolName  string
+	Duration  time.Duration
+	Failed    bool
+	Start     time.Time
+}
+
+// SessionToolSummary is the aggregate tool activity for one session.
+type SessionToolSummary struct {
+	Tools   []ToolStats
+	Slowest []SlowToolCall
+}
+
+// view builds the snapshot for an event. Caller holds at least the read lock.
+func (e *event) view(_ *session) EventView {
+	v := EventView{
+		Seq:                e.seq,
+		TS:                 e.ts,
+		Dir:                e.dir,
+		Kind:               e.kind,
+		Method:             e.method,
+		ID:                 e.id,
+		Raw:                e.raw,
+		Text:               e.text,
+		Warning:            e.warning,
+		MCPMethod:          e.mcpMethod,
+		MCPName:            e.mcpName,
+		MCPProtocolVersion: e.mcpProtocolVersion,
+		HTTPStatus:         e.status,
+		AuthChallenge:      e.authChallenge,
+		RoutingMismatch:    e.mismatch,
+		Truncated:          e.truncated,
+		Deprecated:         e.deprecated,
+		TaskID:             e.taskID,
+		MRTRRoot:           e.mrtrRoot,
+		MRTRStateIssue:     e.mrtrStateIssue,
+	}
+	if e.call != nil {
+		cv := e.call.view()
+		v.Call = &cv
+	}
+	if e.taskCall != nil {
+		cv := e.taskCall.view()
+		v.TaskCall = &cv
+	}
+	return v
+}
+
+func (c *call) view() CallView {
+	return CallView{
+		ID:         c.id,
+		Method:     c.method,
+		ReqDir:     c.reqDir,
+		IsTool:     c.isTool,
+		ToolName:   c.toolName,
+		Params:     c.params,
+		Result:     c.result,
+		Err:        c.err,
+		ToolErr:    c.toolErr,
+		Errored:    c.errored,
+		Start:      c.start,
+		End:        c.end,
+		State:      c.state,
+		TaskID:     c.taskID,
+		TaskStatus: c.taskStatus,
+	}
+}
+
+// Sessions returns per-session headers in first-seen order.
+func (s *Store) Sessions() []SessionHeader {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]SessionHeader, 0, len(s.order))
+	for _, id := range s.order {
+		sess := s.sessions[id]
+		out = append(out, SessionHeader{
+			ID:                   sess.id,
+			Label:                sess.label,
+			First:                sess.first,
+			Last:                 sess.last,
+			Requests:             sess.requests,
+			Responses:            sess.responses,
+			Notifications:        sess.notifications,
+			Errors:               sess.errors,
+			Pending:              sess.pending,
+			HasCaps:              sess.caps.set,
+			HasToolDrift:         sess.toolDrift.Count() > 0,
+			HasToolBaselineError: sess.toolDrift.BaselineError != "",
+			MissingFrames:        sess.missing,
+		})
+	}
+	return out
+}
+
+// ToolDefinitions returns the current complete tools/list definition set in
+// server order. ok is false until the final page of a listing has arrived.
+func (s *Store) ToolDefinitions(sessionID string) ([]ToolDefinition, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok || !sess.toolListComplete {
+		return nil, false
+	}
+	definitions := make([]ToolDefinition, 0, len(sess.advertisedTools))
+	for _, name := range sess.advertisedTools {
+		definition := sess.toolDefinitions[name]
+		definition.InputSchema = append(json.RawMessage(nil), definition.InputSchema...)
+		definitions = append(definitions, definition)
+	}
+	return definitions, true
+}
+
+// ToolCosts reports the fixed context cost of a session's advertised tool list.
+//
+// Unlike ToolDefinitions this does not require a complete list. A baseline may
+// only be trusted once the whole list has been seen, but a partial list still
+// has a real per-tool cost worth showing, and the caller is told through
+// Complete that the total is a floor. ok is false only when the session never
+// carried a tools/list response at all, which is a different thing from a
+// server that advertises no tools.
+func (s *Store) ToolCosts(sessionID string) (ToolListCost, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok || !sess.toolListSeen {
+		return ToolListCost{}, false
+	}
+	cost := ToolListCost{
+		Tools:    len(sess.advertisedTools),
+		Complete: sess.toolListComplete,
+		PerTool:  make([]ToolCost, 0, len(sess.advertisedTools)),
+	}
+	for _, name := range sess.advertisedTools {
+		definition := sess.toolDefinitions[name]
+		cost.Bytes += definition.Cost.Bytes
+		cost.PerTool = append(cost.PerTool, definition.Cost)
+	}
+	// Heaviest first, then by name for a stable order among equals. Alphabetical
+	// would bury the answer, which is which tools the cost is actually in.
+	slices.SortFunc(cost.PerTool, func(a, b ToolCost) int {
+		if c := cmp.Compare(b.Bytes, a.Bytes); c != 0 {
+			return c
 		}
-	} else {
-		table = m.renderSessionsTable(innerW, innerH)
-		title = fmt.Sprintf("sessions · %d", len(m.sessions))
-		rightTitle = homeAbbrev(paths.SessionsDir())
-	}
-	return m.panelBox(title, rightTitle, m.styles.dim, m.theme.border, padLines(table, innerH), m.width, bodyH)
-}
-
-// homeAbbrev shortens a path under the home directory to a leading ~.
-func homeAbbrev(p string) string {
-	if h, err := os.UserHomeDir(); err == nil && h != "" && strings.HasPrefix(p, h) {
-		return "~" + p[len(h):]
-	}
-	return p
-}
-
-// deleteTargetLabel names the session the confirmation is about.
-func (m Model) deleteTargetLabel() string {
-	if m.view == viewStream {
-		return m.streamLabel
-	}
-	if len(m.sessions) > 0 {
-		return m.sessions[m.selSession].Label
-	}
-	return ""
-}
-
-// flashStyle colors a transient flash by kind: green for a success (leading ✓),
-// red for a failure, yellow for a nudge, so a hint reads as a warning rather
-// than fading into the background.
-func (m Model) flashStyle() lipgloss.Style {
-	switch {
-	case strings.Contains(m.flash, "failed"):
-		return m.styles.respErr
-	case strings.HasPrefix(m.flash, "✓"):
-		return m.styles.live
-	default:
-		return m.styles.warn
-	}
-}
-
-// replaySpinner is the in-flight replay indicator: an animated cyan spinner and
-// the method, shown in the footer instead of opening a placeholder window.
-func (m Model) replaySpinner() string {
-	return m.styles.pending.Render(m.spinnerFrame() + " replaying " + m.replayReq.Method + "…")
-}
-
-// toastLine is a transient notification one row above the footer, flat colored
-// text right-aligned to sit above the footer counters. It carries the replay
-// spinner while a replay is in flight, then a flash, and is blank when idle.
-func (m Model) toastLine() string {
-	var msg string
-	switch {
-	case m.replaying:
-		msg = m.replaySpinner()
-	case m.flashActive():
-		msg = m.flashStyle().Render(m.flash)
-	default:
-		return ""
-	}
-	gap := max(m.width-lipgloss.Width(msg)-1, 0)
-	return strings.Repeat(" ", gap) + msg
-}
-
-// padLines pads s with blank lines up to n lines total.
-func padLines(s string, n int) string {
-	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
-	for len(lines) < n {
-		lines = append(lines, "")
-	}
-	return strings.Join(lines, "\n")
-}
-
-// bar lays left and right onto a single width-wide line, one padding space each
-// end and a flexible gap between. The right side (status, counts) is primary and
-// kept whole. The left (hints, breadcrumb) is truncated first when the two would
-// not fit, so the header and footer stay exactly one line at any width.
-func bar(width int, left, right string) string {
-	if width < 1 {
-		return ""
-	}
-	if lipgloss.Width(right) > width-2 {
-		right = ansi.Truncate(right, max(width-2, 0), "…")
-	}
-	if avail := width - lipgloss.Width(right) - 3; lipgloss.Width(left) > avail {
-		left = ansi.Truncate(left, max(avail, 0), "…")
-	}
-	gap := width - lipgloss.Width(left) - lipgloss.Width(right) - 2
-	if gap < 1 {
-		gap = 1
-	}
-	return " " + left + strings.Repeat(" ", gap) + right + " "
-}
-
-func (m Model) bodyHeight() int {
-	return max(m.height-4, 1) // header + input spacer + body + spacer + footer
-}
-
-// renderStatus is the bottom footer, contextual key hints on the left and the
-// signal counters on the right. A transient flash takes over the right briefly.
-func (m Model) renderStatus() string {
-	return bar(m.width, m.footerHints(), m.footerCounters())
-}
-
-// footerHints lists the handful of keys that matter in the current view, key in
-// blue and label dim. ? opens the full reference.
-func (m Model) footerHints() string {
-	// Nothing to act on until a session connects, the snippet copy hint lives on
-	// the card, so the footer stays minimal.
-	if m.view == viewSessions && len(m.allSessions) == 0 {
-		return m.hintsRow([]hint{{":", "cmd"}, {"?", "help"}, {":q", "quit"}})
-	}
-	hs := []hint{
-		{"enter", "open"}, {"y", "copy path"}, {"e", "export"},
-		{"ctrl-d", "delete"}, {"/", "filter"}, {":", "cmd"}, {"?", "help"},
-	}
-	if m.view == viewStream {
-		hs = []hint{{"enter", "inspect"}}
-		if m.sessionReplayable() {
-			hs = append(hs, hint{"r", "replay"})
-		}
-		hs = append(hs, hint{"c", "caps"}, hint{"s", "summary"}, hint{"/", "filter"}, hint{"p", "pause"}, hint{"?", "help"})
-	}
-	return m.hintsRow(hs)
-}
-
-// hintsRow renders key hints, key in blue and label dim, two spaces between.
-func (m Model) hintsRow(hs []hint) string {
-	var parts []string
-	for _, h := range hs {
-		parts = append(parts, m.styles.hintKey.Render(h.key)+" "+m.styles.hintDesc.Render(h.desc))
-	}
-	return strings.Join(parts, "  ")
-}
-
-// footerCounters is the signal tally on the right, the frame or session count
-// then any nonzero err/bad/warn/pending counts, each in its verdict color.
-func (m Model) footerCounters() string {
-	sep := m.styles.sep.Render(" · ")
-	if m.view != viewStream {
-		parts := []string{m.styles.faint.Render(countLabel(len(m.sessions), len(m.allSessions), "session"))}
-		if e := m.totalErrors(); e > 0 {
-			parts = append(parts, m.styles.respErr.Render(fmt.Sprintf("%d err", e)))
-		}
-		return strings.Join(parts, sep)
-	}
-	parts := []string{m.styles.faint.Render(countLabel(len(m.timeline), m.total, "frame"))}
-	// Dropped frames leave a Seq gap and mean the trace is incomplete, so flag them.
-	if missing := m.currentMissingFrames(); missing > 0 {
-		parts = append(parts, m.styles.respErr.Render(fmt.Sprintf("%d missing", missing)))
-	}
-	c := m.streamSignals
-	for _, sig := range []struct {
-		n     int
-		label string
-		style lipgloss.Style
-	}{
-		{c.errors, "err", m.styles.respErr},
-		{c.bad, "bad", m.styles.invalid},
-		{c.warn, "warn", m.styles.warn},
-		{c.pending, "pending", m.styles.pending},
-	} {
-		if sig.n > 0 {
-			parts = append(parts, sig.style.Render(fmt.Sprintf("%d %s", sig.n, sig.label)))
-		}
-	}
-	return strings.Join(parts, sep)
-}
-
-// currentMissingFrames returns the dropped-frame count for the session being
-// streamed, inferred from Seq gaps by the store.
-func (m Model) currentMissingFrames() uint64 {
-	for _, s := range m.allSessions {
-		if s.ID == m.streamSessionID {
-			return s.MissingFrames
-		}
-	}
-	return 0
-}
-
-// countLabel renders a plain total, or shown/total when a filter is hiding some
-// of the rows. The breadcrumb already carries the session total, so the footer
-// stays quiet until a filter actually narrows the view. noun is singular and is
-// pluralized to match the total.
-func countLabel(shown, total int, noun string) string {
-	if total != 1 {
-		noun += "s"
-	}
-	if shown != total {
-		return fmt.Sprintf("%d/%d %s", shown, total, noun)
-	}
-	return fmt.Sprintf("%d %s", total, noun)
-}
-
-// ---- header ---------------------------------------------------------------
-
-// renderHeader is the single top line, brand and breadcrumb on the left, follow
-// and the live indicator on the right.
-func (m Model) renderHeader() string {
-	left := m.styles.brand.Render("▍mcpsnoop") + "  " + m.breadcrumb()
-	return bar(m.width, left, m.headerStatus())
-}
-
-// breadcrumb is sessions at the root and sessions › demo inside a session, with
-// the active filter appended when one is set.
-func (m Model) breadcrumb() string {
-	var seg string
-	switch {
-	case m.view != viewStream:
-		seg = m.styles.crumbCur.Render("sessions")
-	case m.width < 100:
-		// Narrow, collapse to the label plus its position, cueing [ and ].
-		pos, total := m.sessionPos()
-		seg = m.styles.crumbCur.Render(m.streamLabel) + m.styles.faint.Render(fmt.Sprintf(" (%d/%d)", pos, total))
-	default:
-		seg = m.styles.crumbPrev.Render("sessions") + m.styles.faint.Render(" › ") + m.styles.crumbCur.Render(m.streamLabel)
-	}
-	if q := m.activeFilter(); q != "" {
-		seg += m.styles.faint.Render("  /") + m.styles.dim.Render(q)
-	}
-	return seg
-}
-
-// sessionPos is the 1-based index of the streamed session among the visible
-// sessions, and the total, for the compact breadcrumb.
-func (m Model) sessionPos() (int, int) {
-	for i, s := range m.sessions {
-		if s.ID == m.streamSessionID {
-			return i + 1, len(m.sessions)
-		}
-	}
-	return 0, len(m.sessions)
-}
-
-// headerStatus is the right side of the header, follow when on, then the live,
-// paused, or listening indicator.
-func (m Model) headerStatus() string {
-	var parts []string
-	if m.view == viewStream && m.follow {
-		parts = append(parts, m.styles.follow.Render("⇣ follow"))
-	}
-	switch {
-	case m.paused:
-		parts = append(parts, m.styles.paused.Render("● paused"))
-	case len(m.allSessions) == 0:
-		parts = append(parts, m.styles.follow.Render(m.spinnerFrame()+" listening"))
-	default:
-		parts = append(parts, m.styles.live.Render("● live"))
-	}
-	return strings.Join(parts, m.styles.sep.Render(" · "))
-}
-
-// spinnerFrames is the shared braille spinner, advanced by the tick clock and
-// reused for the listening indicator and in-flight PENDING calls.
-var spinnerFrames = []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
-
-func (m Model) spinnerFrame() string {
-	return string(spinnerFrames[m.spin%len(spinnerFrames)])
-}
-
-func (m Model) totalErrors() int {
-	n := 0
-	for _, s := range m.allSessions {
-		n += s.Errors
-	}
-	return n
-}
-
-type hint struct{ key, desc string }
-
-// ---- input line -----------------------------------------------------------
-
-// renderInputLine is the spacer under the header. It carries the filter or
-// command input when active, with a live match count for filters, and is
-// otherwise blank.
-func (m Model) renderInputLine() string {
-	if m.inputMode == inputNone {
-		return ""
-	}
-	left := m.styles.prompt.Render(m.input.View())
-	if m.inputMode != inputFilter {
-		return bar(m.width, left, "")
-	}
-	shown, total := len(m.sessions), len(m.allSessions)
-	if m.view == viewStream {
-		shown, total = len(m.timeline), m.total
-	}
-	right := m.styles.dim.Render(fmt.Sprintf("%d/%d match", shown, total)) + m.styles.faint.Render("   esc clear")
-	return bar(m.width, left, right)
-}
-
-func (m Model) activeFilter() string {
-	if m.view == viewStream {
-		return m.query
-	}
-	return m.sessionQuery
-}
-
-// ---- sessions table -------------------------------------------------------
-
-func (m Model) renderSessionsTable(w, h int) string {
-	// Empty state, no table header (it'd be an orphan), just a centered card.
-	if len(m.sessions) == 0 {
-		card := m.onboardingCard()
-		if m.sessionQuery != "" {
-			card = m.styles.dim.Render("no sessions match ") + m.styles.infoVal.Render("/"+m.sessionQuery)
-		}
-		return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, card)
-	}
-
-	const nameW, clientW, reqW, respW, errW, actW, lastW = 22, 20, 4, 4, 4, 8, 6
-	// ACTIVITY drops first as the panel narrows, then CLIENT.
-	showAct := w >= 88
-	showClient := w >= 72
-
-	st := m.sessionSort
-	gap := seg("  ", m.styles.faint)
-	var b strings.Builder
-	head := cellL("NAME"+sortMark(st, "name"), nameW)
-	if showClient {
-		head += "  " + cellL("CLIENT", clientW)
-	}
-	head += "  " + cellR("REQ"+sortMark(st, "req"), reqW) + "  " + cellR("RESP"+sortMark(st, "resp"), respW) +
-		"  " + cellR("ERR"+sortMark(st, "err"), errW)
-	if showAct {
-		head += "  " + cellL("ACTIVITY", actW)
-	}
-	head += "  " + cellR("LAST"+sortMark(st, "last"), lastW)
-	b.WriteString(" " + m.styles.tableHead.Render(head) + "\n")
-
-	rows := h - 1
-	start, end := window(m.selSession, len(m.sessions), rows)
-	for i := start; i < end; i++ {
-		s := m.sessions[i]
-		errStyle := m.styles.faint
-		if s.Errors > 0 {
-			errStyle = m.styles.respErr // red when the session carries errors
-		}
-		lastStyle := m.styles.dim
-		if time.Since(s.Last) > 30*time.Minute {
-			lastStyle = m.styles.faint // idle sessions recede
-		}
-		buckets := m.activity[s.ID]
-		actStyle := m.styles.faint // idle
-		for _, v := range buckets {
-			if v > 0 {
-				actStyle = m.styles.resp // recent traffic, green
-				break
-			}
-		}
-		name := s.Label
-		nameStyle := m.styles.neutral
-		// A one-character "!" marker flags a baseline error (red) or drift (yellow)
-		// without stealing width from the label. The full wording lives in the tool
-		// summary overlay where there is room.
-		if s.HasToolBaselineError {
-			name = "! " + name
-			nameStyle = m.styles.respErr
-		} else if s.HasToolDrift {
-			name = "! " + name
-			nameStyle = m.styles.warn
-		}
-		segs := []cell{seg(cellL(name, nameW), nameStyle)}
-		if showClient {
-			client := valueOr(m.clients[s.ID], "-")
-			segs = append(segs, gap, seg(cellL(client, clientW), m.styles.dim))
-		}
-		segs = append(segs,
-			gap, seg(cellR(fmt.Sprintf("%d", s.Requests), reqW), m.styles.dim),
-			gap, seg(cellR(fmt.Sprintf("%d", s.Responses), respW), m.styles.dim),
-			gap, seg(cellR(fmt.Sprintf("%d", s.Errors), errW), errStyle),
-		)
-		if showAct {
-			segs = append(segs, gap, seg(cellL(spark(buckets), actW), actStyle))
-		}
-		segs = append(segs, gap, seg(cellR(humanAge(s.Last), lastW), lastStyle))
-		b.WriteString(m.rowLine(segs, w, i == m.selSession) + "\n")
-	}
-	return b.String()
-}
-
-// ---- stream table ---------------------------------------------------------
-
-// Stream column widths. DETAIL flexes to fill the rest of the row.
-const (
-	streamTimeW   = 12
-	streamDirW    = 1
-	streamMethodW = 34
-	streamIDW     = 4
-	streamDurW    = 9
-	streamStatW   = 7
-)
-
-// streamLayout carries the width-dependent choices for the stream table, a
-// shorter TIME on narrow terminals and DETAIL hidden on narrower ones.
-type streamLayout struct {
-	timeW      int
-	timeFmt    string
-	detailW    int
-	showDetail bool
-}
-
-func (m Model) streamLayoutFor(w int) streamLayout {
-	lay := streamLayout{timeW: streamTimeW, timeFmt: "15:04:05.000", showDetail: m.width >= 100}
-	if m.width < 90 {
-		lay.timeW, lay.timeFmt = 7, "05.0000" // ss.SSSS
-	}
-	fixed := lay.timeW + streamDirW + streamMethodW + streamIDW + streamDurW + streamStatW
-	if lay.showDetail {
-		lay.detailW = max((w-1)-fixed-11, 8) // 11 is the six column gaps
-	}
-	return lay
-}
-
-func (m Model) renderStreamTable(w, h int) string {
-	lay := m.streamLayoutFor(w)
-	st := m.streamSort
-	var b strings.Builder
-	head := cellL("TIME"+sortMark(st, "time"), lay.timeW) + "  " + cellL("", streamDirW) + " " +
-		cellL("METHOD / TOOL"+sortMark(st, "method"), streamMethodW) + "  " + cellR("ID"+sortMark(st, "id"), streamIDW) +
-		"  " + cellR("DUR"+sortMark(st, "dur"), streamDurW) + "  " + cellL("STATUS"+sortMark(st, "status"), streamStatW)
-	if lay.showDetail {
-		head += "  " + cellL("DETAIL", lay.detailW)
-	}
-	b.WriteString(" " + m.styles.tableHead.Render(head) + "\n")
-
-	if len(m.timeline) == 0 {
-		if m.query != "" {
-			b.WriteString(m.styles.faint.Render(" no frames match /" + m.query))
-		} else {
-			b.WriteString(m.styles.faint.Render(" no frames yet"))
-		}
-		return b.String()
-	}
-
-	rows := h - 1
-	start, end := window(m.selEvent, len(m.timeline), rows)
-	for i := start; i < end; i++ {
-		b.WriteString(m.rowLine(m.streamRow(m.timeline[i], lay), w, i == m.selEvent) + "\n")
-	}
-	return b.String()
-}
-
-// cell is one styled segment of a table row, its text already padded to width.
-type cell struct {
-	text  string
-	style lipgloss.Style
-}
-
-func seg(text string, style lipgloss.Style) cell { return cell{text: text, style: style} }
-
-// rowLine renders one row from its segments. A selected row gets a blue ▌ marker
-// in the gutter and a subtle surface band across the full width, and every cell
-// keeps its own hue so verdict and kind colors stay readable and stable when the
-// selection moves. Unselected rows are the plain segments behind a one-space
-// gutter. Either way the line is capped to the width so it never wraps.
-func (m Model) rowLine(segs []cell, w int, selected bool) string {
-	var b strings.Builder
-	if selected {
-		b.WriteString(m.styles.req.Background(m.theme.selection).Render("▌"))
-	} else {
-		b.WriteString(" ")
-	}
-	for _, s := range segs {
-		st := s.style
-		if selected {
-			st = st.Background(m.theme.selection)
-		}
-		b.WriteString(st.Render(s.text))
-	}
-	line := b.String()
-	if selected {
-		if pad := w - lipgloss.Width(line); pad > 0 {
-			line += lipgloss.NewStyle().Background(m.theme.selection).Render(strings.Repeat(" ", pad))
-		}
-	}
-	if lipgloss.Width(line) > w {
-		line = ansi.Truncate(line, w, "")
-	}
-	return line
-}
-
-// streamRow turns a frame into its row segments. The glyph and METHOD carry the
-// kind color, the tool name is bright, DUR and STATUS carry the verdict, and
-// DETAIL is uniformly faint (progress notifications aside).
-func (m Model) streamRow(e store.EventView, lay streamLayout) []cell {
-	c := m.streamCells(e)
-	kind := m.kindStyle(e)
-
-	segs := []cell{
-		seg(cellL(e.TS.Format(lay.timeFmt), lay.timeW), m.styles.dim),
-		seg("  ", m.styles.faint),
-		seg(cellL(c.dir, streamDirW), kind),
-		seg(" ", m.styles.faint),
-	}
-	if c.tool != "" {
-		prefix := c.method + " "
-		segs = append(segs,
-			seg(prefix, kind),
-			seg(cellL(c.tool, streamMethodW-lipgloss.Width(prefix)), m.styles.bright),
-		)
-	} else {
-		segs = append(segs, seg(cellL(c.method, streamMethodW), kind))
-	}
-	segs = append(segs,
-		seg("  ", m.styles.faint),
-		seg(cellR(c.id, streamIDW), m.styles.dim),
-		seg("  ", m.styles.faint),
-		seg(cellR(c.dur, streamDurW), m.durStyle(e)),
-		seg("  ", m.styles.faint),
-		seg(cellL(c.status, streamStatW), m.statusStyle(e)),
-	)
-	if lay.showDetail {
-		segs = append(segs, seg("  ", m.styles.faint))
-		segs = append(segs, m.detailSegs(c, lay.detailW)...)
-	}
-	return segs
-}
-
-// durStyle colors the DUR value. It only turns cyan for a live pending timer and
-// is dim otherwise, so latency reads as a plain number, not a verdict.
-func (m Model) durStyle(e store.EventView) lipgloss.Style {
-	if e.Call != nil && (e.Call.State == store.Pending || e.Call.State == store.Streaming) {
-		return m.styles.pending
-	}
-	return m.styles.dim
-}
-
-// detailSegs is the DETAIL column, a single faint line uniform across every row,
-// or a small bar for a progress notification.
-func (m Model) detailSegs(c streamCell, detailW int) []cell {
-	if c.progress != nil {
-		return m.progressSegs(*c.progress, detailW)
-	}
-	return []cell{seg(cellL(c.detail, detailW), m.styles.faint)}
-}
-
-// progressSegs draws a thin ━━──── bar and the done/total fraction, the filled
-// part cyan and the rest faint, matching the panel line-art. The heavy and light
-// rules also read without color.
-func (m Model) progressSegs(p progressBar, detailW int) []cell {
-	const barW = 8
-	filled := 0
-	if p.total > 0 {
-		filled = clamp(p.done*barW/p.total, 0, barW)
-	}
-	done := strings.Repeat("━", filled)
-	rest := strings.Repeat("─", barW-filled) + fmt.Sprintf("  %d/%d", p.done, p.total)
-	if p.token != "" {
-		rest += " · " + p.token
-	}
-	rest = cellL(rest, max(detailW-lipgloss.Width(done), 0))
-	return []cell{
-		seg(done, m.styles.pending),
-		seg(rest, m.styles.faint),
-	}
-}
-
-type streamCell struct {
-	time, dir, method, id, dur, status, detail string
-	tool                                       string       // tool name, rendered bright after the method
-	progress                                   *progressBar // set for a progress notification carrying a total
-}
-
-type progressBar struct {
-	done, total int
-	token       string
-}
-
-func (m Model) streamCells(e store.EventView) streamCell {
-	c := streamCell{time: e.TS.Format("15:04:05.000"), id: e.ID}
-	switch e.Kind {
-	case store.EventStderr:
-		c.dir, c.method = "┆", "stderr"
-		c.detail = e.Text
-	case store.EventRequest:
-		c.dir = arrow(e.Dir)
-		c.method = e.Method
-		if e.Call != nil && e.Call.IsTool && e.Call.ToolName != "" {
-			c.method, c.tool = "tools/call", e.Call.ToolName
-		}
-		if e.Call != nil {
-			c.detail = compactJSON(e.Call.Params)
-			// Surface in-flight (possibly hung) calls, a spinner plus live elapsed.
-			if e.Call.State == store.Pending {
-				c.status = "pending"
-				c.dur = m.spinnerFrame() + " " + e.Call.Duration().Round(100*time.Millisecond).String()
-			} else if e.Call.State == store.Streaming {
-				c.status = "streaming"
-				c.dur = e.Call.Duration().Round(100 * time.Millisecond).String()
-			} else if e.Call.State == store.Superseded {
-				// Its id was reused while in flight, so it will never be answered.
-				c.status = "superseded"
-			}
-		}
-	case store.EventResponse:
-		c.dir = arrow(e.Dir)
-		c.method = "response"
-		if e.Call != nil {
-			c.dur = e.Call.Duration().Round(time.Millisecond).String()
-			switch {
-			case e.Call.TaskID != "" && e.Call.State == store.Pending:
-				c.status = e.Call.TaskStatus
-				c.detail = compactJSON(e.Call.Result)
-			case e.Call.Err != nil:
-				c.status = "err"
-				c.detail = rpcErrorText(*e.Call.Err)
-			case e.Call.ToolErr:
-				c.status = "err"
-				c.detail = toolErrorText(e.Call.Result)
-			default:
-				c.status = "ok"
-				c.detail = compactJSON(e.Call.Result)
-			}
-		}
-	case store.EventNotification:
-		c.dir, c.method = "·", "notify "+e.Method
-		c.detail = compactJSON(e.Raw)
-		if e.Method == "notifications/progress" {
-			if p, ok := parseProgress(e.Raw); ok {
-				c.progress = &p
-			}
-		}
-	case store.EventInvalid:
-		c.dir, c.method, c.status = "!", "invalid rpc", "bad"
-		if len(e.Raw) > 0 {
-			c.detail = string(e.Raw)
-		} else {
-			c.detail = e.Text
-		}
-	case store.EventTransport:
-		// Reading the status out loud is the whole point of this row: it exists
-		// because a 401 challenge and a 202 acknowledging a notification carry no
-		// body, so before this they produced nothing at all.
-		c.dir, c.method = arrow(e.Dir), fmt.Sprintf("http %d", e.HTTPStatus)
-		c.detail = http.StatusText(e.HTTPStatus)
-		if e.AuthChallenge != "" {
-			c.detail += " · " + e.AuthChallenge
-		}
-		if body := transportBody(e); body != "" {
-			c.detail += " · " + body
-		}
-		c.status = "ok"
-		if e.HTTPStatus >= 400 {
-			c.status = "err"
-		}
-	default:
-		c.dir, c.method = "?", "frame"
-		c.detail = string(e.Raw)
-	}
-	if e.Kind != store.EventInvalid && e.Warning != "" {
-		c.status = "warn"
-		if c.detail == "" {
-			c.detail = e.Warning
-		} else {
-			c.detail = e.Warning + " · " + c.detail
-		}
-	}
-	// A capped observed copy is a caution, not a protocol warning, so it carries a
-	// structured flag (never failing check) but reads the same in the row.
-	if e.Truncated {
-		c.status = "warn"
-		const msg = "observed copy truncated at the frame cap, forwarding unaffected"
-		if c.detail == "" {
-			c.detail = msg
-		} else {
-			c.detail = msg + " · " + c.detail
-		}
-	}
-	if e.Deprecated != "" {
-		c.status = "warn"
-		if c.detail == "" {
-			c.detail = e.Deprecated
-		} else {
-			c.detail = e.Deprecated + " · " + c.detail
-		}
-	}
-	if e.TaskID != "" {
-		link := "task " + e.TaskID
-		if e.TaskCall != nil {
-			link += " → tools/call id " + e.TaskCall.ID
-			switch e.TaskCall.TaskStatus {
-			case "input_required":
-				c.status = "input_required"
-			case "cancelled":
-				// Terminal without a result, but stopped on purpose rather than broken,
-				// so it should not read as a generic error in the row.
-				c.status = "cancelled"
-			case "failed":
-				c.status = "err"
-				if e.TaskCall.Err != nil {
-					link += " · " + e.TaskCall.Err.Message
-				}
-			}
-		}
-		if c.detail == "" {
-			c.detail = link
-		} else {
-			c.detail = link + " · " + c.detail
-		}
-	}
-	if e.MRTRRoot != "" {
-		// A multi round-trip retry carries a different id by design, so without
-		// saying what it continues the row looks like an unrelated second call.
-		link := "continues id " + e.MRTRRoot
-		if c.detail == "" {
-			c.detail = link
-		} else {
-			c.detail = link + " · " + c.detail
-		}
-	}
-	if e.MRTRStateIssue != "" {
-		c.status = "state!"
-	}
-	return c
-}
-
-// parseProgress reads a notifications/progress payload. It reports ok only when a
-// total is present, so the caller can fall back to raw JSON otherwise.
-func parseProgress(raw json.RawMessage) (progressBar, bool) {
-	var msg struct {
-		Params struct {
-			Progress      float64         `json:"progress"`
-			Total         float64         `json:"total"`
-			ProgressToken json.RawMessage `json:"progressToken"`
-		} `json:"params"`
-	}
-	if json.Unmarshal(raw, &msg) != nil || msg.Params.Total == 0 {
-		return progressBar{}, false
-	}
-	token := strings.Trim(string(msg.Params.ProgressToken), `"`)
-	return progressBar{done: int(msg.Params.Progress), total: int(msg.Params.Total), token: token}, true
-}
-
-// toolErrorText pulls the human message out of a tool-error result
-// ({"content":[{"type":"text","text":"…"}],"isError":true}).
-func toolErrorText(result json.RawMessage) string {
-	var r struct {
-		Content []struct {
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if json.Unmarshal(result, &r) == nil && len(r.Content) > 0 && r.Content[0].Text != "" {
-		return r.Content[0].Text
-	}
-	return compactJSON(result)
-}
-
-// transportBody flattens the observed body of a transport frame into one line a
-// row can hold. A JSON body arrives in Raw, while a non-JSON one arrives in Text
-// (splitObserved routes it there), and non-JSON is the common case here since
-// this is typically a gateway's HTML error page. That page spans many lines and
-// is written by whatever is on the other end: truncate measures width, so a
-// short but multi-line detail passes it untouched and breaks the row, and a raw
-// escape sequence would drive the terminal rather than be shown in it.
-func transportBody(e store.EventView) string {
-	if len(e.Raw) > 0 {
-		return compactJSON(e.Raw)
-	}
-	var b strings.Builder
-	pending := false
-	for _, r := range e.Text {
-		switch {
-		case unicode.IsSpace(r):
-			pending = b.Len() > 0 // collapse a run, and never lead with one
-		case unicode.IsControl(r):
-			// Dropped rather than escaped. There is nothing here worth reading.
-		default:
-			if pending {
-				b.WriteRune(' ')
-				pending = false
-			}
-			b.WriteRune(r)
-		}
-	}
-	return b.String()
-}
-
-// rpcErrorText renders a JSON-RPC error for a one-line preview. The code was
-// missing from this row entirely, so a reader could not tell a spec-defined
-// -32601 from whatever number a server picked for itself.
-func rpcErrorText(err proxy.RPCError) string {
-	head := store.ErrorCodeText(err.Code)
-	if err.Message == "" {
-		return head
-	}
-	return head + ": " + err.Message
-}
-
-// compactJSON renders raw JSON on a single line for the DETAIL preview column.
-func compactJSON(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var b bytes.Buffer
-	if json.Compact(&b, raw) != nil {
-		return strings.TrimSpace(string(raw))
-	}
-	return b.String()
-}
-
-func (m Model) statusStyle(e store.EventView) lipgloss.Style {
-	if e.Kind == store.EventInvalid {
-		return m.styles.invalid
-	}
-	if e.Warning != "" {
-		return m.styles.warn
-	}
-	// A truncated observation reads "warn" in the row, so its cell must be warn
-	// colored too. It no longer rides the Warning field, so check it explicitly.
-	if e.Truncated {
-		return m.styles.warn
-	}
-	if e.Deprecated != "" {
-		return m.styles.warn
-	}
-	if e.Call != nil {
-		switch {
-		case e.Call.State == store.Pending:
-			return m.styles.pending
-		case e.Call.State == store.Streaming:
-			return m.styles.follow
-		case e.Call.State == store.Superseded:
-			return m.styles.warn // never answered, not a success
-		case e.Call.Failed():
-			return m.styles.respErr
-		default:
-			return m.styles.resp
-		}
-	}
-	return m.styles.dim
-}
-
-// kindStyle colors the direction glyph and METHOD by frame kind, requests blue,
-// responses neutral fg, notifications and invalid frames comment, stderr comment
-// italic. Verdict color never lands here, only in STATUS, DUR, and the counters.
-func (m Model) kindStyle(e store.EventView) lipgloss.Style {
-	switch e.Kind {
-	case store.EventRequest:
-		return m.styles.req
-	case store.EventResponse:
-		return m.styles.neutral
-	default: // notification, stderr, invalid, all neutral comment, told apart by glyph
-		return m.styles.notif
-	}
-}
-
-// ---- help -----------------------------------------------------------------
-
-type helpGroup struct {
-	title string
-	keys  [][2]string
-}
-
-// renderHelp is the keybindings reference, a centered bordered overlay (the
-// inspector chrome) with a two-column grid of sections and a title line. The keys
-// are the ones the model actually binds, descriptions avoid slashes except in key
-// forms like x / y.
-func (m Model) renderHelp() string {
-	nav := helpGroup{"NAVIGATION", [][2]string{
-		{"j / k · ↑ / ↓", "move up or down"},
-		{"g / G", "go to top or bottom"},
-		{"ctrl-f / ctrl-b", "page down or up"},
-		{"[ / ]", "previous or next session"},
-		{"enter", "open session or frame"},
-		{"esc", "back up or clear filter"},
-	}}
-	frameActions := helpGroup{"FRAME ACTIONS", [][2]string{
-		{"r", "replay the selected tool call"},
-		{"c", "show negotiated capabilities"},
-		{"s", "show per-tool latency and error summary"},
-		{"p", "pause or resume the stream"},
-		{"f", "toggle follow"},
-	}}
-	manage := helpGroup{"MANAGE", [][2]string{
-		{"y", "copy frame JSON or log path"},
-		{"e", "export session as HTML"},
-		{"ctrl-d", "delete the selected session"},
-	}}
-	views := helpGroup{"VIEWS & SEARCH", [][2]string{
-		{"/", "filter the current table"},
-		{":", "command mode"},
-		{"shift+N/R/S/E/L", "sort sessions by column"},
-		{"shift+T/M/I/D/S", "sort stream by column"},
-		{"?", "toggle this help"},
-	}}
-	inFrame := helpGroup{"IN A FRAME", [][2]string{
-		{"/", "search within the frame"},
-		{"n / N", "next or previous match"},
-		{"x", "jump to the paired frame"},
-		{"y", "copy the frame JSON"},
-	}}
-	general := helpGroup{"GENERAL", [][2]string{
-		{":q", "quit"},
-	}}
-	filter := helpGroup{"STREAM FILTER QUERY", [][2]string{
-		{"<text>", "substring over method, tool, id, payload"},
-		{"tool:echo", "by tool name"},
-		{"status:err|warn|ok|pending|bad|mismatch", "by outcome"},
-		{"kind:req|resp|notify|stderr|invalid", "by message type"},
-		{"dir:c2s|s2c", "by direction"},
-		{"method:tools/call", "by method"},
-		{"id:7", "by id"},
-	}}
-
-	// One shared key-column width across both halves, so every description starts
-	// at the same column and the grid reads evenly.
-	keyW := max(helpKeyWidth(nav, frameActions, manage), helpKeyWidth(views, inFrame, general))
-	left := m.helpColumn(keyW, nav, frameActions, manage)
-	right := m.helpColumn(keyW, views, inFrame, general)
-	grid := lipgloss.JoinHorizontal(lipgloss.Top, left, "    ", right)
-	filterBlock := m.helpSection(helpKeyWidth(filter), filter)
-
-	contentW := max(lipgloss.Width(grid), lipgloss.Width(filterBlock))
-	ver := Version
-	if !strings.HasPrefix(ver, "v") {
-		ver = "v" + ver
-	}
-	title := m.styles.infoVal.Render("KEYBINDINGS")
-	verText := m.styles.faint.Render("mcpsnoop " + ver)
-	titleGap := max(contentW-lipgloss.Width(title)-lipgloss.Width(verText), 1)
-	titleLine := title + strings.Repeat(" ", titleGap) + verText
-
-	body := lipgloss.JoinVertical(lipgloss.Left, titleLine, "", grid, "", filterBlock)
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).BorderForeground(m.theme.blue).Padding(0, 2).
-		Render(body)
-	footer := " " + m.styles.faint.Render("? or esc to close")
-	panel := lipgloss.JoinVertical(lipgloss.Left, box, footer)
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
-}
-
-// helpKeyWidth is the widest key cell across the given groups.
-func helpKeyWidth(gs ...helpGroup) int {
-	w := 0
-	for _, g := range gs {
-		for _, k := range g.keys {
-			w = max(w, lipgloss.Width(k[0]))
-		}
-	}
-	return w
-}
-
-// helpSection renders one group, a blue title over key/description rows whose
-// descriptions all start at keyW so the column stays even.
-func (m Model) helpSection(keyW int, g helpGroup) string {
-	rows := []string{m.styles.sectionHead.Render(g.title)}
-	for _, k := range g.keys {
-		gap := keyW - lipgloss.Width(k[0]) + 2
-		rows = append(rows, "  "+m.styles.hintKey.Render(k[0])+strings.Repeat(" ", gap)+m.styles.hintDesc.Render(k[1]))
-	}
-	return strings.Join(rows, "\n")
-}
-
-// helpColumn stacks sections into one column with a blank line between them, all
-// sharing keyW so descriptions line up across groups.
-func (m Model) helpColumn(keyW int, gs ...helpGroup) string {
-	parts := make([]string, len(gs))
-	for i, g := range gs {
-		parts[i] = m.helpSection(keyW, g)
-	}
-	return strings.Join(parts, "\n\n")
-}
-
-// ---- inspector / capabilities / replay content ----------------------------
-
-// inspectorBody is the scrollable content of the frame inspector, the pretty
-// JSON (or the raw stderr line) in plain form. It is numbered and highlighted for
-// display and searched in plain form.
-func (m Model) inspectorBody() string {
-	if m.inspect < 0 || m.inspect >= len(m.full) {
-		return ""
-	}
-	e := m.full[m.inspect]
-	var b strings.Builder
-	if e.Text != "" {
-		b.WriteString(e.Text)
-		if len(e.Raw) > 0 {
-			b.WriteString("\n")
-		}
-	}
-	if len(e.Raw) > 0 {
-		b.WriteString(prettyJSON(e.Raw))
-	}
-	return b.String()
-}
-
-// inspectorHeader is the single fixed line above the inspector body, the frame
-// meta joined by faint dots on the left and the pair widget plus timestamp on the
-// right, sized to width w.
-func (m Model) inspectorHeader(w int) string {
-	if m.inspect < 0 || m.inspect >= len(m.full) {
-		return ""
-	}
-	e := m.full[m.inspect]
-	c := m.streamCells(e)
-	sep := m.styles.faint.Render(" · ")
-	parts := []string{m.styles.dim.Render(dirLabel(e.Dir))}
-	if e.Call != nil {
-		if e.Call.Method != "" {
-			parts = append(parts, m.styles.req.Render(e.Call.Method))
-		}
-		parts = append(parts, m.styles.dim.Render("id "+e.Call.ID),
-			m.styles.dim.Render(e.Call.Duration().Round(time.Millisecond).String()))
-	}
-	if c.status != "" {
-		parts = append(parts, m.statusStyle(e).Render(c.status))
-	}
-	left := m.styles.infoVal.Render(fmt.Sprintf("FRAME %d/%d", m.inspect+1, len(m.full))) + "  " + strings.Join(parts, sep)
-	right := m.pairWidget() + sep + m.styles.faint.Render(e.TS.Format("15:04:05.000"))
-	head := bar(w, left, right)
-	// A second chrome line carries the Streamable HTTP request headers (SEP-2243
-	// routing plus MCP-Protocol-Version) verbatim when the request had them, so the
-	// busy meta line stays readable and older transports show nothing. overlayHeaderH
-	// tracks the extra line.
-	if hasTransportMeta(e) {
-		var rp []string
-		if e.MCPMethod != "" {
-			rp = append(rp, m.styles.dim.Render("Mcp-Method ")+m.styles.neutral.Render(e.MCPMethod))
-		}
-		if e.MCPName != "" {
-			rp = append(rp, m.styles.dim.Render("Mcp-Name ")+m.styles.neutral.Render(e.MCPName))
-		}
-		if e.MCPProtocolVersion != "" {
-			rp = append(rp, m.styles.dim.Render("MCP-Protocol-Version ")+m.styles.neutral.Render(e.MCPProtocolVersion))
-		}
-		if e.HTTPStatus != 0 {
-			rp = append(rp, m.styles.dim.Render("HTTP ")+m.styles.neutral.Render(fmt.Sprintf("%d %s", e.HTTPStatus, http.StatusText(e.HTTPStatus))))
-		}
-		if e.AuthChallenge != "" {
-			rp = append(rp, m.styles.dim.Render("WWW-Authenticate ")+m.styles.neutral.Render(e.AuthChallenge))
-		}
-		head += "\n" + bar(w, strings.Join(rp, sep), "")
-	}
-	return head
-}
-
-// inspectorHeaderH is the number of fixed chrome lines above the inspector body:
-// the meta line, plus a routing-headers line when the inspected frame has them.
-func (m Model) inspectorHeaderH() int {
-	if m.inspect >= 0 && m.inspect < len(m.full) {
-		if hasTransportMeta(m.full[m.inspect]) {
-			return 2
-		}
-	}
-	return 1
-}
-
-// hasTransportMeta reports whether a frame carries a second chrome line. The
-// renderer and the height calculation both ask, and they must never disagree:
-// one saying yes while the other says no leaves the inspector body off by a row.
-func hasTransportMeta(e store.EventView) bool {
-	return e.MCPMethod != "" || e.MCPName != "" || e.MCPProtocolVersion != "" || e.HTTPStatus != 0
-}
-
-// pairWidget is the right side of the inspector header, req N ⇄ resp N with the
-// current frame bright bold and the partner (what x jumps to) blue, or req N ⇄
-// pending in cyan while a request awaits its response, or a plain seq N for a
-// frame with no pair.
-func (m Model) pairWidget() string {
-	if m.inspect < 0 || m.inspect >= len(m.full) {
-		return ""
-	}
-	e := m.full[m.inspect]
-	plain := m.styles.faint.Render(fmt.Sprintf("seq %d", e.Seq))
-	if e.Call == nil {
-		return plain
-	}
-	arrow := m.styles.faint.Render(" ⇄  ")
-	switch e.Kind {
-	case store.EventRequest:
-		cur := m.styles.infoVal.Render(fmt.Sprintf("req %d", e.Seq))
-		if e.Call.State == store.Pending {
-			return cur + arrow + m.styles.pending.Render("pending")
-		}
-		if e.Call.State == store.Streaming {
-			return cur + arrow + m.styles.follow.Render("streaming")
-		}
-		if pi, ok := m.pairIndex(m.inspect); ok {
-			return cur + arrow + m.styles.req.Render(fmt.Sprintf("resp %d", m.full[pi].Seq))
-		}
-	case store.EventResponse:
-		cur := m.styles.infoVal.Render(fmt.Sprintf("resp %d", e.Seq))
-		if pi, ok := m.pairIndex(m.inspect); ok {
-			return m.styles.req.Render(fmt.Sprintf("req %d", m.full[pi].Seq)) + arrow + cur
-		}
-	}
-	return plain
-}
-
-// pairIndex finds the request for a response (or vice versa) so x can jump
-// between the two halves of one exchange. Each event carries its own CallView
-// copy, so the match is on the call identity, its id and start time.
-func (m Model) pairIndex(sel int) (int, bool) {
-	if sel < 0 || sel >= len(m.full) || m.full[sel].Call == nil {
-		return 0, false
-	}
-	c := m.full[sel].Call
-	want := store.EventRequest
-	if m.full[sel].Kind == store.EventRequest {
-		want = store.EventResponse
-	}
-	for i, e := range m.full {
-		if i != sel && e.Kind == want && e.Call != nil && e.Call.ID == c.ID && e.Call.Start.Equal(c.Start) {
-			return i, true
-		}
-	}
-	return 0, false
-}
-
-func dirLabel(d proxy.Direction) string {
-	if d == proxy.ServerToClient {
-		return "s2c"
-	}
-	return "c2s"
-}
-
-// overlayPadX insets every overlay's content from its border by a fixed number
-// of columns, so the inspector, capabilities, summary, and replay panels share
-// one comfortable left and right margin instead of each starting flush.
-const overlayPadX = 2
-
-// renderOverlay draws the active overlay, a centered rounded panel with fixed
-// chrome above a scrollable body and a hint footer below.
-func (m Model) renderOverlay() string {
-	cw, _ := m.overlayDims()
-	ch := m.overlayHeaderH + m.vp.Height + 1 // header lines, the content-sized viewport, the indicator
-	inner := m.vp.View()
-	if m.overlay == overlayInspector {
-		inner = m.inspectorHeader(cw) + "\n" + inner
-	}
-	inner += "\n" + m.scrollLine(cw)
-	boxW := cw + 2*overlayPadX
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).BorderForeground(m.theme.blue).
-		Padding(0, overlayPadX).
-		Width(boxW).Height(ch)
-	panel := lipgloss.JoinVertical(lipgloss.Left, box.Render(inner), m.overlayFooter(boxW))
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
-}
-
-// panelBox renders body inside a rounded border with title embedded in the top
-// edge and an optional faint rightTitle before the closing corner, sized to width
-// w and height h. Body lines are clipped to the height with a faint count of what
-// is hidden.
-func (m Model) panelBox(title, rightTitle string, titleStyle lipgloss.Style, border lipgloss.TerminalColor, body string, w, h int) string {
-	bs := lipgloss.NewStyle().Foreground(border)
-	inner := max(w-2, 1)
-	head := bs.Render("╭─") + " " + titleStyle.Render(ansi.Truncate(title, max(inner-3, 1), "…")) + " "
-	tail := bs.Render("╮")
-	if rightTitle != "" {
-		rightTitle = ansi.Truncate(rightTitle, max(w-lipgloss.Width(head)-6, 0), "…")
-		tail = " " + m.styles.faint.Render(rightTitle) + " " + bs.Render("─╮")
-	}
-	top := head + bs.Render(strings.Repeat("─", max(w-lipgloss.Width(head)-lipgloss.Width(tail), 0))) + tail
-
-	lines := strings.Split(body, "\n")
-	bodyH := max(h-2, 1)
-	var rows []string
-	for i := range bodyH {
-		var content string
-		switch {
-		case i == bodyH-1 && len(lines) > bodyH:
-			content = m.styles.faint.Render(fmt.Sprintf("… %d more lines", len(lines)-bodyH+1))
-		case i < len(lines):
-			content = lines[i]
-		}
-		rows = append(rows, bs.Render("│")+fitCell(content, inner)+bs.Render("│"))
-	}
-	bottom := bs.Render("╰" + strings.Repeat("─", inner) + "╯")
-	return top + "\n" + strings.Join(rows, "\n") + "\n" + bottom
-}
-
-// fitCell pads or ansi-truncates s to exactly width w.
-func fitCell(s string, w int) string {
-	if lipgloss.Width(s) > w {
-		return ansi.Truncate(s, w, "…")
-	}
-	return s + strings.Repeat(" ", max(w-lipgloss.Width(s), 0))
-}
-
-// overlayDims is the centered panel content width, capped near 110 columns, and
-// the maximum viewport height. The returned width is the text area, the box
-// interior less overlayPadX on each side. The whole modal (two borders, the
-// padding, the header, the viewport, the indicator line, and the footer) is
-// capped at rows-4, so a short payload sizes to its content instead of
-// stretching to full screen.
-func (m Model) overlayDims() (w, maxVpH int) {
-	w = max(min(110, m.width-4)-2-2*overlayPadX, 1)
-	maxVpH = max(m.height-8-m.overlayHeaderH, 1) // borders(2) + header + indicator(1) + footer(1)
-	return w, maxVpH
-}
-
-// overlayFooter is the hint line under the panel, or the search prompt and live
-// match count while searching.
-func (m Model) overlayFooter(w int) string {
-	if m.inputMode == inputSearch {
-		right := ""
-		if n := len(m.overlayMatches); n > 0 {
-			right = m.styles.dim.Render(fmt.Sprintf("%d/%d match", m.overlayMatchIx+1, n))
-		} else if m.overlaySearch != "" {
-			right = m.styles.dim.Render("no match")
-		}
-		return bar(w, m.styles.prompt.Render(m.input.View()), right)
-	}
-	// The scroll hint appears only when the body actually overflows the viewport,
-	// so every overlay reads the same way: a short digest that fits shows no scroll
-	// hint, a long one does. Overlay-specific keys follow.
-	var hs []hint
-	if m.vp.TotalLineCount() > m.vp.Height {
-		hs = append(hs, hint{"↑↓", "scroll"})
-	}
-	switch {
-	case m.overlay == overlayInspector:
-		hs = append(hs, hint{"/", "search"}, hint{"n/N", "match"}, hint{"y", "copy"})
-		// r and x are only offered when they can act on the inspected frame.
-		if m.canReplay() {
-			hs = append(hs, hint{"r", "replay"})
-		}
-		if _, ok := m.pairIndex(m.inspect); ok {
-			hs = append(hs, hint{"x", "pair"})
-		}
-		hs = append(hs, hint{"esc", "close"})
-	case m.overlay == overlayReplay && m.replayReq.Method != "":
-		hs = append(hs, hint{"r", "replay again"}, hint{"y", "copy"}, hint{"esc", "close"})
-	default:
-		hs = append(hs, hint{"y", "copy"}, hint{"esc", "close"})
-	}
-	right := ""
-	switch {
-	case m.replaying:
-		right = m.replaySpinner()
-	case m.flashActive():
-		right = m.flashStyle().Render(m.flash)
-	}
-	return bar(w, m.hintsRow(hs), right)
-}
-
-// scrollLine is the faint indicator of how much body is hidden below the fold,
-// blank when everything fits.
-func (m Model) scrollLine(w int) string {
-	total, visible := m.vp.TotalLineCount(), m.vp.Height
-	if total <= visible {
-		return ""
-	}
-	pct := int(m.vp.ScrollPercent() * 100)
-	hidden := max(total-visible-m.vp.YOffset, 0)
-	txt := fmt.Sprintf("▲▼ %d%%", pct)
-	if hidden > 0 {
-		txt = fmt.Sprintf("▼ %d more lines · %d%%", hidden, pct)
-	}
-	return m.styles.faint.Render(txt)
-}
-
-func (m Model) capsContent() string {
-	sid := m.currentSessionID()
-	label := m.currentLabel()
-	caps, ok := m.store.Capabilities(sid)
-	if !ok {
-		return m.styles.faint.Render("no capabilities observed yet for this session")
-	}
-	// This screen answers one question, which capabilities did each side declare,
-	// with a marker per capability and nothing else. The raw declaration, with
-	// listChanged and any other sub-flags, is one keystroke away in the inspector
-	// on the frame that carried it (initialize, or a stateless _meta/server-discover).
-	w, _ := m.overlayDims()
-	title := m.capsTitle(label, valueOr(caps.ProtocolVersion, "unknown"), w)
-	client := m.capSection("client", caps.ClientInfo, clientCapOrder, caps.Client)
-	server := m.capSection("server", caps.ServerInfo, serverCapOrder, caps.Server)
-	// A blank line under the title and one between the two groups.
-	body := title + "\n\n" + client + "\n\n" + server
-	// Extensions are negotiated per pair rather than declared per side, so they
-	// get one block under both sections instead of a row inside each. The block
-	// is omitted entirely when neither side advertised any, so an ordinary
-	// session renders exactly as it did before.
-	if section := m.extensionsSection(caps.Extensions); section != "" {
-		body += "\n\n" + section
-	}
-	// The server may attach usage guidance for the model. Show it under the two
-	// sections when present, dim so it never competes with the capability markers.
-	if caps.Instructions != "" {
-		body += "\n\n" + m.styles.dim.Render("instructions") + "\n" + m.styles.faint.Render(caps.Instructions)
-	}
-	return body
-}
-
-// capsTitle is the header line: the accent title and session label on the left,
-// the negotiated protocol version dim on the right, filling the content width so
-// the version sits flush against the panel's right margin.
-func (m Model) capsTitle(label, version string, w int) string {
-	left := m.styles.brand.Render("capabilities") + m.styles.faint.Render(" · ") + m.styles.bright.Render(label)
-	right := m.styles.dim.Render("protocol ") + m.styles.neutral.Render(version)
-	gap := max(w-lipgloss.Width(left)-lipgloss.Width(right), 1)
-	return left + strings.Repeat(" ", gap) + right
-}
-
-// summary table column widths, all padded with lipgloss.Width so styled cells
-// stay aligned.
-const (
-	sumToolW   = 18
-	sumSchemaW = 7
-	sumCallsW  = 7
-	sumErrW    = 6
-	sumLatW    = 10
-	sumDefW    = 9
-	sumResW    = 10
-	// covLabelW fits the longest gutter label plus a space. "definitions" is
-	// eleven cells wide, so eleven would leave no gap at all and run the label
-	// into its value.
-	covLabelW   = 12
-	driftLabelW = 20
-)
-
-func (m Model) summaryContent() string {
-	sid := m.currentSessionID()
-	label := m.currentLabel()
-	summary, _ := m.store.ToolSummary(sid)
-	_, unused, undeclared, hasTools := m.store.ToolUsage(sid)
-	drift, hasDrift := m.store.ToolDrift(sid)
-	findingsByName := map[string][]store.SchemaFinding{}
-
-	if definitions, ok := m.store.ToolDefinitions(sid); ok {
-		for _, d := range definitions {
-			findingsByName[d.Name] = d.Findings
-		}
-	}
-	// Costs come from ToolCosts rather than ToolDefinitions because that one is
-	// gated on a complete tool list. A half-paginated list still has a real
-	// per-tool weight, and blanking the column while showing the rows would read
-	// as "this tool is free".
-	costByName := map[string]store.ToolCost{}
-	listCost, hasCost := m.store.ToolCosts(sid)
-	for _, c := range listCost.PerTool {
-		costByName[c.Name] = c
-	}
-	w, _ := m.overlayDims()
-
-	calls := 0
-	for _, t := range summary.Tools {
-		calls += t.Calls
-	}
-	left := m.styles.brand.Render("tool summary") + m.styles.faint.Render(" · ") + m.styles.bright.Render(label)
-	right := ""
-	if calls > 0 {
-		right = m.styles.dim.Render(fmt.Sprintf("%d calls", calls))
-	}
-	gap := max(w-lipgloss.Width(left)-lipgloss.Width(right), 1)
-	header := left + strings.Repeat(" ", gap) + right
-
-	// hasCost joins the guard because a seen tools/list is worth showing on its
-	// own, even an empty one: a server that advertised no tools still answers the
-	// fixed-cost question, with a 0 B definitions line, and that is a different
-	// screen from a session that never listed at all.
-	if len(summary.Tools) == 0 && !hasTools && !hasDrift && !hasCost {
-		return header + "\n\n" + m.styles.dim.Render("no tool calls observed yet for this session")
-	}
-
-	var sections []string
-	if hasDrift && drift.BaselineError != "" {
-		sections = append(sections, m.styles.respErr.Render("tool baseline error")+"\n"+m.styles.warn.Render(drift.BaselineError))
-	}
-	if hasDrift && !drift.Empty() {
-		if drift.Count() > 0 {
-			sections = append(sections, m.definitionDriftSection(drift, w))
-		}
-	}
-	// The fixed cost leads, because it is the one paid whether or not anything
-	// below it was ever called.
-	if hasCost {
-		sections = append(sections, m.definitionCostLine(listCost))
-	}
-
-	// TABLE: every advertised tool plus any called one, so the full tool set is
-	// visible from the start and its counts fill in as calls arrive. Uncalled
-	// tools are faint 0-call rows; problems sort to the top (errors first, then by
-	// the shown median latency descending), so idle tools sink to the bottom. The
-	// ERR column carries the only verdict color, plus the cyan pending spinner,
-	// and SCHEMA carries warn.
-	tools := slices.Clone(summary.Tools)
-	for _, name := range unused {
-		tools = append(tools, store.ToolStats{Name: name})
-	}
-	slices.SortStableFunc(tools, func(a, b store.ToolStats) int {
-		if ae, be := a.Errors > 0, b.Errors > 0; ae != be {
-			if ae {
-				return -1
-			}
-			return 1
-		}
-		switch {
-		case a.P50 > b.P50:
-			return -1
-		case a.P50 < b.P50:
-			return 1
-		default:
-			return 0
-		}
+		return cmp.Compare(a.Name, b.Name)
 	})
-	var t strings.Builder
-	t.WriteString(m.styles.dim.Render(cellL("TOOL", sumToolW) +
-		cellR("CALLS", sumCallsW) + cellR("ERR", sumErrW) + cellR("LATENCY", sumLatW) +
-		cellR("DEF", sumDefW) + cellR("RESULT", sumResW) +
-		"  " + cellL("SCHEMA", sumSchemaW)))
-	for _, tool := range tools {
-		base := m.styles.neutral
-		if tool.Calls == 0 {
-			base = m.styles.faint // an advertised-but-idle tool recedes until it is called
-		}
-		errCell := m.styles.faint.Render("·")
-		if tool.Errors > 0 {
-			errCell = m.styles.respErr.Render(fmt.Sprintf("%d", tool.Errors))
-		}
-		// LATENCY is the median (p50), a plain number the reader judges for
-		// themselves. A tool whose calls are all still in flight shows a live cyan
-		// spinner rather than a dash.
-		lat := base.Render(formatLatency(tool.P50))
-		if tool.Pending > 0 && tool.Pending == tool.Calls {
-			lat = m.styles.pending.Render(m.spinnerFrame())
-		}
-		// SCHEMA names the most notable construct a tool's advertised schema uses
-		// that is known to travel badly across clients, plus a "+" when there is
-		// more than one kind. Purely observational, so it carries the warn color,
-		// never the ERR column's red.
-		// An empty cell is left blank rather than dotted. The ERR column already
-		// uses · to mean zero, and repeating it here both adds noise on the common
-		// case of a clean schema and makes a row match a search for either column.
-		schemaCell := cellL("", sumSchemaW)
-		if findings := findingsByName[tool.Name]; len(findings) > 0 {
-			label := schemaKindLabel(headlineFinding(findings))
-			if len(findings) > 1 {
-				label += "+"
-			}
-			schemaCell = m.styles.warn.Render(cellL(label, sumSchemaW))
-		}
-		// DEF is what advertising the tool costs, once per conversation. RESULT
-		// is what its answers have cost so far, and grows per call. Both carry
-		// their unit so neither can be read as a token count. A tool the server
-		// never advertised has no definition cost to show, which is a real state
-		// (see the undeclared line below) rather than a zero.
-		defCell := m.styles.faint.Render(cellR("·", sumDefW))
-		if c, ok := costByName[tool.Name]; ok {
-			defCell = cellR(base.Render(formatBytes(int64(c.Bytes))), sumDefW)
-		}
-		resCell := cellR(base.Render(formatBytes(tool.ResultBytes)), sumResW)
-		t.WriteString("\n" + base.Render(cellL(tool.Name, sumToolW)) +
-			cellR(base.Render(fmt.Sprintf("%d", tool.Calls)), sumCallsW) +
-			cellR(errCell, sumErrW) +
-			cellR(lat, sumLatW) +
-			defCell + resCell +
-			"  " + schemaCell)
-	}
-	sections = append(sections, t.String())
-
-	// The worst single result is the per-call cost's tail, which a total hides:
-	// one 4 MiB answer among a hundred small ones reads as an unremarkable
-	// average until it is named.
-	if name, worst := heaviestResult(summary.Tools); worst > 0 {
-		sections = append(sections, m.styles.dim.Render(cellL("heaviest", covLabelW))+
-			m.styles.neutral.Render(fmt.Sprintf("%s returned %s in one result", name, formatBytes(int64(worst)))))
-	}
-
-	// DRIFT: tools the client called that the server never advertised in
-	// tools/list. They appear in the table too, but a red line flags them as a
-	// contract mismatch worth noticing.
-	if len(undeclared) > 0 {
-		indent := strings.Repeat(" ", covLabelW)
-		sections = append(sections, m.styles.dim.Render(cellL("undeclared", covLabelW))+m.styles.respErr.Render(wrapWords(undeclared, indent, w)))
-	}
-
-	return header + "\n\n" + strings.Join(sections, "\n\n")
+	return cost, true
 }
 
-// schemaHeadlineOrder ranks findings for the single-label SCHEMA column. An
-// external reference leads because it points outside the wire entirely, which is
-// both the least portable case and the one the spec warns implementers about.
-// The composition keywords follow, then an internal reference, then an untyped
-// property, which is the weakest signal since a description often carries the
-// meaning a type would.
-var schemaHeadlineOrder = []store.SchemaFindingKind{
-	store.FindingExternalRef,
-	store.FindingOneOf,
-	store.FindingAnyOf,
-	store.FindingAllOf,
-	store.FindingNot,
-	store.FindingRef,
-	store.FindingUntypedProperty,
-}
-
-// headlineFinding picks which finding the column names. The store returns them
-// in the order the walk met them, which is an artifact of schema layout rather
-// than of how much each one matters, so the choice is made here.
-func headlineFinding(findings []store.SchemaFinding) store.SchemaFindingKind {
-	for _, want := range schemaHeadlineOrder {
-		for _, f := range findings {
-			if f.Kind == want {
-				return want
-			}
-		}
-	}
-	return findings[0].Kind
-}
-
-// schemaKindLabel is the short display text for a schema finding kind in the
-// narrow SCHEMA column. Display wording is a TUI concern, not the store's.
-func schemaKindLabel(k store.SchemaFindingKind) string {
-	switch k {
-	case store.FindingExternalRef:
-		return "ext ref"
-	case store.FindingUntypedProperty:
-		return "untyped"
-	default:
-		return string(k)
+// SetToolDrift attaches the current baseline comparison to a session.
+func (s *Store) SetToolDrift(sessionID string, drift ToolDrift) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[sessionID]; ok {
+		sess.toolDrift = drift
+		sess.toolDriftSet = true
 	}
 }
 
-func (m Model) definitionDriftSection(drift store.ToolDrift, width int) string {
-	var lines []string
-	for _, change := range []struct {
-		label string
-		names []string
-	}{
-		{"added", drift.AddedTools},
-		{"removed", drift.RemovedTools},
-		{"description changed", drift.ChangedDescriptions},
-		{"schema changed", drift.ChangedSchemas},
-	} {
-		if len(change.names) == 0 {
-			continue
-		}
-		indent := strings.Repeat(" ", driftLabelW)
-		lines = append(lines, m.styles.dim.Render(cellL(change.label, driftLabelW))+m.styles.warn.Render(wrapWords(change.names, indent, width)))
+// ToolDrift returns the current baseline comparison for a session.
+func (s *Store) ToolDrift(sessionID string) (ToolDrift, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok || !sess.toolDriftSet {
+		return ToolDrift{}, false
 	}
-	return m.styles.warn.Render("tool definition drift") + "\n" + strings.Join(lines, "\n")
+	return cloneToolDrift(sess.toolDrift), true
 }
 
-// wrapWords lays space-separated words into lines no wider than width, each
-// continuation line prefixed with indent, so a long name list wraps at word
-// boundaries instead of splitting a name mid-way.
-func wrapWords(words []string, indent string, width int) string {
-	avail := max(width-lipgloss.Width(indent), 8)
-	var b strings.Builder
-	lineW := 0
-	for i, word := range words {
-		ww := lipgloss.Width(word)
-		switch {
-		case i == 0:
-			b.WriteString(word)
-			lineW = ww
-		case lineW+1+ww > avail:
-			b.WriteString("\n" + indent + word)
-			lineW = ww
-		default:
-			b.WriteString(" " + word)
-			lineW += 1 + ww
-		}
-	}
-	return b.String()
-}
-
-// formatLatency renders a call latency compactly, with finer digits for smaller
-// values, so every value fits the summary's fixed-width column instead of an
-// over-precise string like 1.234567s. Zero means no completed calls, a dash.
-func formatLatency(d time.Duration) string {
-	switch {
-	case d <= 0:
-		return "-"
-	case d < time.Millisecond:
-		return d.Round(time.Microsecond).String()
-	case d < time.Second:
-		return d.Round(100 * time.Microsecond).String()
-	default:
-		return d.Round(10 * time.Millisecond).String()
+func cloneToolDrift(drift ToolDrift) ToolDrift {
+	return ToolDrift{
+		AddedTools:          slices.Clone(drift.AddedTools),
+		RemovedTools:        slices.Clone(drift.RemovedTools),
+		ChangedDescriptions: slices.Clone(drift.ChangedDescriptions),
+		ChangedSchemas:      slices.Clone(drift.ChangedSchemas),
+		BaselineError:       drift.BaselineError,
 	}
 }
 
-// definitionCostLine states the fixed half of the context bill: what this
-// server's tool list weighs before a single call is made. An unfinished
-// tools/list reports a floor and says so, since presenting a partial sum as the
-// total is the one way this number could mislead.
-func (m Model) definitionCostLine(cost store.ToolListCost) string {
-	tools := "tools"
-	if cost.Tools == 1 {
-		tools = "tool"
-	}
-	value := fmt.Sprintf("%d %s · %s", cost.Tools, tools, formatBytesProse(int64(cost.Bytes)))
-	note := " of tool definitions, paid on every conversation"
-	style := m.styles.neutral
-	if !cost.Complete {
-		value = fmt.Sprintf("%d %s · %s so far", cost.Tools, tools, formatBytesProse(int64(cost.Bytes)))
-		note = ", tools/list never finished paginating"
-		style = m.styles.warn
-	}
-	return m.styles.dim.Render(cellL("definitions", covLabelW)) + style.Render(value) + m.styles.faint.Render(note)
-}
-
-// heaviestResult names the tool with the largest single observed result.
-func heaviestResult(tools []store.ToolStats) (string, int) {
-	name, worst := "", 0
-	for _, t := range tools {
-		if t.MaxResultBytes > worst {
-			name, worst = t.Name, t.MaxResultBytes
-		}
-	}
-	return name, worst
-}
-
-// formatBytes renders a byte count for a narrow column. Bytes and never tokens:
-// a token count is model specific, so mcpsnoop reports the exact bytes and lets
-// the reader apply whatever ratio their model implies. The unit rides every
-// value so no cell can be mistaken for a token count, and the binary units are
-// spelled KiB and MiB rather than kB, because a number presented as exact
-// should not quietly mean 1024.
-func formatBytes(n int64) string {
-	switch {
-	case n <= 0:
-		return "·"
-	case n < 1<<10:
-		return fmt.Sprintf("%d B", n)
-	case n < 1<<20:
-		return fmt.Sprintf("%.1f KiB", float64(n)/(1<<10))
-	default:
-		return fmt.Sprintf("%.1f MiB", float64(n)/(1<<20))
-	}
-}
-
-// formatBytesProse is formatBytes without the table's zero dot. The dot means
-// "nothing to show" in a narrow cell, but a sentence has to say zero out loud:
-// a server advertising no tools costs 0 B, and that is worth reading as a fact
-// rather than as a blank.
-func formatBytesProse(n int64) string {
-	if n <= 0 {
-		return "0 B"
-	}
-	return formatBytes(n)
-}
-
-func infoLine(raw json.RawMessage) string {
-	var info struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
-	}
-	if len(raw) == 0 || json.Unmarshal(raw, &info) != nil || info.Name == "" {
-		return ""
-	}
-	if info.Version != "" {
-		return info.Name + " v" + info.Version
-	}
-	return info.Name
-}
-
-// capLabelW is the label gutter, so the client and server implementation names
-// start at the same column under the title.
-const capLabelW = 8
-
-// clientCapOrder and serverCapOrder are the standard MCP capabilities per side,
-// in display order, so a capability a side did not declare still shows as a
-// hollow ○ row instead of silently missing. Capabilities are an open set, so a
-// side may also declare names outside these.
-var (
-	clientCapOrder = []string{"roots", "sampling", "elicitation"}
-	serverCapOrder = []string{"tools", "resources", "prompts", "logging", "completions"}
-)
-
-// capLabelRow is one gutter row, a dim label padded to the gutter then its value.
-// No trailing newline, the caller assembles the blocks.
-func (m Model) capLabelRow(label, value string) string {
-	return m.styles.dim.Render(cellL(label, capLabelW)) + value
-}
-
-// infoValue renders an implementation's name bright and its version faint, for
-// the client and server rows.
-func (m Model) infoValue(raw json.RawMessage) string {
-	name, version := infoNameVersion(raw)
-	switch {
-	case name == "":
-		return m.styles.faint.Render("unknown")
-	case version != "":
-		return m.styles.bright.Render(name) + " " + m.styles.faint.Render(version)
-	default:
-		return m.styles.bright.Render(name)
-	}
-}
-
-func infoNameVersion(raw json.RawMessage) (name, version string) {
-	var info struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
-	}
-	if len(raw) == 0 || json.Unmarshal(raw, &info) != nil {
-		return "", ""
-	}
-	return info.Name, info.Version
-}
-
-// capSection renders one side of the handshake: the label and implementation
-// row, then a filled ● row for every declared capability (the known ones in
-// standard order, then any experimental extras) and a hollow ○ row for each
-// known capability the side did not declare.
-func (m Model) capSection(label string, info json.RawMessage, order []string, raw json.RawMessage) string {
-	declared := capNames(raw)
-	rows := []string{m.capLabelRow(label, m.infoValue(info))}
-
-	known := make(map[string]bool, len(order))
-	var absent []string
-	for _, name := range order {
-		known[name] = true
-		if declared[name] {
-			rows = append(rows, m.capRow(true, name))
-		} else {
-			absent = append(absent, name)
-		}
-	}
-	// Never hide a declared capability: surface any outside the known set as a
-	// present row too, so an experimental cap is visible rather than dropped.
-	var extra []string
-	for name := range declared {
-		if !known[name] {
-			extra = append(extra, name)
-		}
-	}
-	slices.Sort(extra)
-	for _, name := range extra {
-		rows = append(rows, m.capRow(true, name))
-	}
-	for _, name := range absent {
-		rows = append(rows, m.capRow(false, name))
-	}
-	return strings.Join(rows, "\n")
-}
-
-// capRow is one capability line: a two-space indent, a one-cell marker, then the
-// name. Declared is a green ● with the name in text, absent a faint ○ with the
-// name faint. Deprecated capabilities append a dim migration hint. ● and ○ share
-// one cell width so the names align, and the filled/hollow glyph carries the
-// state on its own so NO_COLOR stays legible.
-func (m Model) capRow(present bool, name string) string {
-	label := name
-	if present {
-		if note := store.DeprecatedCapabilityNote(name); note != "" {
-			label = name + " (deprecated: " + note + ")"
-			return "  " + m.styles.resp.Render("●") + " " + m.styles.warn.Render(label)
-		}
-		return "  " + m.styles.resp.Render("●") + " " + m.styles.neutral.Render(label)
-	}
-	return "  " + m.styles.faint.Render("○") + " " + m.styles.faint.Render(label)
-}
-
-// extensionsSection renders the negotiated extensions (SEP-2133) as one block
-// under both capability sections, or "" when neither side advertised any, so
-// the screen never grows an empty heading.
-func (m Model) extensionsSection(extensions []store.ExtensionView) string {
-	if len(extensions) == 0 {
-		return ""
-	}
-	rows := make([]string, 0, len(extensions)+1)
-	rows = append(rows, m.styles.dim.Render("extensions"))
-	for _, e := range extensions {
-		rows = append(rows, m.extensionRow(e))
-	}
-	return strings.Join(rows, "\n")
-}
-
-// extensionRow is one extension line, matching capRow's two-space indent and
-// one-cell marker so the blocks align. The useful signal is agreement, not
-// presence, so a filled ● means both sides advertised it and a hollow ○ names
-// the side that advertised it alone. The glyph carries the state on its own so
-// NO_COLOR stays legible, and the id is printed exactly as advertised, in
-// reverse-DNS form, because that is what appears in the spec, in the traffic
-// and in a bug report.
-func (m Model) extensionRow(e store.ExtensionView) string {
-	if e.Agreed() {
-		return "  " + m.styles.resp.Render("●") + " " + m.styles.neutral.Render(e.ID)
-	}
-	side := "server only"
-	if e.Client {
-		side = "client only"
-	}
-	return "  " + m.styles.faint.Render("○") + " " + m.styles.faint.Render(e.ID+" ("+side+")")
-}
-
-// capNames returns the set of capability names a side declared. Values are
-// ignored: this screen shows only whether a capability was declared, not its
-// sub-flags. The extensions map is skipped: it is a container of extension ids
-// rather than a capability, and it has its own section, so listing it here
-// would render a phantom "extensions" capability alongside the real ones.
-func capNames(raw json.RawMessage) map[string]bool {
-	var obj map[string]json.RawMessage
-	if json.Unmarshal(raw, &obj) != nil {
+// Timeline returns a snapshot of a session's events, oldest first. A nil slice
+// is returned for an unknown session.
+func (s *Store) Timeline(sessionID string) []EventView {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
 		return nil
 	}
-	set := make(map[string]bool, len(obj))
-	for name := range obj {
-		if name == store.ExtensionsCapability {
-			continue
-		}
-		set[name] = true
+	out := make([]EventView, 0, len(sess.events))
+	for _, ev := range sess.events {
+		out = append(out, ev.view(sess))
 	}
-	return set
+	return out
 }
 
-func valueOr(s, fallback string) string {
-	if s == "" {
-		return fallback
+// Capabilities returns the negotiated capabilities for a session.
+func (s *Store) Capabilities(sessionID string) (CapsView, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok || !sess.caps.set {
+		return CapsView{}, false
 	}
-	return s
+	return CapsView{
+		ProtocolVersion: sess.caps.protocolVersion,
+		ClientInfo:      sess.caps.clientInfo,
+		ServerInfo:      sess.caps.serverInfo,
+		Client:          sess.caps.client,
+		Server:          sess.caps.server,
+		Instructions:    sess.caps.instructions,
+		Extensions: mergeExtensions(
+			extensionIDs(sess.caps.client),
+			extensionIDs(sess.caps.server),
+		),
+	}, true
 }
 
-// ---- small helpers --------------------------------------------------------
+// ToolUsage reports which advertised tools were called during the session.
+func (s *Store) ToolUsage(sessionID string) (used, unused, unadvertised []string, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-func arrow(d proxy.Direction) string {
-	if d == proxy.ServerToClient {
-		return "←"
+	sess, found := s.sessions[sessionID]
+	if !found {
+		return nil, nil, nil, false
 	}
-	return "→"
-}
 
-// highlightMatches wraps every case-insensitive occurrence of q in line with
-// style. Content is mostly plain JSON, so byte indexing is safe enough here.
-func highlightMatches(line, q string, style lipgloss.Style) string {
-	if q == "" {
-		return line
-	}
-	low, lq := strings.ToLower(line), strings.ToLower(q)
-	var b strings.Builder
-	for i := 0; ; {
-		j := strings.Index(low[i:], lq)
-		if j < 0 {
-			b.WriteString(line[i:])
-			return b.String()
-		}
-		j += i
-		b.WriteString(line[i:j])
-		b.WriteString(style.Render(line[j : j+len(q)]))
-		i = j + len(q)
-	}
-}
-
-// numberBody wraps each logical line of body to width, prefixes a 3-wide faint
-// line number (blank on wrapped continuations), and optionally syntax-highlights
-// the JSON. The highlighted and plain forms wrap identically so search line
-// indices line up.
-func (m Model) numberBody(body string, width int, highlight bool) string {
-	const gutterW = 5 // a 3-wide number plus two spaces
-	textW := max(width-gutterW, 1)
-	num := lipgloss.NewStyle().Foreground(m.theme.faint)
-	var out []string
-	for i, line := range strings.Split(body, "\n") {
-		content := line
-		if highlight {
-			content = m.highlightJSON(line)
-		}
-		for j, disp := range strings.Split(ansi.Hardwrap(content, textW, false), "\n") {
-			switch {
-			case j > 0:
-				out = append(out, strings.Repeat(" ", gutterW)+disp)
-			case highlight:
-				out = append(out, num.Render(fmt.Sprintf("%3d  ", i+1))+disp)
-			default:
-				out = append(out, fmt.Sprintf("%3d  ", i+1)+disp)
-			}
+	called := make(map[string]bool)
+	for _, c := range sess.calls {
+		if c.isTool && c.toolName != "" {
+			called[c.toolName] = true
 		}
 	}
-	return strings.Join(out, "\n")
-}
 
-// highlightJSON colors one line of pretty-printed JSON, keys blue, string values
-// green, numbers yellow, true/false/null red, and structural punctuation faint.
-// It scans runes so a color never lands inside a multibyte sequence.
-func (m Model) highlightJSON(line string) string {
-	// Only keys carry color. Values (strings, numbers, true/false/null) stay
-	// neutral so the verdict hues (red err, cyan pending) never leak into the body
-	// and read as false signals, and punctuation recedes.
-	key := lipgloss.NewStyle().Foreground(m.theme.blue)
-	str := lipgloss.NewStyle().Foreground(m.theme.fg)
-	num := str
-	lit := str
-	punc := lipgloss.NewStyle().Foreground(m.theme.faint)
-
-	r := []rune(line)
-	var b strings.Builder
-	for i := 0; i < len(r); {
-		c := r[i]
-		switch {
-		case c == '"':
-			j := i + 1
-			for j < len(r) {
-				if r[j] == '\\' {
-					j += 2
-					continue
-				}
-				if r[j] == '"' {
-					break
-				}
-				j++
-			}
-			end := min(j+1, len(r))
-			text := string(r[i:end])
-			k := end
-			for k < len(r) && r[k] == ' ' {
-				k++
-			}
-			if k < len(r) && r[k] == ':' {
-				b.WriteString(key.Render(text)) // a key is a string followed by a colon
-			} else {
-				b.WriteString(str.Render(text))
-			}
-			i = end
-		case c >= '0' && c <= '9' || (c == '-' && i+1 < len(r) && r[i+1] >= '0' && r[i+1] <= '9'):
-			j := i + 1
-			for j < len(r) && isNumberRune(r[j]) {
-				j++
-			}
-			b.WriteString(num.Render(string(r[i:j])))
-			i = j
-		case c == 't' || c == 'f' || c == 'n':
-			if w := literalAt(r, i); w != "" {
-				b.WriteString(lit.Render(w))
-				i += len([]rune(w))
-				continue
-			}
-			b.WriteRune(c)
-			i++
-		case strings.ContainsRune("{}[],:", c):
-			b.WriteString(punc.Render(string(c)))
-			i++
-		default:
-			b.WriteRune(c)
-			i++
+	for _, name := range sess.advertisedTools {
+		if called[name] {
+			used = append(used, name)
+		} else {
+			unused = append(unused, name)
 		}
 	}
-	return b.String()
-}
 
-func isNumberRune(c rune) bool {
-	return c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E'
-}
-
-// literalAt reports the JSON literal (true, false, null) starting at i, if any.
-func literalAt(r []rune, i int) string {
-	for _, lit := range []string{"true", "false", "null"} {
-		n := len([]rune(lit))
-		if i+n <= len(r) && string(r[i:i+n]) == lit && (i+n == len(r) || !isLetterRune(r[i+n])) {
-			return lit
+	for name := range called {
+		if _, ok := sess.advertisedSet[name]; !ok {
+			unadvertised = append(unadvertised, name)
 		}
 	}
-	return ""
+	sort.Strings(unadvertised)
+
+	if len(sess.advertisedTools) == 0 && len(unadvertised) == 0 {
+		return nil, nil, nil, false
+	}
+	return used, unused, unadvertised, true
 }
 
-func isLetterRune(c rune) bool {
-	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+// Command returns the wrapped server command for a session (from the meta
+// frame), used to replay against an isolated copy. ok is false if unknown.
+func (s *Store) Command(sessionID string) (command []string, cwd string, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, found := s.sessions[sessionID]
+	if !found || len(sess.command) == 0 {
+		return nil, "", false
+	}
+	return append([]string(nil), sess.command...), sess.cwd, true
 }
 
-var sparkRamp = []rune("⣀⣄⣤⣶⣿")
-
-// spark renders bucket counts as a sparkline, scaled to the busiest bucket.
-func spark(buckets []int) string {
-	hi := 0
-	for _, v := range buckets {
-		hi = max(hi, v)
+// Activity buckets the session's frame timestamps into n equal windows over the
+// last span, oldest window first, for the sessions activity sparkline.
+func (s *Store) Activity(sessionID string, n int, span time.Duration) []int {
+	buckets := make([]int, max(n, 0))
+	if n <= 0 {
+		return buckets
 	}
-	var b strings.Builder
-	for _, v := range buckets {
-		i := 0
-		if hi > 0 {
-			i = v * (len(sparkRamp) - 1) / hi
-		}
-		b.WriteRune(sparkRamp[i])
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return buckets
 	}
-	return b.String()
-}
-
-// shortDur formats a latency compactly, ms below a second and one decimal second
-// above.
-func shortDur(d time.Duration) string {
-	if d < time.Second {
-		return fmt.Sprintf("%dms", d.Round(time.Millisecond)/time.Millisecond)
-	}
-	return fmt.Sprintf("%.1fs", d.Seconds())
-}
-
-// sortMark returns the ▾/▴ arrow appended to the active column header.
-func sortMark(st sortState, col string) string {
-	if st.col != col {
-		return ""
-	}
-	if st.desc {
-		return " ▾"
-	}
-	return " ▴"
-}
-
-// onboardingSnippet is the config line shown in the empty state and copied by y.
-const onboardingSnippet = `"command": "mcpsnoop", "args": ["--", "node", "build/index.js"]`
-
-// onboardingCard is the first-run empty state, a self-bordered centered card
-// telling the user how to attach mcpsnoop. Rendered via lipgloss.Place by the
-// caller.
-func (m Model) onboardingCard() string {
-	num := m.styles.hintKey.Render
-	dim := m.styles.dim.Render
-	const cardW = 68
-
-	brand := m.styles.brand.Render("▍mcpsnoop")
-	waiting := dim("waiting for MCP traffic ") + m.styles.follow.Render(m.spinnerFrame())
-	gap := max(cardW-lipgloss.Width(brand)-lipgloss.Width(waiting), 1)
-	titleRow := brand + strings.Repeat(" ", gap) + waiting
-	rule := m.styles.faint.Render(strings.Repeat("─", cardW))
-
-	snippet := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).BorderForeground(m.theme.border).Padding(0, 1).
-		Render(m.highlightJSON(onboardingSnippet))
-	copyHint := "  " + num("y") + " " + dim("copy snippet")
-
-	step1 := num("1.") + "  " + dim("wrap your server in your client's MCP config")
-	step2 := num("2.") + "  " + dim("use your client, every tool call lands here live")
-
-	label := func(s string) string { return dim(s + strings.Repeat(" ", max(18-len(s), 1))) }
-	http := label("Streamable HTTP") + m.styles.hintKey.Render("mcpsnoop http --target <url>")
-	demo := label("Just want a look") + m.styles.hintKey.Render("mcpsnoop demo")
-
-	footer := m.styles.faint.Render("shim socket ready · " + homeAbbrev(paths.Base()))
-
-	inner := lipgloss.JoinVertical(lipgloss.Left,
-		titleRow, rule, "",
-		step1, "", snippet, copyHint, "", step2, "",
-		http, demo, "",
-		footer,
-	)
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).BorderForeground(m.theme.border).
-		Padding(1, 3).Render(inner)
-}
-
-// frameText is the copy-to-clipboard payload for a frame, pretty JSON, or the
-// raw stderr line.
-func frameText(e store.EventView) string {
-	if len(e.Raw) > 0 {
-		return prettyJSON(e.Raw)
-	}
-	return e.Text
-}
-
-func prettyJSON(raw json.RawMessage) string {
-	var buf bytes.Buffer
-	if err := json.Indent(&buf, raw, "", "  "); err != nil {
-		return string(raw)
-	}
-	return buf.String()
-}
-
-func humanAge(t time.Time) string {
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	case d < time.Hour:
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	default:
-		return fmt.Sprintf("%dh", int(d.Hours()))
-	}
-}
-
-// cellL / cellR pad (or truncate) s to width w, left/right aligned.
-func cellL(s string, w int) string {
-	s = truncate(s, w)
-	if pad := w - lipgloss.Width(s); pad > 0 {
-		return s + strings.Repeat(" ", pad)
-	}
-	return s
-}
-
-func cellR(s string, w int) string {
-	s = truncate(s, w)
-	if pad := w - lipgloss.Width(s); pad > 0 {
-		return strings.Repeat(" ", pad) + s
-	}
-	return s
-}
-
-func window(sel, n, rows int) (int, int) {
-	if rows <= 0 || n == 0 {
-		return 0, 0
-	}
-	if n <= rows {
-		return 0, n
-	}
-	start := sel - rows/2
-	if start < 0 {
-		start = 0
-	}
-	if start+rows > n {
-		start = n - rows
-	}
-	return start, start + rows
-}
-
-// truncate shortens s to at most w terminal cells, appending an ellipsis when it
-// cuts. It measures in cells throughout (the unit lipgloss.Width uses), never rune
-// counts, so a wide rune (CJK, emoji) is two cells and cannot overrun the budget.
-// With wide runes an exact fit is not always possible, so the result may be a cell
-// narrower than w; callers (cellL, cellR) pad the remainder.
-func truncate(s string, w int) string {
-	if w <= 0 {
-		return ""
-	}
-	if lipgloss.Width(s) <= w {
-		return s
-	}
-	// One cell is reserved for the ellipsis. Take runes until the next one would
-	// push the accumulated width past that budget. Advance by the rune's real byte
-	// size from the source, not len(string(r)): an invalid byte decodes to U+FFFD
-	// (three bytes re-encoded) after consuming one, so computing the offset from the
-	// re-encoded form would overshoot and misalign the cell.
-	budget := w - 1
-	width, end := 0, 0
-	for end < len(s) {
-		r, size := utf8.DecodeRuneInString(s[end:])
-		rw := lipgloss.Width(string(r))
-		if width+rw > budget {
+	start := time.Now().Add(-span)
+	step := span / time.Duration(n)
+	// Events are in arrival (ascending time) order, so walk back from the newest and
+	// stop at the first one older than the window, instead of scanning the whole
+	// session on every refresh.
+	for i := len(sess.events) - 1; i >= 0; i-- {
+		ev := sess.events[i]
+		if ev.ts.Before(start) {
 			break
 		}
-		width += rw
-		end += size
+		b := int(ev.ts.Sub(start) / step)
+		if b >= n {
+			b = n - 1
+		}
+		buckets[b]++
 	}
-	if end == 0 {
-		return "" // the budget cannot fit even one rune, so no bare ellipsis
-	}
-	return s[:end] + "…"
+	return buckets
 }
 
-// softWrap hard-wraps any line wider than width so long values (e.g. a big JSON
-// string) stay visible in the inspector instead of running off the edge. Lines
-// already within width are left untouched. ANSI-aware.
-func softWrap(s string, width int) string {
-	if width <= 1 {
-		return s
+// Calls returns all correlated calls for a session in request order.
+func (s *Store) Calls(sessionID string) []CallView {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil
 	}
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		if lipgloss.Width(line) > width {
-			lines[i] = ansi.Hardwrap(line, width, false)
+	out := make([]CallView, 0, len(sess.events))
+	for _, ev := range sess.events {
+		// A multi round-trip retry points at the call it continues, so counting it
+		// again here would report one logical operation as several and feed its
+		// duration into the statistics twice.
+		if ev.kind == EventRequest && ev.call != nil && ev.mrtrRoot == "" {
+			out = append(out, ev.call.view())
 		}
 	}
-	return strings.Join(lines, "\n")
+	return out
+}
+
+// ToolSummary returns per-tool latency and error statistics plus the five
+// slowest completed tool calls. Pending calls are counted but have no latency.
+func (s *Store) ToolSummary(sessionID string) (SessionToolSummary, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return SessionToolSummary{}, false
+	}
+
+	type aggregate struct {
+		stats     ToolStats
+		durations []time.Duration
+	}
+	byName := make(map[string]*aggregate)
+	var slowest []SlowToolCall
+	callIndex := 0
+	for _, ev := range sess.events {
+		// Skipping a continuation matters twice over: it would count one logical
+		// operation as several calls, and feed the same duration into the
+		// percentiles once per round trip.
+		if ev.kind != EventRequest || ev.call == nil || ev.mrtrRoot != "" {
+			continue
+		}
+		c := ev.call
+		index := callIndex
+		callIndex++
+		if !c.isTool {
+			continue
+		}
+		agg := byName[c.toolName]
+		if agg == nil {
+			agg = &aggregate{stats: ToolStats{Name: c.toolName}}
+			byName[c.toolName] = agg
+		}
+		agg.stats.Calls++
+		if c.state == Pending {
+			agg.stats.Pending++
+			continue
+		}
+		if c.state == Superseded {
+			// Its id was reused, so it was never answered. It still counts as a call
+			// (like a pending one), but has no real latency to feed the percentiles.
+			continue
+		}
+		if c.errored {
+			agg.stats.Errors++
+		}
+		if n := len(c.result); n > 0 {
+			agg.stats.ResultBytes += int64(n)
+			agg.stats.MaxResultBytes = max(agg.stats.MaxResultBytes, n)
+		}
+		duration := c.end.Sub(c.start)
+		agg.durations = append(agg.durations, duration)
+		slowest = append(slowest, SlowToolCall{
+			CallIndex: index, ID: c.id, ToolName: c.toolName,
+			Duration: duration, Failed: c.errored, Start: c.start,
+		})
+	}
+
+	tools := make([]ToolStats, 0, len(byName))
+	for _, agg := range byName {
+		slices.Sort(agg.durations)
+		agg.stats.P50 = nearestRank(agg.durations, 0.50)
+		agg.stats.P95 = nearestRank(agg.durations, 0.95)
+		agg.stats.P99 = nearestRank(agg.durations, 0.99)
+		tools = append(tools, agg.stats)
+	}
+	slices.SortFunc(tools, func(a, b ToolStats) int { return cmp.Compare(a.Name, b.Name) })
+	slices.SortStableFunc(slowest, func(a, b SlowToolCall) int {
+		if c := cmp.Compare(b.Duration, a.Duration); c != 0 {
+			return c
+		}
+		return a.Start.Compare(b.Start)
+	})
+	if len(slowest) > 5 {
+		slowest = slowest[:5]
+	}
+	return SessionToolSummary{Tools: tools, Slowest: slowest}, true
+}
+
+func nearestRank(sorted []time.Duration, percentile float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
+	return sorted[max(index, 0)]
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -581,7 +581,7 @@ func (m Model) streamRow(e store.EventView, lay streamLayout) []cell {
 // durStyle colors the DUR value. It only turns cyan for a live pending timer and
 // is dim otherwise, so latency reads as a plain number, not a verdict.
 func (m Model) durStyle(e store.EventView) lipgloss.Style {
-	if e.Call != nil && e.Call.State == store.Pending {
+	if e.Call != nil && (e.Call.State == store.Pending || e.Call.State == store.Streaming) {
 		return m.styles.pending
 	}
 	return m.styles.dim
@@ -646,6 +646,9 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			if e.Call.State == store.Pending {
 				c.status = "pending"
 				c.dur = m.spinnerFrame() + " " + e.Call.Duration().Round(100*time.Millisecond).String()
+			} else if e.Call.State == store.Streaming {
+				c.status = "streaming"
+				c.dur = e.Call.Duration().Round(100 * time.Millisecond).String()
 			} else if e.Call.State == store.Superseded {
 				// Its id was reused while in flight, so it will never be answered.
 				c.status = "superseded"
@@ -876,6 +879,8 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 		switch {
 		case e.Call.State == store.Pending:
 			return m.styles.pending
+		case e.Call.State == store.Streaming:
+			return m.styles.follow
 		case e.Call.State == store.Superseded:
 			return m.styles.warn // never answered, not a success
 		case e.Call.Failed():
@@ -1128,6 +1133,9 @@ func (m Model) pairWidget() string {
 		cur := m.styles.infoVal.Render(fmt.Sprintf("req %d", e.Seq))
 		if e.Call.State == store.Pending {
 			return cur + arrow + m.styles.pending.Render("pending")
+		}
+		if e.Call.State == store.Streaming {
+			return cur + arrow + m.styles.follow.Render("streaming")
 		}
 		if pi, ok := m.pairIndex(m.inspect); ok {
 			return cur + arrow + m.styles.req.Render(fmt.Sprintf("resp %d", m.full[pi].Seq))


### PR DESCRIPTION
## Summary

Recognise `subscriptions/listen` as a long-lived stream request instead of a hung pending RPC. Open listen streams no longer increment the session pending counter, render as `streaming` in the TUI, or fail `mcpsnoop check --fail-on pending` on healthy sessions.

## Motivation

The 2026-07-28 revision replaced resource subscribe streams with a single long-lived `subscriptions/listen` request whose response arrives only when the stream ends. mcpsnoop treated it like any other request, so it showed a live pending timer and permanently inflated `session.pending`.

Fixes #150.

## Changes

- Add a `Streaming` call state for stream-opening requests.
- Open `subscriptions/listen` in `Streaming` state without bumping `pending`.
- Complete streaming calls on the final response; only decrement `pending` when the call was actually pending.
- Close streaming calls when the server sends `notifications/cancelled` for the listen id.
- Show `streaming` status in the TUI and export layer instead of the pending spinner.
- Add store regression tests for pending accounting, normal completion, and cancel notification handling.

## Tests

```bash
make check
```

- `go vet`, `staticcheck`: pass
- `go test -race ./...`: pass (store tests including new subscriptions/listen cases; two pre-existing TUI test failures on `main` unrelated to this change)

## Notes

- Subscription notification correlation via `_meta["io.modelcontextprotocol/subscriptionId"]` is left for a follow-up, as described in the issue.
- OTLP/HTML export could surface `streaming` more explicitly in a later PR.