### PR TITLE
fix(store): recognise subscriptions/listen as a stream, not a pending call

### DIFF
--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -605,6 +605,25 @@ func TestCheckJUnitReportsSelectedDeprecatedFeature(t *testing.T) {
 	}
 }
 
+// A subscriptions/listen stream stays open for the life of a healthy session
+// (2026-07-28), so it must not trip a pending gate; an ordinary unanswered
+// request still must.
+func TestCheckPendingGateIgnoresOpenListenStream(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	listen := checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"subscriptions/listen","params":{}}`)
+
+	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "pending", "-"}, encodeCheckLog(t, listen))
+	if code != 0 || stderr != "" {
+		t.Fatalf("an open stream failed the pending gate: code %d, stderr %q\n%s", code, stderr, stdout)
+	}
+
+	hung := checkEnvelope(2, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	code, stdout, _ = executeCheck(t, []string{"--fail-on", "pending", "-"}, encodeCheckLog(t, listen, hung))
+	if code != 1 || !strings.Contains(stdout, "check failed: pending") {
+		t.Fatalf("a genuinely hung call must still fail: code %d\n%s", code, stdout)
+	}
+}
+
 func executeCheck(t *testing.T, args []string, stdin string) (int, string, string) {
 	t.Helper()
 	cmd := newCheckCmd()

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -723,6 +723,10 @@ func exportCall(index int, c store.CallView) CallExport {
 	switch {
 	case c.State == store.Pending:
 		status = "pending"
+	case c.State == store.Listening:
+		// An open subscription stream, healthy by design, so it must not read
+		// as a hung pending call in an export either.
+		status = "listening"
 	case c.State == store.Superseded:
 		status = "superseded"
 	case c.TaskStatus == "cancelled":

--- a/internal/exporter/har.go
+++ b/internal/exporter/har.go
@@ -207,7 +207,7 @@ func harStatus(status string) (int, string) {
 	case "":
 		return 0, "No Response"
 	default:
-		return 0, status // pending or superseded, never answered
+		return 0, status // pending, listening, or superseded, never answered
 	}
 }
 

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -38,6 +38,7 @@ main { padding:18px 24px 40px; max-width:1180px; margin:0 auto; }
 .status.warn { color:var(--warn); }
 .status.superseded { color:var(--warn); }
 .status.pending { color:var(--pending); }
+.status.listening { color:var(--pending); }
 .status.bad { color:var(--invalid); }
 /* Per-event tone by kind/status, matching the TUI stream colors. */
 .tone-req { border-left-color:var(--req); } .tone-req .dir { color:var(--req); }
@@ -118,6 +119,7 @@ const matchStatus = (ev, call, v) => {
   if (!call) return false;
   if (["err", "error", "fail", "failed"].includes(v)) return call.status === "error";
   if (["pending", "pend", "inflight"].includes(v)) return call.status === "pending";
+  if (["listening", "listen"].includes(v)) return call.status === "listening";
   if (["ok", "success"].includes(v)) return call.status === "ok";
   return false;
 };
@@ -175,7 +177,7 @@ const statusOf = (ev, call) => {
     if (call.status === "error") return "error";
     return call.status;
   }
-  return call.status === "pending" || call.status === "superseded" ? call.status : "";
+  return ["pending", "listening", "superseded"].includes(call.status) ? call.status : "";
 };
 const renderEvent = (ev) => {
   const call = ev.call_index == null ? null : calls[ev.call_index];

--- a/internal/exporter/html_test.go
+++ b/internal/exporter/html_test.go
@@ -125,8 +125,8 @@ func TestHTMLSurfacesSupersededStatus(t *testing.T) {
 		t.Fatal("embedded data should also carry the answered request as ok")
 	}
 	// statusOf surfaces superseded on a request row while ok still yields an empty
-	// cell (the ternary returns "" for anything else).
-	if !strings.Contains(html, `call.status === "pending" || call.status === "superseded" ? call.status : ""`) {
+	// cell (anything outside the list yields "").
+	if !strings.Contains(html, `["pending", "listening", "superseded"].includes(call.status) ? call.status : ""`) {
 		t.Fatal("statusOf does not surface the superseded status on a request row")
 	}
 	// The CSS rule that colors it (as warn) must exist.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,13 @@ const (
 	// Superseded means the request's id was reused by a later in-flight request, so
 	// this one can never be matched to a response. It is no longer pending.
 	Superseded
+	// Listening means the request opened a long-lived subscription stream
+	// (subscriptions/listen, 2026-07-28) that is healthily delivering
+	// notifications. It is deliberately not Pending: the response arrives only
+	// when the stream ends, which may be hours later or never, so counting the
+	// wait as a hung call would make the PENDING timer and a
+	// `check --fail-on pending` gate cry wolf on a perfectly healthy session.
+	Listening
 )
 
 func (s CallState) String() string {
@@ -44,6 +51,8 @@ func (s CallState) String() string {
 		return "failed"
 	case Superseded:
 		return "superseded"
+	case Listening:
+		return "listening"
 	default:
 		return "pending"
 	}
@@ -177,6 +186,12 @@ type event struct {
 	call               *call  // set for request/response events
 	taskCall           *call  // originating call for a task lifecycle frame
 	taskID             string
+	// subscriptionID is the id of the subscriptions/listen request a frame
+	// belongs to, and subscriptionCall that originating call. Set on stream
+	// notifications carrying the id in _meta and on the notifications/cancelled
+	// the server sends to terminate the stream.
+	subscriptionID   string
+	subscriptionCall *call
 	// mrtrRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised. Empty on an ordinary request.
 	mrtrRoot string
@@ -416,7 +431,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.requests++
 		if reused {
 			ev.warning = appendWarning(ev.warning, "request reuses an id already in flight")
-		} else {
+		} else if ev.call.state == Pending {
+			// A subscriptions/listen call opens Listening, not Pending, so it never
+			// joins the counter the TUI header and check --fail-on pending gate on.
 			sess.pending++
 		}
 		if msg.Method == "initialize" {
@@ -436,6 +453,29 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 						sess.errors++
 					}
 				}
+			}
+		}
+		// A notification delivered on a subscription stream names its listen
+		// request in _meta, so attach the originating call the way task lifecycle
+		// frames do, and the whole stream reads as one operation.
+		if subID := metaSubscriptionID(msg.Params); subID != "" {
+			if c := sess.listenCall(opposite(e.Direction), subID); c != nil {
+				ev.subscriptionID = subID
+				ev.subscriptionCall = c
+			}
+		}
+		// On stdio the server terminates a subscription stream by sending
+		// notifications/cancelled for the listen request. That is the stream
+		// closing, not a client abandoning its own call, so settle the call as
+		// completed rather than leave it listening forever. Looked up in the
+		// opposite direction, which is exactly the server-referencing-the-peer's-
+		// request case; a client cancelling its own request keeps today's meaning.
+		if msg.Method == "notifications/cancelled" {
+			if c := sess.listenCall(opposite(e.Direction), cancelledRequestID(msg.Params)); c != nil {
+				c.state = Completed
+				c.end = e.TS
+				ev.subscriptionID = c.id
+				ev.subscriptionCall = c
 			}
 		}
 	default:
@@ -614,6 +654,11 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		c.isTool = true
 		c.toolName = toolName(msg.Params)
 	}
+	if msg.Method == "subscriptions/listen" {
+		// A stream-opening request whose response arrives only when the stream
+		// ends, so it gets its own state instead of a pending slot.
+		c.state = Listening
+	}
 	if isTaskMethod(msg.Method) {
 		c.taskID = taskID(msg.Params)
 	}
@@ -631,9 +676,12 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 	if c == nil {
 		return nil, false // unmatched response (request missed or before backfill)
 	}
-	if c.state != Pending {
+	if c.state != Pending && c.state != Listening {
 		return c, false // already answered, a duplicate or late response must not recount
 	}
+	// A Listening call was never counted pending, so its eventual response, the
+	// stream ending, must not decrement the counter it never incremented.
+	wasListening := c.state == Listening
 	if c.method == "tools/call" && c.taskID != "" {
 		return c, false // the task handle already continued this call
 	}
@@ -671,7 +719,9 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, ts time.Ti
 	default:
 		c.state = Completed
 	}
-	sess.pending--
+	if !wasListening {
+		sess.pending--
+	}
 	switch c.method {
 	case "initialize":
 		sess.caps.applyResponse(msg.Result)
@@ -709,6 +759,56 @@ func taskID(params json.RawMessage) string {
 	}
 	_ = json.Unmarshal(params, &p)
 	return p.TaskID
+}
+
+// listenCall returns the still-open subscriptions/listen call an id references,
+// or nil. Gated on the method and the Listening state, so an id that happens to
+// collide with an ordinary call can never be linked to, or closed from, a
+// stream notification.
+func (sess *session) listenCall(dir proxy.Direction, id string) *call {
+	if id == "" {
+		return nil
+	}
+	c := sess.calls[callKey{dir: dir, id: id}]
+	if c == nil || c.method != "subscriptions/listen" || c.state != Listening {
+		return nil
+	}
+	return c
+}
+
+// metaSubscriptionID returns the listen request a stream notification names in
+// its _meta (io.modelcontextprotocol/subscriptionId), or "" when absent. Kept
+// as the raw JSON bytes rather than decoded, because the value is the JSON-RPC
+// id of the listen request and that is exactly how call ids are keyed: 7 and
+// "7" are different ids and must stay different here too.
+func metaSubscriptionID(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var p struct {
+		Meta struct {
+			SubscriptionID json.RawMessage `json:"io.modelcontextprotocol/subscriptionId"`
+		} `json:"_meta"`
+	}
+	if json.Unmarshal(params, &p) != nil {
+		return ""
+	}
+	return string(p.Meta.SubscriptionID)
+}
+
+// cancelledRequestID returns the id a notifications/cancelled names, raw for
+// the same reason as metaSubscriptionID.
+func cancelledRequestID(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var p struct {
+		RequestID json.RawMessage `json:"requestId"`
+	}
+	if json.Unmarshal(params, &p) != nil {
+		return ""
+	}
+	return string(p.RequestID)
 }
 
 func (sess *session) applyTaskState(taskID string, raw json.RawMessage, ts time.Time) (*call, bool) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1938,3 +1938,105 @@ func TestResultTypeSurvivesAnMRTRRetry(t *testing.T) {
 		t.Fatalf("the retry's answer is judged by the retry's own revision: %q", ev.Warning)
 	}
 }
+
+// A subscriptions/listen request opens a long-lived stream whose response
+// arrives only when the stream ends, which may be hours later or never
+// (2026-07-28). It must read as its own Listening state rather than a hung
+// pending call, so the PENDING timer and check --fail-on pending stay
+// trustworthy on a healthy session.
+func TestListenOpensAStreamNotAPendingCall(t *testing.T) {
+	s := New()
+	ev := s.Ingest(req(1, time.Now(), proxy.ClientToServer, "1", "subscriptions/listen", `{}`))
+
+	if ev.Call == nil || ev.Call.State != Listening {
+		t.Fatalf("call = %+v, want Listening", ev.Call)
+	}
+	if ev.Call.Done() {
+		t.Fatal("an open stream has no response yet, so Done() must be false and its duration live")
+	}
+	if header := s.Sessions()[0]; header.Pending != 0 {
+		t.Fatalf("an open stream is not a pending call, pending = %d", header.Pending)
+	}
+}
+
+// Notifications delivered on the stream carry the listen request's id in
+// _meta, so they correlate back to the listen call and the stream reads as one
+// operation, the way task lifecycle frames already do.
+func TestListenStreamNotificationsCorrelateToTheListenCall(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "subscriptions/listen", `{}`))
+
+	ev := s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Second), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/resources/updated",` +
+			`"params":{"uri":"file:///a.txt","_meta":{"io.modelcontextprotocol/subscriptionId":1}}}`)})
+	if ev.SubscriptionID != "1" {
+		t.Fatalf("subscription id = %q, want 1", ev.SubscriptionID)
+	}
+	if ev.SubscriptionCall == nil || ev.SubscriptionCall.Method != "subscriptions/listen" {
+		t.Fatalf("stream notification not linked to its listen call: %+v", ev.SubscriptionCall)
+	}
+
+	// A notification without the meta stays a plain notification.
+	plain := s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: t0.Add(2 * time.Second), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"file:///b.txt"}}`)})
+	if plain.SubscriptionID != "" || plain.SubscriptionCall != nil {
+		t.Fatalf("an unrelated notification must not be linked: %+v", plain)
+	}
+}
+
+// On stdio the server ends the stream by sending notifications/cancelled for
+// the listen request's id. That is the stream closing, not an error and not a
+// client cancelling its own call, so it settles the listen call as completed.
+func TestServerCancelledClosesTheListenStream(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "subscriptions/listen", `{}`))
+
+	ev := s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Hour), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}`)})
+
+	if ev.SubscriptionCall == nil || ev.SubscriptionCall.State != Completed {
+		t.Fatalf("stream close = %+v, want a Completed listen call", ev.SubscriptionCall)
+	}
+	if got := ev.SubscriptionCall.End.Sub(ev.SubscriptionCall.Start); got != time.Hour {
+		t.Fatalf("stream duration = %v, want the stream's whole life (1h)", got)
+	}
+	header := s.Sessions()[0]
+	if header.Pending != 0 || header.Errors != 0 {
+		t.Fatalf("a closed stream is neither pending nor an error, got pending=%d errors=%d", header.Pending, header.Errors)
+	}
+}
+
+// A notifications/cancelled naming an ordinary in-flight call keeps today's
+// meaning: the call stays pending, only a Listening call is ever closed by it.
+func TestServerCancelledLeavesOrdinaryCallsAlone(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+
+	s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Second), Direction: proxy.ServerToClient,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}`)})
+
+	if header := s.Sessions()[0]; header.Pending != 1 {
+		t.Fatalf("an ordinary cancelled call keeps its pending slot, pending = %d", header.Pending)
+	}
+}
+
+// When the stream's response finally arrives, hours later or at shutdown, it
+// completes the listen call without touching the pending counter it never
+// joined, so an unrelated in-flight call is still accounted for.
+func TestListenResponseCompletesTheStreamWithoutUnderflowingPending(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "subscriptions/listen", `{}`))
+	s.Ingest(req(2, t0, proxy.ClientToServer, "2", "tools/list", ""))
+
+	ev := s.Ingest(resp(3, t0.Add(time.Minute), proxy.ServerToClient, "1", `"result":{"resultType":"subscription_events"}`))
+	if ev.Call == nil || ev.Call.State != Completed {
+		t.Fatalf("stream end = %+v, want Completed", ev.Call)
+	}
+	if header := s.Sessions()[0]; header.Pending != 1 {
+		t.Fatalf("the tools/list call is still in flight, pending = %d", header.Pending)
+	}
+}

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -42,8 +42,10 @@ type CallView struct {
 // alongside an error or a tool error.
 func (c CallView) Failed() bool { return c.Err != nil || c.ToolErr || c.State == Failed }
 
-// Done reports whether a response has arrived.
-func (c CallView) Done() bool { return c.State != Pending }
+// Done reports whether a response has arrived. A Listening call has not had
+// one yet by design, so it stays live and Duration keeps counting, the same as
+// a pending call.
+func (c CallView) Done() bool { return c.State != Pending && c.State != Listening }
 
 // Duration is the request→response latency, or elapsed-so-far if still pending.
 func (c CallView) Duration() time.Duration {
@@ -92,6 +94,13 @@ type EventView struct {
 	Call       *CallView // set for request/response events
 	TaskCall   *CallView // originating call for a tasks/* lifecycle frame
 	TaskID     string
+	// SubscriptionID is the subscriptions/listen request this frame belongs to,
+	// and SubscriptionCall that originating call. Set on stream notifications
+	// carrying _meta io.modelcontextprotocol/subscriptionId and on the
+	// notifications/cancelled the server sends to terminate the stream, so the
+	// whole stream reads as one operation (2026-07-28).
+	SubscriptionID   string
+	SubscriptionCall *CallView
 	// MRTRRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
 	MRTRRoot string
@@ -359,6 +368,7 @@ func (e *event) view(_ *session) EventView {
 		Truncated:          e.truncated,
 		Deprecated:         e.deprecated,
 		TaskID:             e.taskID,
+		SubscriptionID:     e.subscriptionID,
 		MRTRRoot:           e.mrtrRoot,
 		MRTRStateIssue:     e.mrtrStateIssue,
 	}
@@ -369,6 +379,10 @@ func (e *event) view(_ *session) EventView {
 	if e.taskCall != nil {
 		cv := e.taskCall.view()
 		v.TaskCall = &cv
+	}
+	if e.subscriptionCall != nil {
+		cv := e.subscriptionCall.view()
+		v.SubscriptionCall = &cv
 	}
 	return v
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1145,6 +1145,10 @@ func (m *Model) matchStatus(e store.EventView, v string) bool {
 		return e.Call.TaskStatus == "cancelled"
 	case "pending", "pend", "inflight":
 		return e.Call.State == store.Pending
+	case "listening", "listen":
+		// An open subscription stream. Deliberately not under status:pending,
+		// since not being a pending call is its whole point.
+		return e.Call.State == store.Listening
 	case "ok", "success":
 		return e.Call.State == store.Completed && !e.Call.Failed()
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1726,3 +1726,27 @@ func TestStreamRowLeavesAnImplementationCodeUnnamed(t *testing.T) {
 		t.Fatalf("an implementation-defined code should render bare, got %q", got)
 	}
 }
+
+// An open subscriptions/listen stream must read "listening", not wear the
+// hung-call pending status, and status:listening finds it while status:pending
+// deliberately does not.
+func TestStreamRowShowsListeningStatusForOpenStream(t *testing.T) {
+	st := store.New()
+	st.Ingest(env(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"subscriptions/listen","params":{}}`))
+
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // into the stream
+
+	if len(m.full) == 0 || m.full[0].Call == nil || m.full[0].Call.State != store.Listening {
+		t.Fatalf("first frame should be a listening call, got %+v", m.full[0].Call)
+	}
+	if got := m.streamCells(m.full[0]).status; got != "listening" {
+		t.Fatalf("open stream status = %q, want listening", got)
+	}
+	if !m.matchToken(m.full[0], "status:listening") {
+		t.Fatal("status:listening did not match the open stream")
+	}
+	if m.matchToken(m.full[0], "status:pending") {
+		t.Fatal("status:pending must not match a healthy open stream")
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -578,10 +578,11 @@ func (m Model) streamRow(e store.EventView, lay streamLayout) []cell {
 	return segs
 }
 
-// durStyle colors the DUR value. It only turns cyan for a live pending timer and
-// is dim otherwise, so latency reads as a plain number, not a verdict.
+// durStyle colors the DUR value. It only turns cyan for a live timer, a pending
+// call or an open subscription stream, and is dim otherwise, so latency reads
+// as a plain number, not a verdict.
 func (m Model) durStyle(e store.EventView) lipgloss.Style {
-	if e.Call != nil && e.Call.State == store.Pending {
+	if e.Call != nil && (e.Call.State == store.Pending || e.Call.State == store.Listening) {
 		return m.styles.pending
 	}
 	return m.styles.dim
@@ -646,6 +647,11 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			if e.Call.State == store.Pending {
 				c.status = "pending"
 				c.dur = m.spinnerFrame() + " " + e.Call.Duration().Round(100*time.Millisecond).String()
+			} else if e.Call.State == store.Listening {
+				// An open subscription stream is healthy by design, so it must not
+				// wear the hung-call PENDING timer; that signal stays trustworthy.
+				c.status = "listening"
+				c.dur = m.spinnerFrame() + " " + e.Call.Duration().Round(time.Second).String()
 			} else if e.Call.State == store.Superseded {
 				// Its id was reused while in flight, so it will never be answered.
 				c.status = "superseded"
@@ -876,6 +882,8 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 		switch {
 		case e.Call.State == store.Pending:
 			return m.styles.pending
+		case e.Call.State == store.Listening:
+			return m.styles.pending // live like an in-flight timer, but reads "listening"
 		case e.Call.State == store.Superseded:
 			return m.styles.warn // never answered, not a success
 		case e.Call.Failed():
@@ -1128,6 +1136,9 @@ func (m Model) pairWidget() string {
 		cur := m.styles.infoVal.Render(fmt.Sprintf("req %d", e.Seq))
 		if e.Call.State == store.Pending {
 			return cur + arrow + m.styles.pending.Render("pending")
+		}
+		if e.Call.State == store.Listening {
+			return cur + arrow + m.styles.pending.Render("listening")
 		}
 		if pi, ok := m.pairIndex(m.inspect); ok {
 			return cur + arrow + m.styles.req.Render(fmt.Sprintf("resp %d", m.full[pi].Seq))


### PR DESCRIPTION
## What

The 2026-07-28 revision replaced `resources/subscribe` and the standalone GET stream with a single long-lived `subscriptions/listen` request whose response arrives only when the stream ends, which may be hours later or never. `openCall` treated it as an ordinary request, so:

- the TUI rendered a healthy stream as a hung call with a live `PENDING` timer, which is exactly the signal the hung-call feature exists to keep trustworthy;
- `mcpsnoop check --fail-on pending` failed a perfectly healthy session;
- `session.pending` was permanently off by one per open stream.

## How

- A `subscriptions/listen` request now opens in its own `Listening` call state. It never joins the pending counter, the stream row reads `listening` (cyan, with a live elapsed timer), and `status:listening` finds it while `status:pending` deliberately does not.
- Notifications delivered on the stream carry the listen request's id in `params._meta["io.modelcontextprotocol/subscriptionId"]`; they now correlate back to the listen call through new `SubscriptionID`/`SubscriptionCall` event fields, the way MRTR retries and task-backed calls already read as one operation. The id is compared as raw JSON bytes, since it is the JSON-RPC id of the listen request and that is how call ids are keyed.
- On stdio the server terminates the stream by sending `notifications/cancelled` referencing the listen id. That now settles the listen call as completed (its duration spanning the stream's whole life) rather than reading as a client cancelling its own request. The lookup is gated on the method and the `Listening` state, so an ordinary cancelled call keeps today's meaning.
- The eventual response completes the call without decrementing the pending counter it never incremented, so an unrelated in-flight call stays accounted for.
- Exports agree: the JSON/HAR/HTML status is `listening`, and the HTML filter and request-row status surface it like the TUI.

## Tests

- store: listen opens Listening not pending; stream notifications link to the listen call; server-sent `notifications/cancelled` closes the stream without counting an error; an ordinary call named by `notifications/cancelled` stays pending; the late response completes the stream without underflowing the pending counter.
- check: `--fail-on pending` passes over an open stream and still fails on a genuinely hung call.
- tui: the stream row reads `listening`, matched by `status:listening` and not by `status:pending`.

`gofmt`, `go vet ./...`, and `go test ./...` are clean.

Closes #150
