### PR TITLE
fix(cli): reject unsafe --label values before session log paths

### DIFF
--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -277,6 +277,11 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 			if err != nil {
 				return err
 			}
+			if label != "" {
+				if err := paths.ValidateLabel(label); err != nil {
+					return fmt.Errorf("invalid --label: %w", err)
+				}
+			}
 			return codeOf(runShimFn(args, label, traceFile, noTrace, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths), trace))
 		},
 	}
@@ -473,6 +478,10 @@ func runShim(command []string, label, traceFile string, noTrace bool, redaction 
 	if label == "" {
 		label = labelFor(command)
 	}
+	if err := paths.ValidateLabel(label); err != nil {
+		fmt.Fprintf(os.Stderr, "mcpsnoop: invalid label: %v\n", err)
+		return 2
+	}
 	sessionID := newSessionID(label)
 
 	sink := traceSink(sessionID, traceFile, noTrace, redaction, trace)
@@ -581,6 +590,10 @@ func newHTTPCmd() *cobra.Command {
 				} else {
 					lbl = "http"
 				}
+			}
+			if err := paths.ValidateLabel(lbl); err != nil {
+				fmt.Fprintln(os.Stderr, "mcpsnoop http: invalid --label:", err)
+				return exitCode(2)
 			}
 			sessionID := newSessionID(lbl)
 

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -113,6 +113,24 @@ func TestExecuteStampsHARCreatorVersion(t *testing.T) {
 	}
 }
 
+func TestRootRejectsUnsafeLabel(t *testing.T) {
+	if code := execute([]string{"--label", "../../evil", "--", "node", "server.js"}); code != 2 {
+		t.Fatalf("exit = %d, want 2 for unsafe --label", code)
+	}
+}
+
+func TestRootRejectsUnsafeDerivedLabel(t *testing.T) {
+	if code := execute([]string{"--", ".."}); code != 2 {
+		t.Fatalf("exit = %d, want 2 for unsafe derived label", code)
+	}
+}
+
+func TestHTTPRejectsUnsafeLabel(t *testing.T) {
+	if code := execute([]string{"http", "--target", "http://localhost:3000/mcp", "--label", "../../evil"}); code != 2 {
+		t.Fatalf("exit = %d, want 2 for unsafe http --label", code)
+	}
+}
+
 func TestRootPassesWrappedCommandThroughUntouched(t *testing.T) {
 	var got []string
 	defer stubShim(&got)()

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -12,9 +12,11 @@
 package paths
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // maxSocketPathLen is a conservative unix-domain socket path limit. sun_path is
@@ -76,6 +78,24 @@ func ToolBaselinesDir() string {
 	d := filepath.Join(Base(), "tool-baselines")
 	_ = os.MkdirAll(d, 0o700)
 	return d
+}
+
+// ValidateLabel rejects labels that would make SessionLogPath escape SessionsDir.
+// Labels must be a single path component: no separators, no traversal, no NUL.
+func ValidateLabel(label string) error {
+	if label == "" {
+		return errors.New("label must not be empty")
+	}
+	if strings.ContainsRune(label, '\x00') {
+		return errors.New("label must not contain a NUL byte")
+	}
+	if label == "." || label == ".." {
+		return errors.New("label must not be a path segment")
+	}
+	if strings.ContainsAny(label, `/\`) {
+		return errors.New("label must not contain path separators")
+	}
+	return nil
 }
 
 // SessionLogPath returns the JSONL trace path for a given session id.

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -6,6 +6,37 @@ import (
 	"testing"
 )
 
+func TestValidateLabelRejectsUnsafeValues(t *testing.T) {
+	for _, label := range []string{
+		"",
+		".",
+		"..",
+		"../../evil",
+		`..\evil`,
+		"foo/bar",
+		`foo\bar`,
+		"@scope/server-foo",
+		"foo\x00bar",
+	} {
+		if err := ValidateLabel(label); err == nil {
+			t.Errorf("ValidateLabel(%q) = nil, want error", label)
+		}
+	}
+}
+
+func TestValidateLabelAcceptsStableNames(t *testing.T) {
+	for _, label := range []string{
+		"filesystem",
+		"server-filesystem",
+		"localhost:3000",
+		"foo..bar",
+	} {
+		if err := ValidateLabel(label); err != nil {
+			t.Errorf("ValidateLabel(%q) = %v, want nil", label, err)
+		}
+	}
+}
+
 func TestCheckSocketPathExplainsOverLongPath(t *testing.T) {
 	long := "/" + strings.Repeat("a", maxSocketPathLen) + "/hub.sock"
 	err := CheckSocketPath(long)


### PR DESCRIPTION
## Summary

Reject `--label` values (and derived labels) that contain path separators, traversal segments, or NUL bytes before constructing session ids used as log file names.

## Motivation

Fixes #155. An explicit `--label ../../evil` flowed verbatim into `newSessionID`, so `SessionLogPath` could write traces outside the sessions directory. The same applied to `mcpsnoop http --label`.

## Changes

- Add `paths.ValidateLabel` to reject empty labels, `.` / `..`, `/` / `\`, and NUL bytes
- Validate explicit `--label` in the root command before spawning the shim
- Validate resolved labels in `runShim` after `labelFor` (covers derived labels like `..`)
- Validate labels in the `http` subcommand before session creation
- Add unit and CLI tests for unsafe explicit, derived, and http labels

## Tests

- `go test -race ./cmd/mcpsnoop/... ./internal/paths/...` — pass
- `go vet ./...` and `staticcheck ./...` — pass
- Note: `internal/tui` has two pre-existing failures on `main` (`TestStreamRowShowsSupersededStatusInWarnStyle`, `TestStatusStyleWarnsOnTruncated`), unrelated to this change

## Notes

- Tool baselines hash labels, so they were never vulnerable to path traversal
- `--trace-file` remains a separate, documented override for custom log paths