### PR TITLE
chore(release): retire the tap, mcpsnoop is in homebrew-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,23 +32,6 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-# Publish a Homebrew formula to the kerlenton/homebrew-mcpsnoop tap on each
-# release. Needs HOMEBREW_TAP_TOKEN (a PAT that can push to that tap repo).
-brews:
-  - name: mcpsnoop
-    repository:
-      owner: kerlenton
-      name: homebrew-mcpsnoop
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    homepage: "https://github.com/kerlenton/mcpsnoop"
-    description: "Wireshark for MCP: a transparent proxy and TUI for debugging MCP traffic"
-    license: "MIT"
-    commit_author:
-      name: goreleaser
-      email: noreply@github.com
-    test: |
-      system "#{bin}/mcpsnoop", "version"
-
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@latest
 ### Homebrew
 
 ```bash
-brew install kerlenton/mcpsnoop/mcpsnoop
+brew install mcpsnoop
 ```
 
 Prebuilt binaries for every platform are on the [Releases](https://github.com/kerlenton/mcpsnoop/releases) page.


### PR DESCRIPTION
mcpsnoop is in homebrew-core. Installing it no longer needs a tap, a `brew trust`, or anything else:
```bash
brew install mcpsnoop
```

The tap itself stays alive with a `tap_migrations.json` pointing at homebrew/core, so anyone who installed from it moves over on their next `brew update` without doing anything
