### PR TITLE
feat(http): observe and validate Mcp-Param headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,14 @@ The same signal covers a required routing header that is missing entirely. In
 request with `400` and `-32020`. mcpsnoop raises it only once the session is
 known to speak that revision or later: earlier revisions do not define these
 headers at all, so omitting them there is correct.
-A server's own `-32020` rejection counts as the same signal. The server validates
-`Mcp-Param-{Name}` values and header encodings that mcpsnoop never sees, so its
-verdict is sometimes the only evidence a mismatch happened.
+A server's own `-32020` rejection counts as the same signal. On HTTP
+`tools/call` requests, mcpsnoop also shows each `Mcp-Param-{Name}` header and,
+when the matching advertised tool definition is known, compares it with the
+annotated argument path. Nested properties, the Base64 sentinel, booleans, and
+numeric-equivalent safe integers are handled without string-comparison false
+positives. Unknown parameter headers and sessions without a matching tool
+definition remain observational only. Existing key- and value-based redaction
+also applies to captured parameter-header values before they reach a sink.
 Use `--format junit` to write one JUnit `<testcase>` per signal and session;
 failures follow the same `--fail-on` selection as the text output.
 

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1056,3 +1056,86 @@ func TestJSONExportPreservesMarkup(t *testing.T) {
 		}
 	}
 }
+
+// TestParamHeadersSurviveTheJSONLRoundTrip pins the on-disk shape of the
+// Mcp-Param capture and of the redaction flag that scopes its checks. open,
+// export and check all rebuild a session by decoding the log back into
+// proxy.Envelope, so a renamed or dropped json tag loses every captured header
+// silently: the store sees none, reports no header verdict, and a check run over
+// a bad capture comes back clean. Nothing else in the suite reads a header off
+// disk, so a rename ships green without this.
+func TestParamHeadersSurviveTheJSONLRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	tool := `{"name":"route","inputSchema":{"type":"object","properties":` +
+		`{"region":{"type":"string","x-mcp-header":"Region"}}}}`
+	meta := `"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+		`"io.modelcontextprotocol/clientCapabilities":{}}`
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: t0,
+		Transport: proxy.TransportHTTP, Direction: proxy.ClientToServer,
+		MCPMethod: "tools/list", MCPProtocolVersion: "2026-07-28",
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + meta + `}}`),
+	})
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: t0.Add(time.Millisecond),
+		Transport: proxy.TransportHTTP, Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"tools":[` + tool + `]}}`),
+	})
+	// The header disagrees with the body, so a session reloaded from disk must
+	// still carry both the captured header and the verdict drawn from it.
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 3, TS: t0.Add(2 * time.Millisecond),
+		Transport: proxy.TransportHTTP, Direction: proxy.ClientToServer,
+		MCPMethod: "tools/call", MCPName: "route", MCPProtocolVersion: "2026-07-28",
+		MCPParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "eu-west1"}},
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":` +
+			`{"name":"route","arguments":{"region":"us-west1"},` + meta + `}}`),
+	})
+	// A frame mcpsnoop scrubbed. Its placeholder must still read as a placeholder
+	// after a reload, or the redaction guard turns back into a false mismatch.
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 4, TS: t0.Add(3 * time.Millisecond),
+		Transport: proxy.TransportHTTP, Direction: proxy.ClientToServer,
+		MCPMethod: "tools/call", MCPName: "route", MCPProtocolVersion: "2026-07-28",
+		MCPParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "[REDACTED]"}},
+		Redacted:        true,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":` +
+			`{"name":"route","arguments":{"region":"us-west1"},` + meta + `}}`),
+	})
+
+	// The wire names are part of the log format, not implementation details, so
+	// they are asserted off the raw line. A struct-to-struct round trip inside one
+	// build would happily agree with itself after a rename.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if want := `"mcp_param_headers":[{"name":"Mcp-Param-Region","value":"eu-west1"}]`; !strings.Contains(lines[2], want) {
+		t.Fatalf("on-disk envelope lost its parameter headers:\n%s", lines[2])
+	}
+	if !strings.Contains(lines[3], `"redacted":true`) {
+		t.Fatalf("on-disk envelope lost its redaction flag:\n%s", lines[3])
+	}
+
+	st, sessionID, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	timeline := st.Timeline(sessionID)
+	call := timeline[len(timeline)-2]
+	if len(call.MCPParamHeaders) != 1 ||
+		call.MCPParamHeaders[0].Name != "Mcp-Param-Region" ||
+		call.MCPParamHeaders[0].Value != "eu-west1" {
+		t.Fatalf("reloaded parameter headers = %+v", call.MCPParamHeaders)
+	}
+	if !call.RoutingMismatch || !strings.Contains(call.Warning, "Mcp-Param-Region") {
+		t.Fatalf("reloaded call lost its header verdict: mismatch=%v warning=%q",
+			call.RoutingMismatch, call.Warning)
+	}
+	scrubbed := timeline[len(timeline)-1]
+	if scrubbed.RoutingMismatch || strings.Contains(scrubbed.Warning, "Mcp-Param") {
+		t.Fatalf("a reloaded scrubbed frame was reported as a mismatch: warning=%q", scrubbed.Warning)
+	}
+}

--- a/internal/proxy/frame.go
+++ b/internal/proxy/frame.go
@@ -38,8 +38,11 @@ type SessionMeta struct {
 }
 
 // MCPParamHeader is one custom tool-parameter header observed on an HTTP
-// request. Name is kept because field names are case-insensitive and clients do
-// not have to use Go's canonical spelling.
+// request. Name is net/http's canonical spelling of the field, not the client's
+// own: Go runs every field name through textproto.CanonicalMIMEHeaderKey before
+// mcpsnoop sees it, so `MCP-PARAM-REGION` and `mcp-param-region` both arrive as
+// `Mcp-Param-Region`. It is kept so the inspector has a name to show, and every
+// comparison against it lowercases first, which is what the spec requires.
 type MCPParamHeader struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
@@ -76,6 +79,11 @@ type Envelope struct {
 	// Truncated marks a frame whose observed copy was cut at the frame-size cap.
 	// The bytes still forwarded to the other side in full; only this copy is short.
 	Truncated bool `json:"truncated,omitempty"`
+	// Redacted marks a frame mcpsnoop's own redaction rewrote. The store needs it
+	// to tell its placeholder apart from a client that simply sent that string,
+	// since "[REDACTED]" is a legal header value and a legal argument, and a check
+	// that skips whenever it sees those bytes is a check a client can switch off.
+	Redacted bool `json:"redacted,omitempty"`
 
 	// Status is the HTTP status of the response this frame arrived on. Zero on
 	// stdio and on client frames, since only a response has one.

--- a/internal/proxy/frame.go
+++ b/internal/proxy/frame.go
@@ -37,6 +37,14 @@ type SessionMeta struct {
 	CWD     string   `json:"cwd,omitempty"`
 }
 
+// MCPParamHeader is one custom tool-parameter header observed on an HTTP
+// request. Name is kept because field names are case-insensitive and clients do
+// not have to use Go's canonical spelling.
+type MCPParamHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // Envelope wraps a single observed event for transport to the hub and for the
 // on-disk session log. The shim stays dumb, it never correlates or interprets,
 // it just timestamps and labels. All correlation/timing lives in the hub.
@@ -59,6 +67,9 @@ type Envelope struct {
 	// MCPProtocolVersion is the MCP-Protocol-Version request header, empty for
 	// stdio and pre-2026 HTTP servers.
 	MCPProtocolVersion string `json:"mcp_protocol_version,omitempty"`
+	// MCPParamHeaders are the Mcp-Param-* request headers generated from
+	// x-mcp-header annotations in a tool's input schema.
+	MCPParamHeaders []MCPParamHeader `json:"mcp_param_headers,omitempty"`
 	// Batch marks a frame that was one element of a JSON-RPC batch array. Routing
 	// headers address a single operation, so they cannot describe a batch.
 	Batch bool `json:"batch,omitempty"`

--- a/internal/proxy/header.go
+++ b/internal/proxy/header.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// Streamable HTTP carries the target operation in the Mcp-Name header and one
+// tool argument per Mcp-Param-{Name} header, but an HTTP field value may hold
+// only visible ASCII, space and tab (RFC 9110). A value outside that set
+// therefore travels Base64, wrapped in a sentinel:
+//
+//	Mcp-Name: =?base64?SGVsbG8sIOS4lueVjA==?=
+//
+// The markers are case-sensitive and must appear exactly as shown, and the spec
+// requires anyone comparing such a header to a body value to decode it first.
+// They live in the proxy because the encoding belongs to the transport, and
+// because both the shim (which scrubs headers) and the store (which compares
+// them) need the same answer.
+const (
+	Base64SentinelPrefix = "=?base64?"
+	Base64SentinelSuffix = "?="
+)
+
+// DecodeHeaderValue returns the value a routing header carries, undoing the
+// Base64 sentinel when one is present. ok is false only when the value claims
+// the sentinel and its payload will not decode, which makes the header
+// malformed; a plain value is returned as it stands with ok true.
+//
+// It decodes exactly once, never recursively. A plain value that happens to look
+// like the sentinel is itself encoded by the client for precisely that reason,
+// so decoding the result again would corrupt it back into something the body
+// never said.
+func DecodeHeaderValue(value string) (string, bool) {
+	inner, wrapped := strings.CutPrefix(value, Base64SentinelPrefix)
+	if !wrapped {
+		return value, true
+	}
+	inner, wrapped = strings.CutSuffix(inner, Base64SentinelSuffix)
+	if !wrapped {
+		return value, true
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(inner); err == nil {
+		return string(decoded), true
+	}
+	// Padded standard Base64 is what the spec shows and what every mainstream
+	// encoder emits, but accept the unpadded form too. The cost of being strict
+	// is a false mismatch on a client whose only sin is padding; the cost of being
+	// lenient is nil, since a genuinely corrupt value still fails to match.
+	if decoded, err := base64.RawStdEncoding.DecodeString(inner); err == nil {
+		return string(decoded), true
+	}
+	return "", false
+}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -69,13 +70,14 @@ const (
 	mcpProtocolVersionHeader = "MCP-Protocol-Version"
 )
 
-// route carries the routing headers observed on a request, both empty when the
-// frame is a response or the client did not send them. batch marks a frame
+// route carries the routing headers observed on a request, empty when the frame
+// is a response or the client did not send them. batch marks a frame
 // split out of a JSON-RPC batch array, which routing headers cannot address.
 type route struct {
 	method          string // Mcp-Method
 	name            string // Mcp-Name
 	protocolVersion string // MCP-Protocol-Version (request-scoped, not per operation)
+	params          []MCPParamHeader
 	batch           bool
 	truncated       bool   // the observed copy was cut at the frame-size cap
 	status          int    // HTTP status of the response carrying this frame
@@ -103,6 +105,7 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 			MCPMethod:          r.method,
 			MCPName:            r.name,
 			MCPProtocolVersion: r.protocolVersion,
+			MCPParamHeaders:    slices.Clone(r.params),
 			Batch:              r.batch,
 			Truncated:          r.truncated,
 			Status:             r.status,
@@ -113,6 +116,25 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 		}
 		sink.Emit(env)
 	}
+}
+
+func mcpParamHeaders(header http.Header) []MCPParamHeader {
+	var params []MCPParamHeader
+	for name, values := range header {
+		if !strings.HasPrefix(strings.ToLower(name), "mcp-param-") {
+			continue
+		}
+		for _, value := range values {
+			params = append(params, MCPParamHeader{Name: name, Value: value})
+		}
+	}
+	slices.SortStableFunc(params, func(a, b MCPParamHeader) int {
+		if n := strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name)); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return params
 }
 
 // bodyTap forwards an HTTP body verbatim while copying at most cap bytes for
@@ -274,7 +296,12 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Body != nil && r.Method == http.MethodPost {
-			rt := route{method: r.Header.Get(mcpMethodHeader), name: r.Header.Get(mcpNameHeader), protocolVersion: r.Header.Get(mcpProtocolVersionHeader)}
+			rt := route{
+				method:          r.Header.Get(mcpMethodHeader),
+				name:            r.Header.Get(mcpNameHeader),
+				protocolVersion: r.Header.Get(mcpProtocolVersionHeader),
+				params:          mcpParamHeaders(r.Header),
+			}
 			// Same streaming tap for the request body, so a large upload is forwarded
 			// without being held in memory whole.
 			r.Body = newBodyTap(r.Body, maxFrameBytes, func(observed []byte, truncated bool) {
@@ -307,7 +334,7 @@ func emitFrames(emit func(Direction, []byte, route), dir Direction, body []byte,
 				// place the transport layer went missing again.
 				er := route{batch: true, protocolVersion: rt.protocolVersion, status: rt.status, challenge: rt.challenge}
 				if i == 0 {
-					er.method, er.name = rt.method, rt.name
+					er.method, er.name, er.params = rt.method, rt.name, rt.params
 				}
 				emit(dir, m, er)
 			}

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -262,7 +262,12 @@ func TestHTTPProxyForwardsAndCapturesRoutingHeaders(t *testing.T) {
 	}
 }
 
-func TestMCPParamHeadersAreCaseInsensitiveAndSorted(t *testing.T) {
+// TestMCPParamHeadersMatchThePrefixAndSort exercises the prefix match and the
+// ordering on a synthetic map. It is not a statement about the wire: net/http
+// canonicalises every field name before mcpsnoop sees it, so a real request can
+// never produce the uncanonicalised keys below. The test one above sends real
+// bytes and correctly expects the canonical spelling back.
+func TestMCPParamHeadersMatchThePrefixAndSort(t *testing.T) {
 	header := http.Header{
 		"mCp-pArAm-Zone":   {"west"},
 		"MCP-PARAM-Region": {"us", "backup"},

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -67,7 +68,7 @@ func TestBodyTapConcurrentReadAndClose(t *testing.T) {
 // emitterTo adapts a captureSink into the emit func httpProxyHandler expects.
 func emitterTo(sink *captureSink) func(Direction, []byte, route) {
 	return func(d Direction, raw []byte, rt route) {
-		sink.Emit(Envelope{Direction: d, Raw: append([]byte(nil), raw...), MCPMethod: rt.method, MCPName: rt.name, MCPProtocolVersion: rt.protocolVersion, Batch: rt.batch, Truncated: rt.truncated, Status: rt.status, AuthChallenge: rt.challenge})
+		sink.Emit(Envelope{Direction: d, Raw: append([]byte(nil), raw...), MCPMethod: rt.method, MCPName: rt.name, MCPProtocolVersion: rt.protocolVersion, MCPParamHeaders: rt.params, Batch: rt.batch, Truncated: rt.truncated, Status: rt.status, AuthChallenge: rt.challenge})
 	}
 }
 
@@ -222,9 +223,10 @@ func TestHTTPProxySkipsObservingAStillCompressedBody(t *testing.T) {
 }
 
 func TestHTTPProxyForwardsAndCapturesRoutingHeaders(t *testing.T) {
-	var gotMethod, gotName string
+	var gotMethod, gotName, gotRegion string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotName = r.Header.Get("Mcp-Method"), r.Header.Get("Mcp-Name")
+		gotRegion = r.Header.Get("Mcp-Param-Region")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
 	}))
@@ -239,6 +241,7 @@ func TestHTTPProxyForwardsAndCapturesRoutingHeaders(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Mcp-Method", "tools/call")
 	req.Header.Set("Mcp-Name", "echo")
+	req.Header["mCp-pArAm-Region"] = []string{"us-west1"}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -246,13 +249,32 @@ func TestHTTPProxyForwardsAndCapturesRoutingHeaders(t *testing.T) {
 	_ = resp.Body.Close()
 
 	// Forwarded verbatim to the target.
-	if gotMethod != "tools/call" || gotName != "echo" {
-		t.Fatalf("target received Mcp-Method=%q Mcp-Name=%q, want tools/call / echo", gotMethod, gotName)
+	if gotMethod != "tools/call" || gotName != "echo" || gotRegion != "us-west1" {
+		t.Fatalf("target received Mcp-Method=%q Mcp-Name=%q Mcp-Param-Region=%q", gotMethod, gotName, gotRegion)
 	}
 	// Captured onto the observed client->server frame.
 	c2s := sink.byDir(ClientToServer)
 	if len(c2s) != 1 || c2s[0].MCPMethod != "tools/call" || c2s[0].MCPName != "echo" {
 		t.Fatalf("captured frame headers = %+v", c2s)
+	}
+	if got := c2s[0].MCPParamHeaders; !reflect.DeepEqual(got, []MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}}) {
+		t.Fatalf("captured parameter headers = %+v", got)
+	}
+}
+
+func TestMCPParamHeadersAreCaseInsensitiveAndSorted(t *testing.T) {
+	header := http.Header{
+		"mCp-pArAm-Zone":   {"west"},
+		"MCP-PARAM-Region": {"us", "backup"},
+		"X-Other":          {"ignored"},
+	}
+	want := []MCPParamHeader{
+		{Name: "MCP-PARAM-Region", Value: "us"},
+		{Name: "MCP-PARAM-Region", Value: "backup"},
+		{Name: "mCp-pArAm-Zone", Value: "west"},
+	}
+	if got := mcpParamHeaders(header); !reflect.DeepEqual(got, want) {
+		t.Fatalf("mcpParamHeaders() = %+v, want %+v", got, want)
 	}
 }
 
@@ -334,6 +356,7 @@ func TestHTTPProxyBatchHeadersRideFirstElementOnly(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Mcp-Method", "tools/list")
 	req.Header.Set("Mcp-Name", "search")
+	req.Header.Set("Mcp-Param-Region", "us-west1")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -354,6 +377,12 @@ func TestHTTPProxyBatchHeadersRideFirstElementOnly(t *testing.T) {
 	}
 	if c2s[1].MCPMethod != "" || c2s[1].MCPName != "" {
 		t.Fatalf("later elements must not carry the headers, got %+v", c2s[1])
+	}
+	if len(c2s[0].MCPParamHeaders) != 1 || c2s[0].MCPParamHeaders[0].Value != "us-west1" {
+		t.Fatalf("first element should carry parameter headers, got %+v", c2s[0])
+	}
+	if len(c2s[1].MCPParamHeaders) != 0 {
+		t.Fatalf("later elements must not carry parameter headers, got %+v", c2s[1])
 	}
 }
 

--- a/internal/proxy/redact.go
+++ b/internal/proxy/redact.go
@@ -3,8 +3,10 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
+	"math/big"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/ohler55/ojg/jp"
@@ -135,75 +137,124 @@ func (r Redactor) RedactEnvelope(env Envelope) Envelope {
 	if !r.enabled() {
 		return env
 	}
-	// Values a JSONPath rule removed from the body, so the same value can be
-	// removed from a header that mirrors it.
-	var pathReplaced map[string]struct{}
-	if len(r.paths) > 0 && len(env.MCPParamHeaders) > 0 {
-		pathReplaced = make(map[string]struct{}, len(r.paths))
+	// The two halves of the link between a scrubbed body value and the header
+	// that mirrors it. A rule addresses the body and has no expression for a
+	// header, so matching the value is the only link there is; see mirrorsScrubbed
+	// for why the surviving half is needed to keep that link honest. Both are
+	// collected for every rule, not only for paths, because a key rule reaches a
+	// mirrored header no more directly than a path does.
+	var scrubbed, survived map[string]struct{}
+	if len(env.MCPParamHeaders) > 0 {
+		scrubbed = make(map[string]struct{})
+		survived = make(map[string]struct{})
 	}
+	changed := false
 	if len(env.Raw) > 0 {
-		if redacted, ok := r.redactRaw(env.Raw, pathReplaced); ok {
+		if redacted, ok := r.redactRaw(env.Raw, scrubbed, survived); ok {
 			env.Raw = redacted
+			changed = true
 		}
 	}
 	if env.Text != "" && len(r.valuePatterns) > 0 {
-		env.Text = r.redactString(env.Text)
+		if redacted := r.redactString(env.Text); redacted != env.Text {
+			env.Text = redacted
+			changed = true
+		}
 	}
 	// Gated on redaction being on at all, not on keys or values specifically. A
 	// path rule scrubs the body and used to leave the header untouched, which
 	// leaked the secret and made the store report the pair as disagreeing.
 	if len(env.MCPParamHeaders) > 0 {
-		env.MCPParamHeaders = r.redactMCPParamHeaders(env.MCPParamHeaders, pathReplaced)
+		headers, headersChanged := r.redactMCPParamHeaders(env.MCPParamHeaders, scrubbed, survived)
+		env.MCPParamHeaders = headers
+		changed = changed || headersChanged
 	}
+	// Recorded on the frame so the store can tell mcpsnoop's own placeholder from
+	// a client that sent those bytes itself.
+	env.Redacted = env.Redacted || changed
 	return env
 }
 
-// redactMCPParamHeaders scrubs a header three ways. By the annotation name, for
-// a key rule; by the value a path rule already removed from the body, which is
-// the only way a JSONPath can reach a header at all; and by the value patterns.
+// redactMCPParamHeaders scrubs a header three ways. By the value a body rule
+// already removed, which is the only way a rule addressing the body can reach a
+// header at all; by the annotation name, for a key rule; and by the value
+// patterns.
 //
 // The name a key rule matches here is the x-mcp-header annotation, while the
 // body side matches the JSON property name, and the two are independent by
 // design. The spec's own example pairs property "region" with header "Region",
 // so a rule naming one does not name the other. Both spellings are tried for
-// that reason, and the path-replaced set covers the pairs neither spelling hits.
-func (r Redactor) redactMCPParamHeaders(headers []MCPParamHeader, pathReplaced map[string]struct{}) []MCPParamHeader {
-	redacted := slices.Clone(headers)
-	for i := range redacted {
-		if _, mirrored := pathReplaced[redacted[i].Value]; mirrored {
-			redacted[i].Value = redactedValue
+// that reason, and the scrubbed-value set covers the pairs neither spelling hits.
+func (r Redactor) redactMCPParamHeaders(headers []MCPParamHeader, scrubbed, survived map[string]struct{}) ([]MCPParamHeader, bool) {
+	out := slices.Clone(headers)
+	changed := false
+	for i := range out {
+		if mirrorsScrubbed(out[i].Value, scrubbed, survived) {
+			out[i].Value = redactedValue
+			changed = true
 			continue
 		}
-		name := strings.ToLower(redacted[i].Name)
+		name := strings.ToLower(out[i].Name)
 		name, ok := strings.CutPrefix(name, "mcp-param-")
 		_, exactKey := r.keys[name]
 		_, normalizedKey := r.keys[strings.ReplaceAll(name, "-", "_")]
 		if ok && (exactKey || normalizedKey) {
-			redacted[i].Value = redactedValue
+			out[i].Value = redactedValue
+			changed = true
 			continue
 		}
-		redacted[i].Value = r.redactString(redacted[i].Value)
+		if scrubbedValue := r.redactString(out[i].Value); scrubbedValue != out[i].Value {
+			out[i].Value = scrubbedValue
+			changed = true
+		}
 	}
-	return redacted
+	return out, changed
 }
 
-// redactRaw rewrites a frame's payload. replaced, when non-nil, records the
-// scalar values a JSONPath rule removed, so the caller can scrub the same value
-// out of an Mcp-Param header that mirrors it. A JSONPath addresses the body and
-// has no expression for a header, so that list is the only link between them.
-func (r Redactor) redactRaw(raw json.RawMessage, replaced map[string]struct{}) (json.RawMessage, bool) {
+// mirrorsScrubbed reports whether a header carries a value a body rule removed
+// and nothing else in the redacted body still spells.
+//
+// The second half is what keeps the link honest. Two arguments routinely share a
+// spelling, which is the normal case for booleans and small integers, and
+// scrubbing every header that matches would wipe headers bound to properties no
+// rule named, hiding a real disagreement on those. When the spelling is still in
+// the stored body in clear, removing it from the header protects nothing and
+// only costs a check, so the two cases are exactly the ones to separate.
+//
+// The header is decoded first, because a value outside visible ASCII may only
+// travel wrapped in the Base64 sentinel while the body holds it plain.
+func mirrorsScrubbed(value string, scrubbed, survived map[string]struct{}) bool {
+	decoded, ok := DecodeHeaderValue(value)
+	if !ok {
+		return false
+	}
+	if _, removed := scrubbed[decoded]; !removed {
+		return false
+	}
+	_, kept := survived[decoded]
+	return !kept
+}
+
+// redactRaw rewrites a frame's payload. scrubbed, when non-nil, records the
+// scalar values the rules removed and survived records which of those spellings
+// are still somewhere in the rewritten body, so the caller can decide whether
+// scrubbing a header that mirrors one of them buys anything.
+func (r Redactor) redactRaw(raw json.RawMessage, scrubbed, survived map[string]struct{}) (json.RawMessage, bool) {
 	var v any
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
 	if err := dec.Decode(&v); err != nil {
 		return nil, false
 	}
-	changed := r.redactPaths(&v, replaced)
-	if r.redactValue(v) {
+	changed := r.redactPaths(&v, scrubbed)
+	if r.redactValue(v, scrubbed) {
 		changed = true
 	}
 	if !changed {
 		return nil, false
+	}
+	if len(scrubbed) > 0 {
+		collectSurviving(v, scrubbed, survived)
 	}
 	// Not json.Marshal: it would escape <, > and & and hand back a payload the
 	// server never sent. The sink no longer re-escapes either, so this survives
@@ -215,22 +266,23 @@ func (r Redactor) redactRaw(raw json.RawMessage, replaced map[string]struct{}) (
 	return b, true
 }
 
-// redactPaths rewrites every JSONPath match to the placeholder. replaced collects
+// redactPaths rewrites every JSONPath match to the placeholder. scrubbed collects
 // the original scalar spellings it removed, because an Mcp-Param header mirrors
 // an argument value and a JSONPath has no expression for a header. Without that
 // list the body is scrubbed while its mirror in the header keeps the secret, and
 // the store then reports the pair as disagreeing on traffic that was correct.
-func (r Redactor) redactPaths(value *any, replaced map[string]struct{}) bool {
+func (r Redactor) redactPaths(value *any, scrubbed map[string]struct{}) bool {
 	changed := false
 	for _, path := range r.paths {
 		matched := false
+		// Held aside until the rewrite is adopted below. Modify can still fail after
+		// the callback ran, and recording straight into scrubbed would then claim a
+		// value was removed from a body that still holds it, which scrubs the header
+		// mirroring it for nothing.
+		removed := make(map[string]struct{}, 1)
 		modified, err := path.expr.Modify(*value, func(old any) (any, bool) {
 			matched = true
-			if replaced != nil {
-				if s, ok := scalarSpelling(old); ok {
-					replaced[s] = struct{}{}
-				}
-			}
+			recordSpellings(old, removed)
 			return redactedValue, true
 		})
 		// Only adopt the rewritten tree when the path actually hit something, so a
@@ -239,36 +291,77 @@ func (r Redactor) redactPaths(value *any, replaced map[string]struct{}) bool {
 		if err != nil || !matched {
 			continue
 		}
+		for spelling := range removed {
+			if scrubbed != nil {
+				scrubbed[spelling] = struct{}{}
+			}
+		}
 		*value = modified
 		changed = true
 	}
 	return changed
 }
 
-// scalarSpelling is how a JSON scalar would appear as a header value, or false
-// when the value is not a scalar. json.Number keeps the spelling the wire used,
-// which is what the header carries.
-func scalarSpelling(v any) (string, bool) {
+// recordSpellings adds every way a JSON scalar could appear as a header value to
+// set, and does nothing for a non-scalar or a nil set.
+//
+// A number contributes two spellings when they differ, the one the wire used and
+// its plain integer form. The spec has servers compare an x-mcp-header integer
+// numerically, so a body of 4.2e1 and a header of 42 are the same value, and
+// matching only the wire spelling would leave that header holding a number the
+// body no longer shows.
+func recordSpellings(v any, set map[string]struct{}) {
+	if set == nil {
+		return
+	}
 	switch t := v.(type) {
 	case string:
-		return t, true
-	case json.Number:
-		return t.String(), true
+		set[t] = struct{}{}
 	case bool:
-		if t {
-			return "true", true
+		set[strconv.FormatBool(t)] = struct{}{}
+	case json.Number:
+		set[t.String()] = struct{}{}
+		if exact, ok := new(big.Rat).SetString(t.String()); ok && exact.IsInt() {
+			set[exact.Num().String()] = struct{}{}
 		}
-		return "false", true
 	}
-	return "", false
 }
 
-func (r Redactor) redactValue(v any) bool {
+// collectSurviving records which of the scrubbed spellings the rewritten body
+// still contains. Only those are of interest, so a large payload cannot grow the
+// set beyond what was removed.
+func collectSurviving(v any, scrubbed, survived map[string]struct{}) {
+	switch x := v.(type) {
+	case map[string]any:
+		for _, child := range x {
+			collectSurviving(child, scrubbed, survived)
+		}
+	case []any:
+		for _, child := range x {
+			collectSurviving(child, scrubbed, survived)
+		}
+	default:
+		spellings := make(map[string]struct{}, 2)
+		recordSpellings(v, spellings)
+		for spelling := range spellings {
+			if _, removed := scrubbed[spelling]; removed {
+				survived[spelling] = struct{}{}
+			}
+		}
+	}
+}
+
+func (r Redactor) redactValue(v any, scrubbed map[string]struct{}) bool {
 	switch x := v.(type) {
 	case map[string]any:
 		changed := false
 		for key, child := range x {
 			if _, ok := r.keys[strings.ToLower(key)]; ok {
+				// Recorded for the same reason a path match is. A key rule reaches a
+				// mirrored Mcp-Param header no more directly than a path does, and
+				// leaving it unrecorded left --redact-key and --redact-secrets scrubbing
+				// the body while the header kept the secret.
+				recordSpellings(child, scrubbed)
 				x[key] = redactedValue
 				changed = true
 				continue
@@ -281,7 +374,7 @@ func (r Redactor) redactValue(v any) bool {
 				}
 				continue
 			}
-			if r.redactValue(child) {
+			if r.redactValue(child, scrubbed) {
 				changed = true
 			}
 		}
@@ -291,7 +384,7 @@ func (r Redactor) redactValue(v any) bool {
 		for i := 0; i < len(x); i++ {
 			s, ok := x[i].(string)
 			if !ok {
-				if r.redactValue(x[i]) {
+				if r.redactValue(x[i], scrubbed) {
 					changed = true
 				}
 				continue

--- a/internal/proxy/redact.go
+++ b/internal/proxy/redact.go
@@ -135,23 +135,45 @@ func (r Redactor) RedactEnvelope(env Envelope) Envelope {
 	if !r.enabled() {
 		return env
 	}
+	// Values a JSONPath rule removed from the body, so the same value can be
+	// removed from a header that mirrors it.
+	var pathReplaced map[string]struct{}
+	if len(r.paths) > 0 && len(env.MCPParamHeaders) > 0 {
+		pathReplaced = make(map[string]struct{}, len(r.paths))
+	}
 	if len(env.Raw) > 0 {
-		if redacted, ok := r.redactRaw(env.Raw); ok {
+		if redacted, ok := r.redactRaw(env.Raw, pathReplaced); ok {
 			env.Raw = redacted
 		}
 	}
 	if env.Text != "" && len(r.valuePatterns) > 0 {
 		env.Text = r.redactString(env.Text)
 	}
-	if len(env.MCPParamHeaders) > 0 && (len(r.keys) > 0 || len(r.valuePatterns) > 0) {
-		env.MCPParamHeaders = r.redactMCPParamHeaders(env.MCPParamHeaders)
+	// Gated on redaction being on at all, not on keys or values specifically. A
+	// path rule scrubs the body and used to leave the header untouched, which
+	// leaked the secret and made the store report the pair as disagreeing.
+	if len(env.MCPParamHeaders) > 0 {
+		env.MCPParamHeaders = r.redactMCPParamHeaders(env.MCPParamHeaders, pathReplaced)
 	}
 	return env
 }
 
-func (r Redactor) redactMCPParamHeaders(headers []MCPParamHeader) []MCPParamHeader {
+// redactMCPParamHeaders scrubs a header three ways. By the annotation name, for
+// a key rule; by the value a path rule already removed from the body, which is
+// the only way a JSONPath can reach a header at all; and by the value patterns.
+//
+// The name a key rule matches here is the x-mcp-header annotation, while the
+// body side matches the JSON property name, and the two are independent by
+// design. The spec's own example pairs property "region" with header "Region",
+// so a rule naming one does not name the other. Both spellings are tried for
+// that reason, and the path-replaced set covers the pairs neither spelling hits.
+func (r Redactor) redactMCPParamHeaders(headers []MCPParamHeader, pathReplaced map[string]struct{}) []MCPParamHeader {
 	redacted := slices.Clone(headers)
 	for i := range redacted {
+		if _, mirrored := pathReplaced[redacted[i].Value]; mirrored {
+			redacted[i].Value = redactedValue
+			continue
+		}
 		name := strings.ToLower(redacted[i].Name)
 		name, ok := strings.CutPrefix(name, "mcp-param-")
 		_, exactKey := r.keys[name]
@@ -165,14 +187,18 @@ func (r Redactor) redactMCPParamHeaders(headers []MCPParamHeader) []MCPParamHead
 	return redacted
 }
 
-func (r Redactor) redactRaw(raw json.RawMessage) (json.RawMessage, bool) {
+// redactRaw rewrites a frame's payload. replaced, when non-nil, records the
+// scalar values a JSONPath rule removed, so the caller can scrub the same value
+// out of an Mcp-Param header that mirrors it. A JSONPath addresses the body and
+// has no expression for a header, so that list is the only link between them.
+func (r Redactor) redactRaw(raw json.RawMessage, replaced map[string]struct{}) (json.RawMessage, bool) {
 	var v any
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
 	if err := dec.Decode(&v); err != nil {
 		return nil, false
 	}
-	changed := r.redactPaths(&v)
+	changed := r.redactPaths(&v, replaced)
 	if r.redactValue(v) {
 		changed = true
 	}
@@ -189,12 +215,22 @@ func (r Redactor) redactRaw(raw json.RawMessage) (json.RawMessage, bool) {
 	return b, true
 }
 
-func (r Redactor) redactPaths(value *any) bool {
+// redactPaths rewrites every JSONPath match to the placeholder. replaced collects
+// the original scalar spellings it removed, because an Mcp-Param header mirrors
+// an argument value and a JSONPath has no expression for a header. Without that
+// list the body is scrubbed while its mirror in the header keeps the secret, and
+// the store then reports the pair as disagreeing on traffic that was correct.
+func (r Redactor) redactPaths(value *any, replaced map[string]struct{}) bool {
 	changed := false
 	for _, path := range r.paths {
 		matched := false
-		modified, err := path.expr.Modify(*value, func(any) (any, bool) {
+		modified, err := path.expr.Modify(*value, func(old any) (any, bool) {
 			matched = true
+			if replaced != nil {
+				if s, ok := scalarSpelling(old); ok {
+					replaced[s] = struct{}{}
+				}
+			}
 			return redactedValue, true
 		})
 		// Only adopt the rewritten tree when the path actually hit something, so a
@@ -207,6 +243,24 @@ func (r Redactor) redactPaths(value *any) bool {
 		changed = true
 	}
 	return changed
+}
+
+// scalarSpelling is how a JSON scalar would appear as a header value, or false
+// when the value is not a scalar. json.Number keeps the spelling the wire used,
+// which is what the header carries.
+func scalarSpelling(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case json.Number:
+		return t.String(), true
+	case bool:
+		if t {
+			return "true", true
+		}
+		return "false", true
+	}
+	return "", false
 }
 
 func (r Redactor) redactValue(v any) bool {

--- a/internal/proxy/redact.go
+++ b/internal/proxy/redact.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/ohler55/ojg/jp"
@@ -142,7 +143,26 @@ func (r Redactor) RedactEnvelope(env Envelope) Envelope {
 	if env.Text != "" && len(r.valuePatterns) > 0 {
 		env.Text = r.redactString(env.Text)
 	}
+	if len(env.MCPParamHeaders) > 0 && (len(r.keys) > 0 || len(r.valuePatterns) > 0) {
+		env.MCPParamHeaders = r.redactMCPParamHeaders(env.MCPParamHeaders)
+	}
 	return env
+}
+
+func (r Redactor) redactMCPParamHeaders(headers []MCPParamHeader) []MCPParamHeader {
+	redacted := slices.Clone(headers)
+	for i := range redacted {
+		name := strings.ToLower(redacted[i].Name)
+		name, ok := strings.CutPrefix(name, "mcp-param-")
+		_, exactKey := r.keys[name]
+		_, normalizedKey := r.keys[strings.ReplaceAll(name, "-", "_")]
+		if ok && (exactKey || normalizedKey) {
+			redacted[i].Value = redactedValue
+			continue
+		}
+		redacted[i].Value = r.redactString(redacted[i].Value)
+	}
+	return redacted
 }
 
 func (r Redactor) redactRaw(raw json.RawMessage) (json.RawMessage, bool) {

--- a/internal/proxy/redact_test.go
+++ b/internal/proxy/redact_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -430,4 +431,149 @@ func TestRedactPathAlsoScrubsTheMirroredParamHeader(t *testing.T) {
 			t.Fatalf("an unrelated header must survive, got %q", h.Value)
 		}
 	}
+	if !got[0].Redacted {
+		t.Fatal("a rewritten frame must be marked redacted, or the store cannot tell " +
+			"mcpsnoop's placeholder from a client that sent those bytes")
+	}
+}
+
+// TestRedactKeyAndSecretsAlsoScrubTheMirroredParamHeader. The link was recorded
+// for path rules only, so --redact-key and --redact-secrets scrubbed the body and
+// left the header holding the secret, which is the same leak in the two flags
+// most people actually reach for.
+func TestRedactKeyAndSecretsAlsoScrubTheMirroredParamHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cfg    RedactConfig
+		args   string
+		header string
+	}{
+		{"key rule", RedactConfig{Keys: []string{"authKey"}}, `{"authKey":"sk-live-abcdef"}`, "Mcp-Param-Auth"},
+		{"secrets preset", RedactConfig{CommonSecrets: true}, `{"api_key":"sk-live-abcdef"}`, "Mcp-Param-Key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &captureSink{}
+			NewRedactingSink(sink, tc.cfg).Emit(Envelope{
+				Direction: ClientToServer,
+				Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":` +
+					`{"name":"fetch","arguments":` + tc.args + `}}`),
+				MCPParamHeaders: []MCPParamHeader{{Name: tc.header, Value: "sk-live-abcdef"}},
+			})
+			got := sink.byDir(ClientToServer)
+			if len(got) != 1 {
+				t.Fatalf("want one envelope, got %d", len(got))
+			}
+			if strings.Contains(string(got[0].Raw), "sk-live-abcdef") {
+				t.Fatalf("the body should be scrubbed: %s", got[0].Raw)
+			}
+			if v := got[0].MCPParamHeaders[0].Value; strings.Contains(v, "sk-live-abcdef") {
+				t.Fatalf("header %s still carries the secret the rule removed: %q", tc.header, v)
+			}
+		})
+	}
+}
+
+// TestRedactScrubsTheEncodedMirror. A header value outside visible ASCII may only
+// travel wrapped in the Base64 sentinel, while the body holds it plain, so a link
+// that compares the two spellings verbatim never fires and the log keeps a header
+// that decodes straight back to the secret.
+func TestRedactScrubsTheEncodedMirror(t *testing.T) {
+	const secret = "sk-live-абв"
+	path, err := ParseRedactPath("$.params.arguments.authKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &captureSink{}
+	NewRedactingSink(sink, RedactConfig{Paths: []RedactPath{path}}).Emit(Envelope{
+		Direction: ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":` +
+			`{"name":"fetch","arguments":{"authKey":` + quoteJSONString(secret) + `}}}`),
+		MCPParamHeaders: []MCPParamHeader{
+			{Name: "Mcp-Param-Auth", Value: Base64SentinelPrefix +
+				base64.StdEncoding.EncodeToString([]byte(secret)) + Base64SentinelSuffix},
+		},
+	})
+
+	got := sink.byDir(ClientToServer)
+	value := got[0].MCPParamHeaders[0].Value
+	decoded, ok := DecodeHeaderValue(value)
+	if !ok {
+		t.Fatalf("header value stopped decoding: %q", value)
+	}
+	if strings.Contains(decoded, secret) {
+		t.Fatalf("the encoded header still decodes back to the secret: %q", value)
+	}
+}
+
+// TestRedactLeavesHeadersWhoseValueSurvivesElsewhere. Matching by value alone
+// wiped every header sharing a spelling with a scrubbed argument, which is the
+// normal case for booleans and small integers, and the store then skipped those
+// bindings, so a genuine disagreement on them went unreported. When the spelling
+// is still in the stored body in clear, removing it from the header protects
+// nothing and only costs a check.
+func TestRedactLeavesHeadersWhoseValueSurvivesElsewhere(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, args string
+		headers          []MCPParamHeader
+		wantKept         string
+	}{
+		{
+			name: "boolean", path: "$.params.arguments.debug",
+			args:     `{"debug":true,"cacheEnabled":true}`,
+			headers:  []MCPParamHeader{{Name: "Mcp-Param-Debug", Value: "true"}, {Name: "Mcp-Param-Cache", Value: "true"}},
+			wantKept: "true",
+		},
+		{
+			name: "small integer", path: "$.params.arguments.shard",
+			args:     `{"shard":7,"retries":7}`,
+			headers:  []MCPParamHeader{{Name: "Mcp-Param-Shard", Value: "7"}, {Name: "Mcp-Param-Retries", Value: "7"}},
+			wantKept: "7",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path, err := ParseRedactPath(tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sink := &captureSink{}
+			NewRedactingSink(sink, RedactConfig{Paths: []RedactPath{path}}).Emit(Envelope{
+				Direction: ClientToServer,
+				Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":` +
+					`{"name":"fetch","arguments":` + tc.args + `}}`),
+				MCPParamHeaders: tc.headers,
+			})
+			for _, h := range sink.byDir(ClientToServer)[0].MCPParamHeaders {
+				if h.Value != tc.wantKept {
+					t.Fatalf("header %s = %q, want %q: the same spelling is still in the body "+
+						"in clear, so scrubbing the header buys nothing and costs a check",
+						h.Name, h.Value, tc.wantKept)
+				}
+			}
+		})
+	}
+}
+
+// TestRedactScrubsANumericMirrorSpelledDifferently. The spec has these compared
+// numerically, so a body of 4.2e1 and a header of 42 are one value, and matching
+// wire spellings alone left the header showing a number the body no longer does.
+func TestRedactScrubsANumericMirrorSpelledDifferently(t *testing.T) {
+	path, err := ParseRedactPath("$.params.arguments.account")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &captureSink{}
+	NewRedactingSink(sink, RedactConfig{Paths: []RedactPath{path}}).Emit(Envelope{
+		Direction: ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":` +
+			`{"name":"fetch","arguments":{"account":4.2e1}}}`),
+		MCPParamHeaders: []MCPParamHeader{{Name: "Mcp-Param-Account", Value: "42"}},
+	})
+	if v := sink.byDir(ClientToServer)[0].MCPParamHeaders[0].Value; v != redactedValue {
+		t.Fatalf("header = %q, want it scrubbed alongside the body it mirrors", v)
+	}
+}
+
+func quoteJSONString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
 }

--- a/internal/proxy/redact_test.go
+++ b/internal/proxy/redact_test.go
@@ -391,3 +391,43 @@ func TestRedactRawPreservesMarkupInUntouchedFields(t *testing.T) {
 		t.Fatalf("the secret should still be redacted: %s", got)
 	}
 }
+
+// TestRedactPathAlsoScrubsTheMirroredParamHeader is the blocker this closes. A
+// JSONPath addresses the body and has no expression for a header, so path
+// redaction used to scrub the argument and leave its mirror in the Mcp-Param
+// header verbatim. That leaked the secret into the log and made the store report
+// the pair as disagreeing, which fails a default check run on correct traffic.
+func TestRedactPathAlsoScrubsTheMirroredParamHeader(t *testing.T) {
+	path, err := ParseRedactPath("$.params.arguments.authKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &captureSink{}
+	NewRedactingSink(sink, RedactConfig{Paths: []RedactPath{path}}).Emit(Envelope{
+		Direction: ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":` +
+			`{"name":"fetch","arguments":{"region":"us-west1","authKey":"sk-live-abcdef"}}}`),
+		MCPParamHeaders: []MCPParamHeader{
+			{Name: "Mcp-Param-Region", Value: "us-west1"},
+			{Name: "Mcp-Param-Auth", Value: "sk-live-abcdef"},
+		},
+	})
+
+	got := sink.byDir(ClientToServer)
+	if len(got) != 1 {
+		t.Fatalf("want one envelope, got %d", len(got))
+	}
+	if strings.Contains(string(got[0].Raw), "sk-live-abcdef") {
+		t.Fatalf("the body should be scrubbed: %s", got[0].Raw)
+	}
+	for _, h := range got[0].MCPParamHeaders {
+		if strings.Contains(h.Value, "sk-live-abcdef") {
+			t.Fatalf("header %s still carries the secret the path rule removed: %q", h.Name, h.Value)
+		}
+		// A header the rule never named keeps its value, or redaction has turned
+		// into a blanket wipe and the comparison it feeds becomes useless.
+		if h.Name == "Mcp-Param-Region" && h.Value != "us-west1" {
+			t.Fatalf("an unrelated header must survive, got %q", h.Value)
+		}
+	}
+}

--- a/internal/proxy/redact_test.go
+++ b/internal/proxy/redact_test.go
@@ -161,6 +161,35 @@ func TestRedactingSinkScrubsValuePatternMatches(t *testing.T) {
 	}
 }
 
+func TestRedactingSinkScrubsMCPParamHeaders(t *testing.T) {
+	sink := &captureSink{}
+	redacted := NewRedactingSink(sink, RedactConfig{
+		CommonSecrets: true,
+		ValuePatterns: []string{`sk-[A-Za-z0-9]+`},
+	})
+	headers := []MCPParamHeader{
+		{Name: "Mcp-Param-Token", Value: "=?base64?c2VjcmV0?="},
+		{Name: "Mcp-Param-Region", Value: "route sk-abc123 here"},
+		{Name: "Mcp-Param-Safe", Value: "visible"},
+	}
+
+	redacted.Emit(Envelope{MCPParamHeaders: headers})
+
+	got := sink.byDir("")[0].MCPParamHeaders
+	if got[0].Value != redactedValue {
+		t.Fatalf("token header = %q, want redacted", got[0].Value)
+	}
+	if got[1].Value != "route [REDACTED] here" {
+		t.Fatalf("pattern header = %q, want value-pattern redaction", got[1].Value)
+	}
+	if got[2].Value != "visible" {
+		t.Fatalf("safe header = %q, want unchanged", got[2].Value)
+	}
+	if headers[0].Value == redactedValue || strings.Contains(headers[1].Value, redactedValue) {
+		t.Fatal("redaction mutated the caller's envelope slice")
+	}
+}
+
 func TestRedactingSinkScrubsOnlyMatchingJSONPath(t *testing.T) {
 	path, err := ParseRedactPath("$.params.arguments.password")
 	if err != nil {

--- a/internal/store/header.go
+++ b/internal/store/header.go
@@ -1,56 +1,31 @@
 package store
 
 import (
-	"encoding/base64"
-	"strings"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
 )
 
-// Streamable HTTP carries the target operation in the Mcp-Name header, but an
-// HTTP field value may hold only visible ASCII, space and tab (RFC 9110). A
-// name or resource URI outside that set therefore travels Base64, wrapped in a
-// sentinel:
-//
-//	Mcp-Name: =?base64?SGVsbG8sIOS4lueVjA==?=
-//
-// The markers are case-sensitive and must appear exactly as shown, and the spec
-// requires anyone comparing such a header to a body value to decode it first.
+// The Base64 sentinel a routing header value may be wrapped in. Defined by the
+// transport, so the one implementation lives in the proxy and both the shim's
+// redaction and the checks here share it. Aliased rather than re-spelled,
+// because a second copy of the markers is a second thing to drift.
 const (
-	base64SentinelPrefix = "=?base64?"
-	base64SentinelSuffix = "?="
+	base64SentinelPrefix = proxy.Base64SentinelPrefix
+	base64SentinelSuffix = proxy.Base64SentinelSuffix
 )
 
-// decodeHeaderValue returns the value a routing header carries, undoing the
-// Base64 sentinel when one is present. Mcp-Param-{Name} uses the same encoding,
-// so this is the shared entry point for that check when it lands.
-//
-// It decodes exactly once, never recursively. A plain value that happens to look
-// like the sentinel is itself encoded by the client for precisely that reason,
-// so decoding the result again would corrupt it back into something the body
-// never said.
-//
-// A value carrying the sentinel that will not decode is returned untouched. The
-// header is then malformed, which is its own violation, but inventing a second
+// decodeHeaderValue is the Mcp-Name reading of a routing header. A value
+// carrying the sentinel that will not decode is returned untouched. The header
+// is then malformed, which is its own violation, but inventing a second
 // diagnosis here would mean two signals for one frame; falling back to the
 // literal leaves the caller reporting the disagreement it already reports.
+//
+// Mcp-Param-{Name} wants the other half of that answer, since it has no
+// name-versus-body comparison to fall back on, so it calls
+// proxy.DecodeHeaderValue directly and reports the malformed value itself.
 func decodeHeaderValue(value string) string {
-	inner, ok := strings.CutPrefix(value, base64SentinelPrefix)
+	decoded, ok := proxy.DecodeHeaderValue(value)
 	if !ok {
 		return value
 	}
-	inner, ok = strings.CutSuffix(inner, base64SentinelSuffix)
-	if !ok {
-		return value
-	}
-	if decoded, err := base64.StdEncoding.DecodeString(inner); err == nil {
-		return string(decoded)
-	}
-	// Padded standard Base64 is what the spec shows and what every mainstream
-	// encoder emits, but accept the unpadded form too. The cost of being strict
-	// is reintroducing the exact bug this fixes, a false mismatch on a client
-	// whose only sin is padding; the cost of being lenient is nil, since a
-	// genuinely corrupt value still fails to match the body.
-	if decoded, err := base64.RawStdEncoding.DecodeString(inner); err == nil {
-		return string(decoded)
-	}
-	return value
+	return decoded
 }

--- a/internal/store/paramheader.go
+++ b/internal/store/paramheader.go
@@ -1,9 +1,7 @@
 package store
 
 import (
-	"encoding/base64"
 	"encoding/json"
-	"math"
 	"math/big"
 	"slices"
 	"strconv"
@@ -20,6 +18,11 @@ const (
 	// proxy's redaction internals, and a literal that drifts is caught by
 	// TestParamHeaderRedactionMarkerMatchesTheProxy.
 	redactedMarker = "[REDACTED]"
+	// outsideSafeRange names the rule an integer breaks by its magnitude alone.
+	// The spec states the range as its own constraint on an x-mcp-header integer,
+	// separate from being an integer at all, and reporting 2^53 as "not a valid
+	// integer" sends the reader after a type error that is not there.
+	outsideSafeRange = "is outside the safe integer range x-mcp-header requires"
 )
 
 type paramHeaderSchema struct {
@@ -28,9 +31,16 @@ type paramHeaderSchema struct {
 	// string made encoding/json fail the whole tree, and since the caller then
 	// dropped every binding, one union-typed property anywhere in a schema
 	// silently switched off header checking for the entire tool.
-	Type       json.RawMessage              `json:"type"`
-	Header     json.RawMessage              `json:"x-mcp-header"`
-	Properties map[string]paramHeaderSchema `json:"properties"`
+	Type   json.RawMessage `json:"type"`
+	Header json.RawMessage `json:"x-mcp-header"`
+	// Properties holds each subschema raw, and each is decoded on its own, because
+	// a property value need not be an object. JSON Schema 2020-12 allows the
+	// boolean subschemas true and false there, and mcpsnoop's own redaction
+	// replaces a subschema under a key like "token" with a string. Decoding the
+	// map in one go failed the whole tree on either, which took every binding with
+	// it and, once the verdict was reported, accused the server of a violation it
+	// had not committed.
+	Properties map[string]json.RawMessage `json:"properties"`
 }
 
 // paramHeaderType is the single primitive type a property declares, or "" when
@@ -56,6 +66,13 @@ type paramHeaderBinding struct {
 	typ    string
 }
 
+// paramHeaderViolation is one tool whose advertised schema breaks an x-mcp-header
+// constraint, and which one it breaks.
+type paramHeaderViolation struct {
+	tool   string
+	reason string
+}
+
 func sortedMCPParamHeaders(headers []proxy.MCPParamHeader) []proxy.MCPParamHeader {
 	out := slices.Clone(headers)
 	slices.SortStableFunc(out, func(a, b proxy.MCPParamHeader) int {
@@ -67,7 +84,10 @@ func sortedMCPParamHeaders(headers []proxy.MCPParamHeader) []proxy.MCPParamHeade
 	return out
 }
 
-func mcpParamHeaderWarnings(sess *session, msg proxy.RPCMessage, headers []proxy.MCPParamHeader) []string {
+// mcpParamHeaderWarnings compares each bound header against the argument it
+// mirrors. redacted says the frame passed through mcpsnoop's own redaction,
+// which is what makes the placeholder below trustworthy as a placeholder.
+func mcpParamHeaderWarnings(sess *session, msg proxy.RPCMessage, headers []proxy.MCPParamHeader, redacted bool) []string {
 	var params struct {
 		Name      string                     `json:"name"`
 		Arguments map[string]json.RawMessage `json:"arguments"`
@@ -84,18 +104,19 @@ func mcpParamHeaderWarnings(sess *session, msg proxy.RPCMessage, headers []proxy
 		return nil
 	}
 
-	values := make(map[string]string, len(headers))
+	// Every spelling is kept, not just the first. A repeated field with conflicting
+	// values is a request a conforming server must reject, and keeping only the
+	// first made the verdict depend on which line happened to arrive first.
+	values := make(map[string][]string, len(headers))
 	for _, header := range headers {
 		key := strings.ToLower(header.Name)
-		if _, exists := values[key]; !exists {
-			values[key] = header.Value
-		}
+		values[key] = append(values[key], header.Value)
 	}
 
 	var warnings []string
 	for _, binding := range bindings {
 		fullName := mcpParamHeaderPrefix + binding.header
-		headerValue, present := values[strings.ToLower(fullName)]
+		spellings, present := values[strings.ToLower(fullName)]
 		raw, exists := lookupParamArgument(params.Arguments, binding.path)
 		path := strings.Join(binding.path, ".")
 		if !exists || string(raw) == "null" {
@@ -112,43 +133,104 @@ func mcpParamHeaderWarnings(sess *session, msg proxy.RPCMessage, headers []proxy
 		}
 		// Either side scrubbed by mcpsnoop's own redaction makes the pair
 		// unverifiable, not disagreeing. The proxy scrubs the header alongside the
-		// body, but the two are matched by value and a rule can still reach only
-		// one of them, and a capture redacted by an older build has no header copy
-		// at all. Reporting that as a mismatch invents a protocol violation out of
+		// body, but the two are matched by value and a rule can still reach only one
+		// of them. Reporting that as a mismatch invents a protocol violation out of
 		// the user's privacy setting, and it fails a default check run.
-		if headerValue == redactedMarker || string(raw) == strconv.Quote(redactedMarker) {
+		//
+		// Gated on the frame actually having been redacted. "[REDACTED]" is a legal
+		// header value and a legal string argument, so skipping on those bytes alone
+		// let either peer switch the check off by sending them.
+		if redacted && (slices.Contains(spellings, redactedMarker) ||
+			string(raw) == strconv.Quote(redactedMarker)) {
+			continue
+		}
+		if len(spellings) > 1 && !mcpParamHeaderValuesAgree(spellings, binding.typ) {
+			warnings = append(warnings, "routing header "+fullName+
+				" is repeated with conflicting values, so body parameter "+
+				strconv.Quote(path)+" cannot be checked")
 			continue
 		}
 
-		decoded, ok := decodeMCPParamHeaderValue(headerValue)
+		decoded, ok := proxy.DecodeHeaderValue(spellings[0])
 		if !ok {
 			warnings = append(warnings, "routing header "+fullName+" has invalid Base64 encoding")
 			continue
 		}
-		bodyValue, ok := mcpParamPrimitive(raw, binding.typ)
-		if !ok {
+		bodyValue, reason := mcpParamPrimitive(raw, binding.typ)
+		if reason != "" {
 			warnings = append(warnings, "routing header "+fullName+
-				" cannot be compared because body parameter "+strconv.Quote(path)+
-				" is not a valid "+binding.typ)
+				" cannot be compared because body parameter "+strconv.Quote(path)+" "+reason)
 			continue
 		}
-		if !mcpParamValuesEqual(decoded, bodyValue) {
-			warnings = append(warnings, "routing header "+fullName+" "+strconv.Quote(decoded)+
-				" disagrees with body parameter "+strconv.Quote(path)+" "+strconv.Quote(mcpParamString(bodyValue)))
+		if bodyInteger, isInteger := bodyValue.(int64); isInteger {
+			// Compared numerically, as the spec asks, so 42.0 and 42 agree. An integer
+			// too large to be one gets the rule it actually breaks rather than being
+			// reported as merely disagreeing.
+			header := parseMCPInteger(decoded)
+			if header.integer && !header.safe {
+				warnings = append(warnings, "routing header "+fullName+" "+
+					strconv.Quote(decoded)+" "+outsideSafeRange)
+				continue
+			}
+			if header.safe && header.value == bodyInteger {
+				continue
+			}
+		} else if decoded == mcpParamString(bodyValue) {
+			continue
 		}
+		warnings = append(warnings, "routing header "+fullName+" "+strconv.Quote(decoded)+
+			" disagrees with body parameter "+strconv.Quote(path)+" "+strconv.Quote(mcpParamString(bodyValue)))
 	}
 	return warnings
 }
 
-func mcpParamHeaderBindings(schema json.RawMessage) ([]paramHeaderBinding, bool) {
+// mcpParamHeaderValuesAgree reports whether every spelling of one repeated header
+// carries the same value. Decoded first, so the plain and Base64 forms of one
+// value agree, and integers compared numerically, so 42 and 42.0 agree, because
+// neither is a conflict about what the server was asked to do.
+func mcpParamHeaderValuesAgree(spellings []string, typ string) bool {
+	first, ok := proxy.DecodeHeaderValue(spellings[0])
+	if !ok {
+		return false
+	}
+	firstInteger := parseMCPInteger(first)
+	for _, spelling := range spellings[1:] {
+		next, ok := proxy.DecodeHeaderValue(spelling)
+		if !ok {
+			return false
+		}
+		if typ == "integer" && firstInteger.safe {
+			other := parseMCPInteger(next)
+			if !other.safe || other.value != firstInteger.value {
+				return false
+			}
+			continue
+		}
+		if next != first {
+			return false
+		}
+	}
+	return true
+}
+
+// mcpParamHeaderBindings resolves a tool's x-mcp-header annotations. The second
+// return is the violation to report, empty when there is none.
+//
+// A schema that will not decode returns no bindings and no violation. That is an
+// observation limit rather than a server's fault, and the two must not share one
+// answer: the spec makes a violating annotation a definition the client MUST
+// reject, so saying so is right, while saying it about a schema mcpsnoop merely
+// could not read accuses the server of something it did not do, on a signal that
+// fails a default check run.
+func mcpParamHeaderBindings(schema json.RawMessage) ([]paramHeaderBinding, string) {
 	var root paramHeaderSchema
 	if json.Unmarshal(schema, &root) != nil {
-		return nil, false
+		return nil, ""
 	}
 	seen := make(map[string]struct{})
-	bindings, ok := collectMCPParamHeaderBindings(root.Properties, nil, seen, nil)
-	if !ok {
-		return nil, false
+	bindings, violation := collectMCPParamHeaderBindings(root.Properties, nil, seen, nil)
+	if violation != "" {
+		return nil, violation
 	}
 	slices.SortFunc(bindings, func(a, b paramHeaderBinding) int {
 		if n := strings.Compare(strings.ToLower(a.header), strings.ToLower(b.header)); n != 0 {
@@ -156,39 +238,65 @@ func mcpParamHeaderBindings(schema json.RawMessage) ([]paramHeaderBinding, bool)
 		}
 		return strings.Compare(strings.Join(a.path, "."), strings.Join(b.path, "."))
 	})
-	return bindings, true
+	return bindings, ""
 }
 
-func collectMCPParamHeaderBindings(properties map[string]paramHeaderSchema, prefix []string, seen map[string]struct{}, out []paramHeaderBinding) ([]paramHeaderBinding, bool) {
+func collectMCPParamHeaderBindings(properties map[string]json.RawMessage, prefix []string, seen map[string]struct{}, out []paramHeaderBinding) ([]paramHeaderBinding, string) {
 	names := make([]string, 0, len(properties))
 	for name := range properties {
 		names = append(names, name)
 	}
 	slices.Sort(names)
 	for _, name := range names {
-		property := properties[name]
+		var property paramHeaderSchema
+		if json.Unmarshal(properties[name], &property) != nil {
+			continue
+		}
 		path := append(slices.Clone(prefix), name)
 		if len(property.Header) != 0 {
-			var header string
-			if json.Unmarshal(property.Header, &header) != nil || header == "" ||
-				!validMCPParamHeaderName(header) ||
-				!isMCPParamPrimitive(paramHeaderType(property.Type)) {
-				return nil, false
+			binding, violation := paramHeaderAnnotation(property, path, seen)
+			if violation != "" {
+				return nil, violation
 			}
-			key := strings.ToLower(header)
-			if _, duplicate := seen[key]; duplicate {
-				return nil, false
-			}
-			seen[key] = struct{}{}
-			out = append(out, paramHeaderBinding{path: path, header: header, typ: paramHeaderType(property.Type)})
+			out = append(out, binding)
 		}
-		var ok bool
-		out, ok = collectMCPParamHeaderBindings(property.Properties, path, seen, out)
-		if !ok {
-			return nil, false
+		var violation string
+		out, violation = collectMCPParamHeaderBindings(property.Properties, path, seen, out)
+		if violation != "" {
+			return nil, violation
 		}
 	}
-	return out, true
+	return out, ""
+}
+
+// paramHeaderAnnotation validates one x-mcp-header against the constraints the
+// spec puts on it, naming the one it breaks. The name is what turns the report
+// into something a reader can act on, since a single message covering every
+// rejection reason sends them after the wrong rule.
+func paramHeaderAnnotation(property paramHeaderSchema, path []string, seen map[string]struct{}) (paramHeaderBinding, string) {
+	where := " on property " + strconv.Quote(strings.Join(path, "."))
+	var header string
+	if json.Unmarshal(property.Header, &header) != nil {
+		return paramHeaderBinding{}, "an x-mcp-header" + where + " that is not a string"
+	}
+	if header == "" {
+		return paramHeaderBinding{}, "an empty x-mcp-header" + where
+	}
+	if !validMCPParamHeaderName(header) {
+		return paramHeaderBinding{}, "x-mcp-header " + strconv.Quote(header) + where +
+			", which is not a valid header field name"
+	}
+	typ := paramHeaderType(property.Type)
+	if !isMCPParamPrimitive(typ) {
+		return paramHeaderBinding{}, "x-mcp-header " + strconv.Quote(header) + where +
+			", whose type is not one of string, integer or boolean"
+	}
+	key := strings.ToLower(header)
+	if _, duplicate := seen[key]; duplicate {
+		return paramHeaderBinding{}, "x-mcp-header " + strconv.Quote(header) + " on more than one property"
+	}
+	seen[key] = struct{}{}
+	return paramHeaderBinding{path: path, header: header, typ: typ}, ""
 }
 
 // isMCPParamPrimitive reports whether a declared type may carry an
@@ -232,66 +340,71 @@ func lookupParamArgument(arguments map[string]json.RawMessage, path []string) (j
 	return current, ok
 }
 
-func decodeMCPParamHeaderValue(value string) (string, bool) {
-	inner, encoded := strings.CutPrefix(value, base64SentinelPrefix)
-	if !encoded {
-		return value, true
-	}
-	inner, encoded = strings.CutSuffix(inner, base64SentinelSuffix)
-	if !encoded {
-		return value, true
-	}
-	if decoded, err := base64.StdEncoding.DecodeString(inner); err == nil {
-		return string(decoded), true
-	}
-	if decoded, err := base64.RawStdEncoding.DecodeString(inner); err == nil {
-		return string(decoded), true
-	}
-	return "", false
-}
-
-func mcpParamPrimitive(raw json.RawMessage, typ string) (any, bool) {
+// mcpParamPrimitive reads a body argument as the type its binding declares. The
+// second return is why it could not, empty on success, phrased to follow the
+// parameter's name.
+func mcpParamPrimitive(raw json.RawMessage, typ string) (any, string) {
 	switch typ {
 	case "string":
 		var value string
-		return value, json.Unmarshal(raw, &value) == nil
+		if json.Unmarshal(raw, &value) != nil {
+			return nil, "is not a valid string"
+		}
+		return value, ""
 	case "boolean":
 		var value bool
-		return value, json.Unmarshal(raw, &value) == nil
-	case "integer":
-		value, ok := parseSafeMCPInteger(string(raw))
-		if !ok {
-			return nil, false
+		if json.Unmarshal(raw, &value) != nil {
+			return nil, "is not a valid boolean"
 		}
-		return value, true
+		return value, ""
+	case "integer":
+		parsed := parseMCPInteger(string(raw))
+		switch {
+		case !parsed.integer:
+			return nil, "is not a valid integer"
+		case !parsed.safe:
+			return nil, outsideSafeRange
+		}
+		return parsed.value, ""
 	default:
-		return nil, false
+		return nil, "has a type x-mcp-header does not cover"
 	}
 }
 
-func mcpParamValuesEqual(header string, body any) bool {
-	if integer, ok := body.(int64); ok {
-		value, ok := parseSafeMCPInteger(header)
-		return ok && value == integer
-	}
-	return header == mcpParamString(body)
+// mcpInteger is one integer spelling parsed twice over. integer says the value is
+// an integer at all, safe says it also fits the range the spec requires of an
+// x-mcp-header integer. value is meaningful only when safe.
+type mcpInteger struct {
+	value   int64
+	integer bool
+	safe    bool
 }
 
-func parseSafeMCPInteger(value string) (int64, bool) {
+func parseMCPInteger(value string) mcpInteger {
 	value = strings.TrimSpace(value)
-	parsed, err := strconv.ParseFloat(value, 64)
-	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
-		return 0, false
+	// Three spellings big.Rat accepts that no conforming client can produce, the
+	// underscore separator, hex-float notation and the fraction form, all NaN under
+	// JavaScript's Number(). Everything else stays permissive on purpose: the spec
+	// tells servers to compare these numerically, so 42.0, 042 and 4.2e1 must keep
+	// matching a body of 42, and refusing them would warn on correct traffic, which
+	// is the worse failure of the two.
+	if strings.ContainsAny(value, "_xX/") {
+		return mcpInteger{}
 	}
 	exact, ok := new(big.Rat).SetString(value)
-	if !ok || !exact.IsInt() || !exact.Num().IsInt64() {
-		return 0, false
+	if !ok || !exact.IsInt() {
+		return mcpInteger{}
 	}
-	integer := exact.Num().Int64()
-	if integer < -maxSafeMCPInteger || integer > maxSafeMCPInteger {
-		return 0, false
+	number := exact.Num()
+	if !number.IsInt64() {
+		return mcpInteger{integer: true}
 	}
-	return integer, true
+	parsed := number.Int64()
+	return mcpInteger{
+		value:   parsed,
+		integer: true,
+		safe:    parsed >= -maxSafeMCPInteger && parsed <= maxSafeMCPInteger,
+	}
 }
 
 func mcpParamString(value any) string {

--- a/internal/store/paramheader.go
+++ b/internal/store/paramheader.go
@@ -1,0 +1,265 @@
+package store
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"math"
+	"math/big"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+const (
+	mcpParamHeaderPrefix = "Mcp-Param-"
+	maxSafeMCPInteger    = int64(1<<53 - 1)
+)
+
+type paramHeaderSchema struct {
+	Type       string                       `json:"type"`
+	Header     json.RawMessage              `json:"x-mcp-header"`
+	Properties map[string]paramHeaderSchema `json:"properties"`
+}
+
+type paramHeaderBinding struct {
+	path   []string
+	header string
+	typ    string
+}
+
+func sortedMCPParamHeaders(headers []proxy.MCPParamHeader) []proxy.MCPParamHeader {
+	out := slices.Clone(headers)
+	slices.SortStableFunc(out, func(a, b proxy.MCPParamHeader) int {
+		if n := strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name)); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return out
+}
+
+func mcpParamHeaderWarnings(sess *session, msg proxy.RPCMessage, headers []proxy.MCPParamHeader) []string {
+	var params struct {
+		Name      string                     `json:"name"`
+		Arguments map[string]json.RawMessage `json:"arguments"`
+	}
+	if json.Unmarshal(msg.Params, &params) != nil || params.Name == "" {
+		return nil
+	}
+	definition, ok := sess.toolDefinitions[params.Name]
+	if !ok {
+		return nil
+	}
+	bindings := definition.paramHeaders
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	values := make(map[string]string, len(headers))
+	for _, header := range headers {
+		key := strings.ToLower(header.Name)
+		if _, exists := values[key]; !exists {
+			values[key] = header.Value
+		}
+	}
+
+	var warnings []string
+	for _, binding := range bindings {
+		fullName := mcpParamHeaderPrefix + binding.header
+		headerValue, present := values[strings.ToLower(fullName)]
+		raw, exists := lookupParamArgument(params.Arguments, binding.path)
+		path := strings.Join(binding.path, ".")
+		if !exists || string(raw) == "null" {
+			if present {
+				warnings = append(warnings, "routing header "+fullName+
+					" is present but body parameter "+strconv.Quote(path)+" is absent or null")
+			}
+			continue
+		}
+		if !present {
+			warnings = append(warnings, "required routing header "+fullName+
+				" is missing for body parameter "+strconv.Quote(path))
+			continue
+		}
+
+		decoded, ok := decodeMCPParamHeaderValue(headerValue)
+		if !ok {
+			warnings = append(warnings, "routing header "+fullName+" has invalid Base64 encoding")
+			continue
+		}
+		bodyValue, ok := mcpParamPrimitive(raw, binding.typ)
+		if !ok {
+			warnings = append(warnings, "routing header "+fullName+
+				" cannot be compared because body parameter "+strconv.Quote(path)+
+				" is not a valid "+binding.typ)
+			continue
+		}
+		if !mcpParamValuesEqual(decoded, bodyValue) {
+			warnings = append(warnings, "routing header "+fullName+" "+strconv.Quote(decoded)+
+				" disagrees with body parameter "+strconv.Quote(path)+" "+strconv.Quote(mcpParamString(bodyValue)))
+		}
+	}
+	return warnings
+}
+
+func mcpParamHeaderBindings(schema json.RawMessage) ([]paramHeaderBinding, bool) {
+	var root paramHeaderSchema
+	if json.Unmarshal(schema, &root) != nil {
+		return nil, false
+	}
+	seen := make(map[string]struct{})
+	bindings, ok := collectMCPParamHeaderBindings(root.Properties, nil, seen, nil)
+	if !ok {
+		return nil, false
+	}
+	slices.SortFunc(bindings, func(a, b paramHeaderBinding) int {
+		if n := strings.Compare(strings.ToLower(a.header), strings.ToLower(b.header)); n != 0 {
+			return n
+		}
+		return strings.Compare(strings.Join(a.path, "."), strings.Join(b.path, "."))
+	})
+	return bindings, true
+}
+
+func collectMCPParamHeaderBindings(properties map[string]paramHeaderSchema, prefix []string, seen map[string]struct{}, out []paramHeaderBinding) ([]paramHeaderBinding, bool) {
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		property := properties[name]
+		path := append(slices.Clone(prefix), name)
+		if len(property.Header) != 0 {
+			var header string
+			if json.Unmarshal(property.Header, &header) != nil || header == "" ||
+				!validMCPParamHeaderName(header) ||
+				(property.Type != "string" && property.Type != "integer" && property.Type != "boolean") {
+				return nil, false
+			}
+			key := strings.ToLower(header)
+			if _, duplicate := seen[key]; duplicate {
+				return nil, false
+			}
+			seen[key] = struct{}{}
+			out = append(out, paramHeaderBinding{path: path, header: header, typ: property.Type})
+		}
+		var ok bool
+		out, ok = collectMCPParamHeaderBindings(property.Properties, path, seen, out)
+		if !ok {
+			return nil, false
+		}
+	}
+	return out, true
+}
+
+func validMCPParamHeaderName(name string) bool {
+	for _, c := range name {
+		switch {
+		case c >= '0' && c <= '9', c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z':
+			continue
+		}
+		switch c {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return name != ""
+}
+
+func lookupParamArgument(arguments map[string]json.RawMessage, path []string) (json.RawMessage, bool) {
+	if len(path) == 0 {
+		return nil, false
+	}
+	current, ok := arguments[path[0]]
+	for _, part := range path[1:] {
+		if !ok {
+			return nil, false
+		}
+		var object map[string]json.RawMessage
+		if json.Unmarshal(current, &object) != nil {
+			return nil, false
+		}
+		current, ok = object[part]
+	}
+	return current, ok
+}
+
+func decodeMCPParamHeaderValue(value string) (string, bool) {
+	inner, encoded := strings.CutPrefix(value, base64SentinelPrefix)
+	if !encoded {
+		return value, true
+	}
+	inner, encoded = strings.CutSuffix(inner, base64SentinelSuffix)
+	if !encoded {
+		return value, true
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(inner); err == nil {
+		return string(decoded), true
+	}
+	if decoded, err := base64.RawStdEncoding.DecodeString(inner); err == nil {
+		return string(decoded), true
+	}
+	return "", false
+}
+
+func mcpParamPrimitive(raw json.RawMessage, typ string) (any, bool) {
+	switch typ {
+	case "string":
+		var value string
+		return value, json.Unmarshal(raw, &value) == nil
+	case "boolean":
+		var value bool
+		return value, json.Unmarshal(raw, &value) == nil
+	case "integer":
+		value, ok := parseSafeMCPInteger(string(raw))
+		if !ok {
+			return nil, false
+		}
+		return value, true
+	default:
+		return nil, false
+	}
+}
+
+func mcpParamValuesEqual(header string, body any) bool {
+	if integer, ok := body.(int64); ok {
+		value, ok := parseSafeMCPInteger(header)
+		return ok && value == integer
+	}
+	return header == mcpParamString(body)
+}
+
+func parseSafeMCPInteger(value string) (int64, bool) {
+	value = strings.TrimSpace(value)
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, false
+	}
+	exact, ok := new(big.Rat).SetString(value)
+	if !ok || !exact.IsInt() || !exact.Num().IsInt64() {
+		return 0, false
+	}
+	integer := exact.Num().Int64()
+	if integer < -maxSafeMCPInteger || integer > maxSafeMCPInteger {
+		return 0, false
+	}
+	return integer, true
+}
+
+func mcpParamString(value any) string {
+	switch value := value.(type) {
+	case string:
+		return value
+	case bool:
+		return strconv.FormatBool(value)
+	case int64:
+		return strconv.FormatInt(value, 10)
+	default:
+		return ""
+	}
+}

--- a/internal/store/paramheader.go
+++ b/internal/store/paramheader.go
@@ -15,12 +15,39 @@ import (
 const (
 	mcpParamHeaderPrefix = "Mcp-Param-"
 	maxSafeMCPInteger    = int64(1<<53 - 1)
+	// redactedMarker is what proxy.Redactor writes in place of a scrubbed value.
+	// Duplicated rather than imported because the store must not depend on the
+	// proxy's redaction internals, and a literal that drifts is caught by
+	// TestParamHeaderRedactionMarkerMatchesTheProxy.
+	redactedMarker = "[REDACTED]"
 )
 
 type paramHeaderSchema struct {
-	Type       string                       `json:"type"`
+	// Type is raw because JSON Schema allows both "string" and ["string","null"],
+	// and the union form is common in generated tool schemas. Decoding it into a
+	// string made encoding/json fail the whole tree, and since the caller then
+	// dropped every binding, one union-typed property anywhere in a schema
+	// silently switched off header checking for the entire tool.
+	Type       json.RawMessage              `json:"type"`
 	Header     json.RawMessage              `json:"x-mcp-header"`
 	Properties map[string]paramHeaderSchema `json:"properties"`
+}
+
+// paramHeaderType is the single primitive type a property declares, or "" when
+// it declares none, several, or something that is not a primitive. The spec
+// permits x-mcp-header only on integer, string and boolean, so a union is not a
+// legal place for the annotation, but it is a legal thing to appear elsewhere in
+// the schema and must not poison the walk.
+func paramHeaderType(raw json.RawMessage) string {
+	var single string
+	if json.Unmarshal(raw, &single) == nil {
+		return single
+	}
+	var union []string
+	if json.Unmarshal(raw, &union) == nil && len(union) == 1 {
+		return union[0]
+	}
+	return ""
 }
 
 type paramHeaderBinding struct {
@@ -83,6 +110,15 @@ func mcpParamHeaderWarnings(sess *session, msg proxy.RPCMessage, headers []proxy
 				" is missing for body parameter "+strconv.Quote(path))
 			continue
 		}
+		// Either side scrubbed by mcpsnoop's own redaction makes the pair
+		// unverifiable, not disagreeing. The proxy scrubs the header alongside the
+		// body, but the two are matched by value and a rule can still reach only
+		// one of them, and a capture redacted by an older build has no header copy
+		// at all. Reporting that as a mismatch invents a protocol violation out of
+		// the user's privacy setting, and it fails a default check run.
+		if headerValue == redactedMarker || string(raw) == strconv.Quote(redactedMarker) {
+			continue
+		}
 
 		decoded, ok := decodeMCPParamHeaderValue(headerValue)
 		if !ok {
@@ -136,7 +172,7 @@ func collectMCPParamHeaderBindings(properties map[string]paramHeaderSchema, pref
 			var header string
 			if json.Unmarshal(property.Header, &header) != nil || header == "" ||
 				!validMCPParamHeaderName(header) ||
-				(property.Type != "string" && property.Type != "integer" && property.Type != "boolean") {
+				!isMCPParamPrimitive(paramHeaderType(property.Type)) {
 				return nil, false
 			}
 			key := strings.ToLower(header)
@@ -144,7 +180,7 @@ func collectMCPParamHeaderBindings(properties map[string]paramHeaderSchema, pref
 				return nil, false
 			}
 			seen[key] = struct{}{}
-			out = append(out, paramHeaderBinding{path: path, header: header, typ: property.Type})
+			out = append(out, paramHeaderBinding{path: path, header: header, typ: paramHeaderType(property.Type)})
 		}
 		var ok bool
 		out, ok = collectMCPParamHeaderBindings(property.Properties, path, seen, out)
@@ -153,6 +189,13 @@ func collectMCPParamHeaderBindings(properties map[string]paramHeaderSchema, pref
 		}
 	}
 	return out, true
+}
+
+// isMCPParamPrimitive reports whether a declared type may carry an
+// x-mcp-header. The spec names integer, string and boolean, and excludes number
+// explicitly, because a float has no single decimal spelling to compare against.
+func isMCPParamPrimitive(typ string) bool {
+	return typ == "string" || typ == "integer" || typ == "boolean"
 }
 
 func validMCPParamHeaderName(name string) bool {

--- a/internal/store/paramheader_test.go
+++ b/internal/store/paramheader_test.go
@@ -1,0 +1,269 @@
+package store
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+const paramHeaderTool = `{"name":"route","inputSchema":{"type":"object","properties":{` +
+	`"region":{"type":"string","x-mcp-header":"Region"},` +
+	`"greeting":{"type":"string","x-mcp-header":"Greeting"},` +
+	`"options":{"type":"object","properties":{` +
+	`"verbose":{"type":"boolean","x-mcp-header":"Verbose"},` +
+	`"count":{"type":"integer","x-mcp-header":"Count"}}}}}}`
+
+func seedParamHeaderTool(s *Store) {
+	listExchange(s, 1, "", toolsListResult("", paramHeaderTool))
+}
+
+func paramCall(seq uint64, transport string, batch bool, args string, headers ...proxy.MCPParamHeader) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: time.Now(),
+		Direction: proxy.ClientToServer, Transport: transport, Batch: batch,
+		MCPMethod: "tools/call", MCPName: "route", MCPProtocolVersion: "2026-07-28",
+		MCPParamHeaders: headers,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{` +
+			`"name":"route","arguments":` + args + `}}`),
+	}
+}
+
+func TestMCPParamHeadersMatchNestedPrimitiveArguments(t *testing.T) {
+	s := New()
+	seedParamHeaderTool(s)
+	greeting := "Hello, 世界"
+	encoded := "=?base64?" + base64.StdEncoding.EncodeToString([]byte(greeting)) + "?="
+
+	ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false,
+		`{"region":"us-west1","greeting":"Hello, 世界","options":{"verbose":false,"count":42}}`,
+		proxy.MCPParamHeader{Name: "mcp-param-Verbose", Value: "false"},
+		proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "us-west1"},
+		proxy.MCPParamHeader{Name: "Mcp-Param-Greeting", Value: encoded},
+		proxy.MCPParamHeader{Name: "Mcp-Param-Count", Value: "42.0"},
+	))
+
+	if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+		t.Fatalf("matching parameter headers warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+	}
+	wantNames := []string{"Mcp-Param-Count", "Mcp-Param-Greeting", "Mcp-Param-Region", "mcp-param-Verbose"}
+	if len(ev.MCPParamHeaders) != len(wantNames) {
+		t.Fatalf("captured parameter headers = %+v", ev.MCPParamHeaders)
+	}
+	for i, want := range wantNames {
+		if ev.MCPParamHeaders[i].Name != want {
+			t.Fatalf("header order = %+v, want names %v", ev.MCPParamHeaders, wantNames)
+		}
+	}
+}
+
+func TestMCPParamHeaderMismatchSetsRoutingSignal(t *testing.T) {
+	s := New()
+	seedParamHeaderTool(s)
+	ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"region":"us-west1"}`,
+		proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "eu-west1"},
+	))
+	if !ev.RoutingMismatch || !strings.Contains(ev.Warning, "Mcp-Param-Region") || !strings.Contains(ev.Warning, "region") {
+		t.Fatalf("parameter mismatch not surfaced: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+	}
+}
+
+func TestMCPParamHeaderRequiredForModernAnnotatedArgument(t *testing.T) {
+	s := New()
+	seedParamHeaderTool(s)
+	ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"region":"us-west1"}`))
+	if !ev.RoutingMismatch || !strings.Contains(ev.Warning, "Mcp-Param-Region") || !strings.Contains(ev.Warning, "missing") {
+		t.Fatalf("missing parameter header not surfaced: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+	}
+}
+
+func TestMCPParamHeadersRespectVersionNullAndEncodingBoundaries(t *testing.T) {
+	t.Run("old protocol does not require header", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		e := paramCall(3, proxy.TransportHTTP, false, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "wrong"},
+		)
+		e.MCPProtocolVersion = "2025-11-25"
+		ev := s.Ingest(e)
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("old protocol missing header warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("notification does not require header", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		e := paramCall(3, proxy.TransportHTTP, false, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "wrong"},
+		)
+		e.Raw = json.RawMessage(`{"jsonrpc":"2.0","method":"tools/call","params":{` +
+			`"name":"route","arguments":{"region":"us-west1"},` +
+			`"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`)
+		ev := s.Ingest(e)
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("notification missing parameter header warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("undated request is not judged by modern neighbour", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "us-west1"},
+		))
+		undated := paramCall(4, proxy.TransportHTTP, false, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "wrong"},
+		)
+		undated.MCPProtocolVersion = ""
+		ev := s.Ingest(undated)
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("undated request inherited parameter-header requirement: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("null omits header", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"region":null}`))
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("null parameter without header warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("header for null mismatches", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"region":null}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "us-west1"},
+		))
+		if !ev.RoutingMismatch || !strings.Contains(ev.Warning, "absent or null") {
+			t.Fatalf("header for null not surfaced: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("malformed base64 mismatches", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "=?base64?%%%?="},
+		))
+		if !ev.RoutingMismatch || !strings.Contains(ev.Warning, "invalid Base64") {
+			t.Fatalf("invalid Base64 not surfaced: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("fraction near safe integer limit stays fractional", func(t *testing.T) {
+		schema := `{"name":"route","inputSchema":{"type":"object","properties":` +
+			`{"count":{"type":"integer","x-mcp-header":"Count"}}}}`
+		s := New()
+		listExchange(s, 1, "", toolsListResult("", schema))
+		ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"count":9007199254740991}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Count", Value: "9007199254740991.1"},
+		))
+		if !ev.RoutingMismatch {
+			t.Fatal("a fractional header rounded by float64 must not equal the safe-integer body")
+		}
+	})
+}
+
+func TestMCPParamHeadersAvoidUnsupportedContextFalsePositives(t *testing.T) {
+	t.Run("unknown header", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Unknown", Value: "x"},
+		))
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("unknown parameter header warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("no tool definition", func(t *testing.T) {
+		s := New()
+		ev := s.Ingest(paramCall(1, proxy.TransportHTTP, false, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "wrong"},
+		))
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("header without a definition warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("stdio", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		ev := s.Ingest(paramCall(3, proxy.TransportStdio, false, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "wrong"},
+		))
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("stdio parameter metadata warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+
+	t.Run("batch", func(t *testing.T) {
+		s := New()
+		seedParamHeaderTool(s)
+		e := paramCall(3, proxy.TransportHTTP, true, `{"region":"us-west1"}`,
+			proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "wrong"},
+		)
+		e.MCPMethod, e.MCPName = "", ""
+		ev := s.Ingest(e)
+		if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+			t.Fatalf("batch parameter metadata warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+		}
+	})
+}
+
+func TestMCPParamHeaderIgnoresNonStaticSchemaPath(t *testing.T) {
+	tests := map[string]struct {
+		schema string
+		args   string
+	}{
+		"items": {
+			schema: `{"type":"object","properties":{"items":{"type":"array","items":` +
+				`{"type":"object","properties":{"region":{"type":"string","x-mcp-header":"Region"}}}}}}`,
+			args: `{"items":[{"region":"us-west1"}]}`,
+		},
+		"oneOf": {
+			schema: `{"oneOf":[{"type":"object","properties":` +
+				`{"region":{"type":"string","x-mcp-header":"Region"}}}]}`,
+			args: `{"region":"us-west1"}`,
+		},
+		"ref": {
+			schema: `{"$ref":"#/$defs/Input","$defs":{"Input":{"type":"object","properties":` +
+				`{"region":{"type":"string","x-mcp-header":"Region"}}}}}`,
+			args: `{"region":"us-west1"}`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tool := `{"name":"route","inputSchema":` + test.schema + `}`
+			s := New()
+			listExchange(s, 1, "", toolsListResult("", tool))
+			ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, test.args,
+				proxy.MCPParamHeader{Name: "Mcp-Param-Region", Value: "wrong"},
+			))
+			if ev.RoutingMismatch || strings.Contains(ev.Warning, "Mcp-Param") {
+				t.Fatalf("non-static schema path warned: mismatch=%v warning=%q", ev.RoutingMismatch, ev.Warning)
+			}
+		})
+	}
+}
+
+func TestMCPParamHeaderSnapshotsAreIsolated(t *testing.T) {
+	s := New()
+	seedParamHeaderTool(s)
+	headers := []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}}
+	ev := s.Ingest(paramCall(3, proxy.TransportHTTP, false, `{"region":"us-west1"}`, headers...))
+	headers[0].Value = "changed input"
+	ev.MCPParamHeaders[0].Value = "changed view"
+
+	timeline := s.Timeline("s1")
+	got := timeline[len(timeline)-1].MCPParamHeaders[0].Value
+	if got != "us-west1" {
+		t.Fatalf("stored parameter header changed through an external slice: %q", got)
+	}
+}

--- a/internal/store/paramheader_test.go
+++ b/internal/store/paramheader_test.go
@@ -21,6 +21,20 @@ func seedParamHeaderTool(s *Store) {
 	listExchange(s, 1, "", toolsListResult("", paramHeaderTool))
 }
 
+// listExchangeView is listExchange keeping the response frame, which is where a
+// verdict about an advertised definition has to land.
+func listExchangeView(s *Store, result string) EventView {
+	now := time.Now()
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`),
+	})
+	return s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":` + result + `}`),
+	})
+}
+
 func paramCall(seq uint64, transport string, batch bool, args string, headers ...proxy.MCPParamHeader) proxy.Envelope {
 	return proxy.Envelope{
 		SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: time.Now(),
@@ -272,9 +286,9 @@ func TestMCPParamHeaderSnapshotsAreIsolated(t *testing.T) {
 // which is what mcpParamHeaderWarnings reads its bindings from.
 func paramSession(t *testing.T, tool, schema string) *session {
 	t.Helper()
-	bindings, ok := mcpParamHeaderBindings(json.RawMessage(schema))
-	if !ok {
-		t.Fatalf("schema %s produced no valid bindings", schema)
+	bindings, violation := mcpParamHeaderBindings(json.RawMessage(schema))
+	if violation != "" {
+		t.Fatalf("schema %s reported %s", schema, violation)
 	}
 	return &session{toolDefinitions: map[string]ToolDefinition{
 		tool: {Name: tool, paramHeaders: bindings},
@@ -332,12 +346,241 @@ func TestParamHeaderRedactionIsNotAMismatch(t *testing.T) {
 			sess := paramSession(t, "fetch", schema)
 			got := mcpParamHeaderWarnings(sess,
 				paramCallMsg("fetch", `{"authKey":`+quoteJSON(tc.body)+`}`),
-				[]proxy.MCPParamHeader{{Name: "Mcp-Param-Auth", Value: tc.header}})
+				[]proxy.MCPParamHeader{{Name: "Mcp-Param-Auth", Value: tc.header}}, true)
 			if len(got) != tc.wantWarnings {
 				t.Fatalf("warnings = %v, want %d", got, tc.wantWarnings)
 			}
 		})
 	}
+}
+
+// TestParamHeaderRedactionGuardNeedsAnActualRedaction. "[REDACTED]" is a legal
+// header value and a legal string argument, so a guard that skips on those bytes
+// alone is a check either peer can switch off by sending them. It is scoped to
+// frames mcpsnoop itself rewrote.
+func TestParamHeaderRedactionGuardNeedsAnActualRedaction(t *testing.T) {
+	const schema = `{"type":"object","properties":{"authKey":{"type":"string","x-mcp-header":"Auth"}}}`
+	for _, tc := range []struct {
+		name         string
+		redacted     bool
+		wantWarnings int
+	}{
+		{"frame was redacted", true, 0},
+		{"frame was not redacted", false, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mcpParamHeaderWarnings(paramSession(t, "fetch", schema),
+				paramCallMsg("fetch", `{"authKey":"sk-live-abcdef"}`),
+				[]proxy.MCPParamHeader{{Name: "Mcp-Param-Auth", Value: redactedMarker}}, tc.redacted)
+			if len(got) != tc.wantWarnings {
+				t.Fatalf("warnings = %v, want %d", got, tc.wantWarnings)
+			}
+		})
+	}
+}
+
+// TestParamHeaderRepeatedFieldConflict. HTTP lets a client repeat a field, the
+// spec never blesses it, and a conforming server must reject a request whose
+// header disagrees with the body. Keeping only the first line made the verdict
+// follow wire order, so the same conflicting request passed or failed depending
+// on which line arrived first.
+func TestParamHeaderRepeatedFieldConflict(t *testing.T) {
+	const schema = `{"type":"object","properties":{` +
+		`"region":{"type":"string","x-mcp-header":"Region"},` +
+		`"count":{"type":"integer","x-mcp-header":"Count"}}}`
+	greeting := "=?base64?" + base64.StdEncoding.EncodeToString([]byte("us-west1")) + "?="
+	for _, tc := range []struct {
+		name    string
+		args    string
+		headers []proxy.MCPParamHeader
+		want    string
+	}{
+		{
+			name: "conflicting, agreeing line first",
+			args: `{"region":"us-west1"}`,
+			headers: []proxy.MCPParamHeader{
+				{Name: "Mcp-Param-Region", Value: "us-west1"},
+				{Name: "Mcp-Param-Region", Value: "eu-west1"},
+			},
+			want: "repeated with conflicting values",
+		},
+		{
+			name: "conflicting, disagreeing line first",
+			args: `{"region":"us-west1"}`,
+			headers: []proxy.MCPParamHeader{
+				{Name: "Mcp-Param-Region", Value: "eu-west1"},
+				{Name: "Mcp-Param-Region", Value: "us-west1"},
+			},
+			want: "repeated with conflicting values",
+		},
+		{
+			name: "conflicting across spellings of the name",
+			args: `{"region":"us-west1"}`,
+			headers: []proxy.MCPParamHeader{
+				{Name: "Mcp-Param-Region", Value: "us-west1"},
+				{Name: "mcp-param-region", Value: "eu-west1"},
+			},
+			want: "repeated with conflicting values",
+		},
+		{
+			name: "repeated with the same value is not a conflict",
+			args: `{"region":"us-west1"}`,
+			headers: []proxy.MCPParamHeader{
+				{Name: "Mcp-Param-Region", Value: "us-west1"},
+				{Name: "Mcp-Param-Region", Value: greeting},
+			},
+		},
+		{
+			name: "repeated integer agreeing numerically is not a conflict",
+			args: `{"count":42}`,
+			headers: []proxy.MCPParamHeader{
+				{Name: "Mcp-Param-Count", Value: "42"},
+				{Name: "Mcp-Param-Count", Value: "42.0"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mcpParamHeaderWarnings(paramSession(t, "route", schema),
+				paramCallMsg("route", tc.args), tc.headers, false)
+			if tc.want == "" {
+				if len(got) != 0 {
+					t.Fatalf("warnings = %v, want none", got)
+				}
+				return
+			}
+			if len(got) != 1 || !strings.Contains(got[0], tc.want) {
+				t.Fatalf("warnings = %v, want one containing %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParamHeaderOutOfRangeIntegerNamesItsRule. 2^53 is a perfectly valid JSON
+// integer. What it breaks is the separate rule that an x-mcp-header integer must
+// fit the JavaScript safe range, and reporting it as "not a valid integer" sent
+// the reader after a type error that is not there.
+func TestParamHeaderOutOfRangeIntegerNamesItsRule(t *testing.T) {
+	const schema = `{"type":"object","properties":{"count":{"type":"integer","x-mcp-header":"Count"}}}`
+	for _, tc := range []struct {
+		name         string
+		args, header string
+		want         string
+	}{
+		{"body out of range", `{"count":9007199254740992}`, "9007199254740992", outsideSafeRange},
+		{"header out of range", `{"count":9007199254740991}`, "9007199254740992", outsideSafeRange},
+		{"body at the limit", `{"count":9007199254740991}`, "9007199254740991", ""},
+		{"body is not an integer", `{"count":42.5}`, "42", "is not a valid integer"},
+		{"body is a string", `{"count":"42"}`, "42", "is not a valid integer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mcpParamHeaderWarnings(paramSession(t, "route", schema),
+				paramCallMsg("route", tc.args),
+				[]proxy.MCPParamHeader{{Name: "Mcp-Param-Count", Value: tc.header}}, false)
+			if tc.want == "" {
+				if len(got) != 0 {
+					t.Fatalf("warnings = %v, want none", got)
+				}
+				return
+			}
+			if len(got) != 1 || !strings.Contains(got[0], tc.want) {
+				t.Fatalf("warnings = %v, want one containing %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParamHeaderBindingsReportOnlyRealViolations is the blocker this guards.
+// mcpParamHeaderBindings used to answer "invalid" for anything it could not
+// decode, and the caller turned that into an accusation. A boolean subschema is
+// legal JSON Schema, a tool may carry no inputSchema at all, and mcpsnoop's own
+// --redact-secrets rewrites a subschema under a key like "token" into a string.
+// None of those is a server declaring a forbidden annotation.
+func TestParamHeaderBindingsReportOnlyRealViolations(t *testing.T) {
+	for _, tc := range []struct {
+		name, schema string
+		wantReason   string
+		wantBindings int
+	}{
+		{name: "no schema at all", schema: ``},
+		{name: "schema is not an object", schema: `"gone"`},
+		{name: "boolean subschema", schema: `{"type":"object","properties":{"anything":true}}`},
+		{
+			name:         "redacted subschema beside a live annotation",
+			schema:       `{"type":"object","properties":{"token":"[REDACTED]","region":{"type":"string","x-mcp-header":"Region"}}}`,
+			wantBindings: 1,
+		},
+		{
+			name:         "annotation on a number",
+			schema:       `{"type":"object","properties":{"ratio":{"type":"number","x-mcp-header":"Ratio"}}}`,
+			wantReason:   "whose type is not one of string, integer or boolean",
+			wantBindings: 0,
+		},
+		{
+			name: "same annotation twice",
+			schema: `{"type":"object","properties":{"a":{"type":"string","x-mcp-header":"Region"},` +
+				`"b":{"type":"string","x-mcp-header":"region"}}}`,
+			wantReason: "on more than one property",
+		},
+		{
+			name:       "annotation is not a valid field name",
+			schema:     `{"type":"object","properties":{"a":{"type":"string","x-mcp-header":"A B"}}}`,
+			wantReason: "not a valid header field name",
+		},
+		{
+			name:       "annotation is empty",
+			schema:     `{"type":"object","properties":{"a":{"type":"string","x-mcp-header":""}}}`,
+			wantReason: "an empty x-mcp-header",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bindings, reason := mcpParamHeaderBindings(json.RawMessage(tc.schema))
+			if tc.wantReason == "" {
+				if reason != "" {
+					t.Fatalf("reason = %q, want none", reason)
+				}
+			} else if !strings.Contains(reason, tc.wantReason) {
+				t.Fatalf("reason = %q, want one containing %q", reason, tc.wantReason)
+			}
+			if len(bindings) != tc.wantBindings {
+				t.Fatalf("bindings = %+v, want %d", bindings, tc.wantBindings)
+			}
+		})
+	}
+}
+
+// TestParamHeaderViolationLandsOnTheAdvertisingFrame drives the whole path,
+// since the verdict is parked on the session inside completeCall and drained by
+// Ingest, and asserts the two halves that matter: a real violation is named on
+// the frame that advertised it, and a schema mcpsnoop merely could not read is
+// not reported at all.
+func TestParamHeaderViolationLandsOnTheAdvertisingFrame(t *testing.T) {
+	t.Run("forbidden annotation is named", func(t *testing.T) {
+		s := New()
+		ev := listExchangeView(s, toolsListResult("", `{"name":"route","inputSchema":`+
+			`{"type":"object","properties":{"ratio":{"type":"number","x-mcp-header":"Ratio"}}}}`))
+		if !strings.Contains(ev.Warning, `tool "route" declares`) ||
+			!strings.Contains(ev.Warning, "Ratio") ||
+			!strings.Contains(ev.Warning, "not one of string, integer or boolean") {
+			t.Fatalf("violation not named on the advertising frame: %q", ev.Warning)
+		}
+	})
+
+	t.Run("unreadable schema stays silent", func(t *testing.T) {
+		s := New()
+		ev := listExchangeView(s, toolsListResult("", `{"name":"route","inputSchema":`+
+			`{"type":"object","properties":{"token":"[REDACTED]"}}}`))
+		if strings.Contains(ev.Warning, "x-mcp-header") {
+			t.Fatalf("a schema mcpsnoop could not read was reported as a violation: %q", ev.Warning)
+		}
+	})
+
+	t.Run("a legal schema stays silent", func(t *testing.T) {
+		s := New()
+		ev := listExchangeView(s, toolsListResult("", paramHeaderTool))
+		if strings.Contains(ev.Warning, "x-mcp-header") {
+			t.Fatalf("a legal schema was reported as a violation: %q", ev.Warning)
+		}
+	})
 }
 
 // TestParamHeaderBindingsSurviveAUnionType. A JSON Schema type may be a list,
@@ -349,9 +592,9 @@ func TestParamHeaderBindingsSurviveAUnionType(t *testing.T) {
 	const schema = `{"type":"object","properties":{
 		"region":{"type":"string","x-mcp-header":"Region"},
 		"note":{"type":["string","null"]}}}`
-	bindings, ok := mcpParamHeaderBindings(json.RawMessage(schema))
-	if !ok {
-		t.Fatal("a union type elsewhere in the schema must not invalidate the definition")
+	bindings, violation := mcpParamHeaderBindings(json.RawMessage(schema))
+	if violation != "" {
+		t.Fatalf("a union type elsewhere in the schema must not invalidate the definition: %s", violation)
 	}
 	if len(bindings) != 1 || bindings[0].header != "Region" {
 		t.Fatalf("bindings = %+v, want the one Region binding", bindings)
@@ -360,14 +603,14 @@ func TestParamHeaderBindingsSurviveAUnionType(t *testing.T) {
 	// The violation the old behaviour hid.
 	got := mcpParamHeaderWarnings(paramSession(t, "route", schema),
 		paramCallMsg("route", `{"region":"us-west1"}`),
-		[]proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "eu-west1"}})
+		[]proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "eu-west1"}}, false)
 	if len(got) != 1 {
 		t.Fatalf("a header disagreeing with the body must be reported, got %v", got)
 	}
 
 	// A union is still not a legal place for the annotation itself.
-	if _, ok := mcpParamHeaderBindings(json.RawMessage(
-		`{"properties":{"x":{"type":["string","null"],"x-mcp-header":"X"}}}`)); ok {
+	if _, violation := mcpParamHeaderBindings(json.RawMessage(
+		`{"properties":{"x":{"type":["string","null"],"x-mcp-header":"X"}}}`)); violation == "" {
 		t.Fatal("x-mcp-header on a union type is not permitted")
 	}
 }

--- a/internal/store/paramheader_test.go
+++ b/internal/store/paramheader_test.go
@@ -267,3 +267,113 @@ func TestMCPParamHeaderSnapshotsAreIsolated(t *testing.T) {
 		t.Fatalf("stored parameter header changed through an external slice: %q", got)
 	}
 }
+
+// paramSession is a session carrying one tool definition with the given schema,
+// which is what mcpParamHeaderWarnings reads its bindings from.
+func paramSession(t *testing.T, tool, schema string) *session {
+	t.Helper()
+	bindings, ok := mcpParamHeaderBindings(json.RawMessage(schema))
+	if !ok {
+		t.Fatalf("schema %s produced no valid bindings", schema)
+	}
+	return &session{toolDefinitions: map[string]ToolDefinition{
+		tool: {Name: tool, paramHeaders: bindings},
+	}}
+}
+
+func paramCallMsg(tool, args string) proxy.RPCMessage {
+	return proxy.RPCMessage{
+		Method: "tools/call",
+		Params: json.RawMessage(`{"name":"` + tool + `","arguments":` + args + `}`),
+	}
+}
+
+// TestParamHeaderRedactionMarkerMatchesTheProxy keeps the two literals in step.
+// The store cannot import the proxy's redaction internals, so the marker is
+// duplicated, and a duplicated literal that drifts silently turns the guard below
+// back into the false positive it exists to prevent.
+func TestParamHeaderRedactionMarkerMatchesTheProxy(t *testing.T) {
+	// Asserted through a real redaction rather than against another constant, so
+	// the test fails if the proxy ever changes what it writes.
+	sink := &paramCaptureSink{}
+	proxy.NewRedactingSink(sink, proxy.RedactConfig{Keys: []string{"secret"}}).Emit(proxy.Envelope{
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"params":{"secret":"hunter2"}}`),
+	})
+	if len(sink.envs) != 1 || !strings.Contains(string(sink.envs[0].Raw), redactedMarker) {
+		t.Fatalf("the store's marker %q no longer matches what the proxy writes: %s", redactedMarker, sink.envs[0].Raw)
+	}
+}
+
+type paramCaptureSink struct{ envs []proxy.Envelope }
+
+func (s *paramCaptureSink) Emit(e proxy.Envelope) { s.envs = append(s.envs, e) }
+func (s *paramCaptureSink) Close() error          { return nil }
+
+// TestParamHeaderRedactionIsNotAMismatch is the blocker this guards. mcpsnoop's
+// own redaction scrubs one side of a mirrored pair, and reporting that as a
+// protocol disagreement invents a violation out of a privacy setting, on traffic
+// that was correct, on a signal that fails a default check run.
+func TestParamHeaderRedactionIsNotAMismatch(t *testing.T) {
+	const schema = `{"type":"object","properties":{"authKey":{"type":"string","x-mcp-header":"Auth"}}}`
+	for _, tc := range []struct {
+		name         string
+		header, body string
+		wantWarnings int
+	}{
+		{"both scrubbed", redactedMarker, redactedMarker, 0},
+		{"body scrubbed only", "sk-live-abcdef", redactedMarker, 0},
+		{"header scrubbed only", redactedMarker, "sk-live-abcdef", 0},
+		{"neither scrubbed and equal", "sk-live-abcdef", "sk-live-abcdef", 0},
+		// A real disagreement on unredacted values must still be reported, or the
+		// guard has switched the check off rather than scoping it.
+		{"neither scrubbed and different", "sk-live-abcdef", "sk-live-999999", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sess := paramSession(t, "fetch", schema)
+			got := mcpParamHeaderWarnings(sess,
+				paramCallMsg("fetch", `{"authKey":`+quoteJSON(tc.body)+`}`),
+				[]proxy.MCPParamHeader{{Name: "Mcp-Param-Auth", Value: tc.header}})
+			if len(got) != tc.wantWarnings {
+				t.Fatalf("warnings = %v, want %d", got, tc.wantWarnings)
+			}
+		})
+	}
+}
+
+// TestParamHeaderBindingsSurviveAUnionType. A JSON Schema type may be a list,
+// which is legal and common in generated schemas. Decoding it into a string
+// failed the whole tree, and because the caller discarded the verdict, one such
+// property anywhere in a schema silently switched off header checking for the
+// entire tool, so a genuine violation went unreported.
+func TestParamHeaderBindingsSurviveAUnionType(t *testing.T) {
+	const schema = `{"type":"object","properties":{
+		"region":{"type":"string","x-mcp-header":"Region"},
+		"note":{"type":["string","null"]}}}`
+	bindings, ok := mcpParamHeaderBindings(json.RawMessage(schema))
+	if !ok {
+		t.Fatal("a union type elsewhere in the schema must not invalidate the definition")
+	}
+	if len(bindings) != 1 || bindings[0].header != "Region" {
+		t.Fatalf("bindings = %+v, want the one Region binding", bindings)
+	}
+
+	// The violation the old behaviour hid.
+	got := mcpParamHeaderWarnings(paramSession(t, "route", schema),
+		paramCallMsg("route", `{"region":"us-west1"}`),
+		[]proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "eu-west1"}})
+	if len(got) != 1 {
+		t.Fatalf("a header disagreeing with the body must be reported, got %v", got)
+	}
+
+	// A union is still not a legal place for the annotation itself.
+	if _, ok := mcpParamHeaderBindings(json.RawMessage(
+		`{"properties":{"x":{"type":["string","null"],"x-mcp-header":"X"}}}`)); ok {
+		t.Fatal("x-mcp-header on a union type is not permitted")
+	}
+}
+
+// quoteJSON renders a Go string as a JSON string literal.
+func quoteJSON(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -223,6 +223,11 @@ type session struct {
 	toolListSeen bool
 	toolDrift    ToolDrift
 	toolDriftSet bool
+	// paramHeaderInvalid names tools whose latest advertised inputSchema carries an
+	// x-mcp-header the spec forbids. applyToolsList runs deep inside completeCall,
+	// which cannot widen its return, so the verdict is parked here and Ingest
+	// drains it onto the tools/list response frame that carried the definitions.
+	paramHeaderInvalid []string
 
 	command []string
 	cwd     string
@@ -355,6 +360,14 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		if note := missingResultTypeWarning(msg, c); note != "" {
 			ev.warning = appendWarning(ev.warning, note)
 		}
+		// Drained here rather than returned, because applyToolsList runs inside
+		// completeCall. Each name is reported once, on the frame that advertised it.
+		for _, tool := range sess.paramHeaderInvalid {
+			ev.warning = appendWarning(ev.warning,
+				"tool "+strconv.Quote(tool)+" advertises an x-mcp-header the specification forbids, "+
+					"so its Mcp-Param headers are not checked")
+		}
+		sess.paramHeaderInvalid = nil
 		if c != nil && c.taskID != "" {
 			ev.taskID = c.taskID
 			if c.method != "tools/call" {
@@ -999,6 +1012,7 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 		sess.advertisedTools = nil
 	}
 
+	var invalidParamHeaderTools []string
 	for _, rawTool := range r.Tools {
 		var tool struct {
 			Name string `json:"name"`
@@ -1037,7 +1051,17 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 		sess.advertisedSet[tool.Name] = struct{}{}
 		sess.advertisedTools = append(sess.advertisedTools, tool.Name)
 		schema := append(json.RawMessage(nil), tool.InputSchema...)
-		paramHeaders, _ := mcpParamHeaderBindings(schema)
+		// The validity verdict is reported, not discarded. The spec makes an
+		// x-mcp-header violating its constraints a definition a client MUST reject,
+		// excluding the tool from the list and logging why. mcpsnoop observes rather
+		// than serves, so the analogous answer is to say so on the frame that
+		// advertised it and to compare no headers for that tool, which is what a
+		// conforming client would then be doing anyway. Throwing the verdict away
+		// left every one of those constraints computed and never reported.
+		paramHeaders, paramHeadersValid := mcpParamHeaderBindings(schema)
+		if !paramHeadersValid {
+			invalidParamHeaderTools = append(invalidParamHeaderTools, tool.Name)
+		}
 
 		// Measured from the raw bytes, not gated on the decoded string being
 		// non-empty: whatever the description field holds, those bytes were spent
@@ -1064,6 +1088,7 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 		}
 	}
 	sess.toolListComplete = r.NextCursor == ""
+	sess.paramHeaderInvalid = append(sess.paramHeaderInvalid, invalidParamHeaderTools...)
 }
 
 // hasListCursor reports whether a tools/list request carries a pagination cursor,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -224,10 +224,11 @@ type session struct {
 	toolDrift    ToolDrift
 	toolDriftSet bool
 	// paramHeaderInvalid names tools whose latest advertised inputSchema carries an
-	// x-mcp-header the spec forbids. applyToolsList runs deep inside completeCall,
-	// which cannot widen its return, so the verdict is parked here and Ingest
-	// drains it onto the tools/list response frame that carried the definitions.
-	paramHeaderInvalid []string
+	// x-mcp-header the spec forbids, and which constraint it breaks. applyToolsList
+	// runs deep inside completeCall, which cannot widen its return, so the verdict
+	// is parked here and Ingest drains it onto the tools/list response frame that
+	// carried the definitions.
+	paramHeaderInvalid []paramHeaderViolation
 
 	command []string
 	cwd     string
@@ -362,10 +363,10 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		}
 		// Drained here rather than returned, because applyToolsList runs inside
 		// completeCall. Each name is reported once, on the frame that advertised it.
-		for _, tool := range sess.paramHeaderInvalid {
+		for _, invalid := range sess.paramHeaderInvalid {
 			ev.warning = appendWarning(ev.warning,
-				"tool "+strconv.Quote(tool)+" advertises an x-mcp-header the specification forbids, "+
-					"so its Mcp-Param headers are not checked")
+				"tool "+strconv.Quote(invalid.tool)+" declares "+invalid.reason+
+					", so its Mcp-Param headers are not checked")
 		}
 		sess.paramHeaderInvalid = nil
 		if c != nil && c.taskID != "" {
@@ -590,7 +591,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 	if ev.transport == proxy.TransportHTTP && e.Direction == proxy.ClientToServer &&
 		!ev.batch && msg.Method == "tools/call" && len(msg.ID) > 0 &&
 		requiresRoutingHeaders(requestProtocolVersion(msg.Params, ev.mcpProtocolVersion)) {
-		for _, warning := range mcpParamHeaderWarnings(sess, msg, ev.mcpParamHeaders) {
+		for _, warning := range mcpParamHeaderWarnings(sess, msg, ev.mcpParamHeaders, e.Redacted) {
 			ev.warning = appendWarning(ev.warning, warning)
 			ev.mismatch = true
 		}
@@ -1012,7 +1013,7 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 		sess.advertisedTools = nil
 	}
 
-	var invalidParamHeaderTools []string
+	var invalidParamHeaderTools []paramHeaderViolation
 	for _, rawTool := range r.Tools {
 		var tool struct {
 			Name string `json:"name"`
@@ -1058,9 +1059,15 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 		// advertised it and to compare no headers for that tool, which is what a
 		// conforming client would then be doing anyway. Throwing the verdict away
 		// left every one of those constraints computed and never reported.
-		paramHeaders, paramHeadersValid := mcpParamHeaderBindings(schema)
-		if !paramHeadersValid {
-			invalidParamHeaderTools = append(invalidParamHeaderTools, tool.Name)
+		//
+		// Only an actual violation is reported, and it says which constraint. A
+		// schema mcpsnoop could not read is not the server's fault, and reporting the
+		// two the same way turned the user's own --redact-secrets into an accusation
+		// against traffic that was correct.
+		paramHeaders, violation := mcpParamHeaderBindings(schema)
+		if violation != "" {
+			invalidParamHeaderTools = append(invalidParamHeaderTools,
+				paramHeaderViolation{tool: tool.Name, reason: violation})
 		}
 
 		// Measured from the raw bytes, not gated on the decoded string being

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -167,6 +167,7 @@ type event struct {
 	mcpMethod          string // Mcp-Method routing header (HTTP transport, SEP-2243)
 	mcpName            string // Mcp-Name routing header
 	mcpProtocolVersion string // MCP-Protocol-Version request header
+	mcpParamHeaders    []proxy.MCPParamHeader
 	batch              bool   // one element of a JSON-RPC batch (routing headers cannot address it)
 	transport          string // the channel this frame was observed on (proxy.TransportHTTP, …)
 	status             int    // HTTP status of the response this frame arrived on (zero on stdio)
@@ -292,7 +293,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		return EventView{Kind: EventOther} // control frame, not shown in the stream
 	}
 
-	ev := &event{seq: e.Seq, ts: e.TS, dir: e.Direction, raw: e.Raw, text: e.Text, mcpMethod: e.MCPMethod, mcpName: e.MCPName, mcpProtocolVersion: e.MCPProtocolVersion, batch: e.Batch, transport: e.Transport, status: e.Status, authChallenge: e.AuthChallenge}
+	ev := &event{seq: e.Seq, ts: e.TS, dir: e.Direction, raw: e.Raw, text: e.Text, mcpMethod: e.MCPMethod, mcpName: e.MCPName, mcpProtocolVersion: e.MCPProtocolVersion, mcpParamHeaders: sortedMCPParamHeaders(e.MCPParamHeaders), batch: e.Batch, transport: e.Transport, status: e.Status, authChallenge: e.AuthChallenge}
 
 	if e.Direction == proxy.ServerStderr {
 		ev.kind = EventStderr
@@ -559,6 +560,15 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			"request _meta is missing required io.modelcontextprotocol/clientCapabilities")
 	}
 
+	if ev.transport == proxy.TransportHTTP && e.Direction == proxy.ClientToServer &&
+		!ev.batch && msg.Method == "tools/call" && len(msg.ID) > 0 &&
+		requiresRoutingHeaders(requestProtocolVersion(msg.Params, ev.mcpProtocolVersion)) {
+		for _, warning := range mcpParamHeaderWarnings(sess, msg, ev.mcpParamHeaders) {
+			ev.warning = appendWarning(ev.warning, warning)
+			ev.mismatch = true
+		}
+	}
+
 	if note := deprecatedMethodNote(msg.Method); note != "" {
 		ev.deprecated = note
 	} else if state, ok := parseInputRequired(msg.Result); ok {
@@ -580,9 +590,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 	// The server's own verdict on the header checks mcpsnoop performs itself.
 	// Flagged structurally rather than as a warning: the frame is already an
 	// error and already counted, and what this adds is that the failure was a
-	// routing one. It matters because the server validates more than mcpsnoop
-	// can (Mcp-Param-{Name} values, malformed encodings), so its rejection is
-	// sometimes the only evidence a mismatch happened at all.
+	// routing one. It remains useful when mcpsnoop never observed the matching
+	// tool definition and therefore could not map an Mcp-Param-{Name} header
+	// back to its argument path.
 	if msg.Error != nil && msg.Error.Code == ErrorCodeHeaderMismatch {
 		ev.mismatch = true
 	}
@@ -1000,6 +1010,7 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 		sess.advertisedSet[tool.Name] = struct{}{}
 		sess.advertisedTools = append(sess.advertisedTools, tool.Name)
 		schema := append(json.RawMessage(nil), tool.InputSchema...)
+		paramHeaders, _ := mcpParamHeaderBindings(schema)
 
 		// Measured from the raw bytes, not gated on the decoded string being
 		// non-empty: whatever the description field holds, those bytes were spent
@@ -1016,6 +1027,7 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 			Annotations:  append(json.RawMessage(nil), tool.Annotations...),
 			Icons:        append(json.RawMessage(nil), tool.Icons...),
 			Findings:     analyzeSchema(schema),
+			paramHeaders: paramHeaders,
 			Cost: ToolCost{
 				Name:             tool.Name,
 				Bytes:            compactJSONLen(rawTool),

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -70,17 +70,21 @@ type EventView struct {
 	MCPName   string
 	// MCPProtocolVersion is the MCP-Protocol-Version request header.
 	MCPProtocolVersion string
+	// MCPParamHeaders are the captured Mcp-Param-* request headers in stable,
+	// case-insensitive field-name order.
+	MCPParamHeaders []proxy.MCPParamHeader
 	// HTTPStatus is the status of the response this frame arrived on, zero on
 	// stdio and on client frames. AuthChallenge is that response's
 	// WWW-Authenticate header.
 	HTTPStatus    int
 	AuthChallenge string
-	// RoutingMismatch is true when a routing header (Mcp-Method/Mcp-Name) or the
-	// MCP-Protocol-Version header disagrees with the body, or a routing header rides
-	// a batch, or a required one is missing. It is also true on a server's -32020
-	// response, which is that same condition as the server saw it: it validates
-	// values mcpsnoop cannot check, so its rejection is sometimes the only
-	// evidence. A structured handle for the condition the warning describes, so
+	// RoutingMismatch is true when a routing header (Mcp-Method/Mcp-Name or an
+	// Mcp-Param-* value) or the MCP-Protocol-Version header disagrees with the body,
+	// or a routing header rides a batch, or a required one is missing. It is also
+	// true on a server's -32020
+	// response, which is that same condition as the server saw it and remains
+	// useful when no matching tool definition was observed. A structured handle
+	// for the condition the warning describes, so
 	// filters and exporters need not match warning text.
 	RoutingMismatch bool
 	// Truncated is true when mcpsnoop capped its own observed copy of a large body.
@@ -133,6 +137,7 @@ type ToolDefinition struct {
 	Annotations  json.RawMessage
 	Icons        json.RawMessage
 	Findings     []SchemaFinding
+	paramHeaders []paramHeaderBinding
 	// Cost is what advertising this tool weighs, measured once at ingest.
 	Cost ToolCost
 }
@@ -353,6 +358,7 @@ func (e *event) view(_ *session) EventView {
 		MCPMethod:          e.mcpMethod,
 		MCPName:            e.mcpName,
 		MCPProtocolVersion: e.mcpProtocolVersion,
+		MCPParamHeaders:    slices.Clone(e.mcpParamHeaders),
 		HTTPStatus:         e.status,
 		AuthChallenge:      e.authChallenge,
 		RoutingMismatch:    e.mismatch,

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -303,6 +303,26 @@ func TestInspectorHeaderHSyncsWithProtocolVersionOnly(t *testing.T) {
 	}
 }
 
+func TestInspectorShowsMCPParamHeaders(t *testing.T) {
+	m := New(store.New())
+	m.full = []store.EventView{{
+		MCPParamHeaders: []proxy.MCPParamHeader{
+			{Name: "Mcp-Param-Region", Value: "us-west1"},
+			{Name: "Mcp-Param-Count", Value: "42"},
+		},
+	}}
+	m.inspect = 0
+	if got := m.inspectorHeaderH(); got != 2 {
+		t.Fatalf("inspectorHeaderH() = %d, want 2 for parameter headers", got)
+	}
+	header := m.inspectorHeader(200)
+	for _, want := range []string{"Mcp-Param-Count", "42", "Mcp-Param-Region", "us-west1"} {
+		if !strings.Contains(header, want) {
+			t.Fatalf("inspector header missing %q: %q", want, header)
+		}
+	}
+}
+
 func TestInspectorOverlay(t *testing.T) {
 	st := store.New()
 	seed(st)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1066,9 +1066,9 @@ func (m Model) inspectorHeader(w int) string {
 	right := m.pairWidget() + sep + m.styles.faint.Render(e.TS.Format("15:04:05.000"))
 	head := bar(w, left, right)
 	// A second chrome line carries the Streamable HTTP request headers (SEP-2243
-	// routing plus MCP-Protocol-Version) verbatim when the request had them, so the
-	// busy meta line stays readable and older transports show nothing. overlayHeaderH
-	// tracks the extra line.
+	// routing and parameter headers plus MCP-Protocol-Version) verbatim when the
+	// request had them, so the busy meta line stays readable and older transports
+	// show nothing. overlayHeaderH tracks the extra line.
 	if hasTransportMeta(e) {
 		var rp []string
 		if e.MCPMethod != "" {
@@ -1079,6 +1079,9 @@ func (m Model) inspectorHeader(w int) string {
 		}
 		if e.MCPProtocolVersion != "" {
 			rp = append(rp, m.styles.dim.Render("MCP-Protocol-Version ")+m.styles.neutral.Render(e.MCPProtocolVersion))
+		}
+		for _, header := range e.MCPParamHeaders {
+			rp = append(rp, m.styles.dim.Render(header.Name+" ")+m.styles.neutral.Render(header.Value))
 		}
 		if e.HTTPStatus != 0 {
 			rp = append(rp, m.styles.dim.Render("HTTP ")+m.styles.neutral.Render(fmt.Sprintf("%d %s", e.HTTPStatus, http.StatusText(e.HTTPStatus))))
@@ -1106,7 +1109,7 @@ func (m Model) inspectorHeaderH() int {
 // renderer and the height calculation both ask, and they must never disagree:
 // one saying yes while the other says no leaves the inspector body off by a row.
 func hasTransportMeta(e store.EventView) bool {
-	return e.MCPMethod != "" || e.MCPName != "" || e.MCPProtocolVersion != "" || e.HTTPStatus != 0
+	return e.MCPMethod != "" || e.MCPName != "" || e.MCPProtocolVersion != "" || len(e.MCPParamHeaders) != 0 || e.HTTPStatus != 0
 }
 
 // pairWidget is the right side of the inspector header, req N ⇄ resp N with the


### PR DESCRIPTION
## What and why

The 2026-07-28 protocol revision lets a tool mark statically reachable input
properties with `x-mcp-header`, mirroring their values into `Mcp-Param-*`
headers for routing and rate limiting. mcpsnoop already observes fixed routing
headers, but these dynamic headers were invisible and a disagreement with the
JSON body could pass through a capture without a finding.

This change captures `Mcp-Param-*` headers on Streamable HTTP requests without
altering forwarded headers or body bytes. When a server advertises a tool,
mcpsnoop precomputes its valid `x-mcp-header` property paths; on `tools/call`, it
compares the observed headers with the body using the protocol's string,
boolean, Base64-sentinel, and safe-integer rules. Recognized missing,
unexpected, malformed, or disagreeing values use the existing warning and
routing-mismatch signal.

Validation stays conservative: it follows only static `properties` paths,
ignores unknown headers, and does not run for stdio, batches, old revisions, or
calls without a matching tool definition. The inspector displays captured
parameter headers, and existing key- and value-based redaction applies before
they reach sinks. The additive envelope field is omitted from older or non-HTTP
frames, so existing session logs continue to decode unchanged.

Fixes #157.

## Verification

```bash
make check
```

The complete formatting, vet, staticcheck, and race-test gate passes.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
