### PR TITLE
fix(cli): reject --label values that escape the state dir

### DIFF
--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -198,11 +198,15 @@ func redactConfig(commonSecrets bool, keys redactKeysFlag, values redactValuesFl
 
 func main() { os.Exit(execute(os.Args[1:])) }
 
-// runShimFn and runHubFn are indirected so tests can check how the root command
-// routes the wrapped command without spawning a server or launching the TUI.
+// runShimFn, runHubFn and runHTTPFn are indirected so tests can check how a
+// command routes without spawning a server, launching the TUI, or binding a
+// port. The http seam matters most: without it a test that reaches RunHTTP
+// binds the real --listen address and blocks until the package timeout, which
+// fails the whole package rather than the one test.
 var (
 	runShimFn = runShim
 	runHubFn  = runHub
+	runHTTPFn = proxy.RunHTTP
 )
 
 // exitCode carries a command's process exit code out through cobra's error
@@ -601,7 +605,7 @@ func newHTTPCmd() *cobra.Command {
 			defer stop()
 
 			fmt.Fprintf(os.Stderr, "mcpsnoop: proxying %s → %s (session %s)\n", listen, target, sessionID)
-			if err := proxy.RunHTTP(ctx, proxy.HTTPConfig{
+			if err := runHTTPFn(ctx, proxy.HTTPConfig{
 				Listen:    listen,
 				Target:    target,
 				Label:     lbl,

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -273,6 +273,12 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				return exitCode(1)
 			}
 			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths)
+			// After applyConfig, so a label from a shared .mcpsnoop.toml is held
+			// to the same rule as the flag.
+			if err := paths.CheckLabel(label); err != nil {
+				fmt.Fprintln(os.Stderr, "mcpsnoop:", err)
+				return exitCode(2)
+			}
 			trace, err := parseTraceOptions(otlpEndpoint, otlpHeaders)
 			if err != nil {
 				return err
@@ -566,6 +572,10 @@ func newHTTPCmd() *cobra.Command {
 				return exitCode(1)
 			}
 			applyConfig(cmd.Flags(), cfg, ok, &label, nil, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths)
+			if err := paths.CheckLabel(label); err != nil {
+				fmt.Fprintln(os.Stderr, "mcpsnoop http:", err)
+				return exitCode(2)
+			}
 			if target == "" {
 				fmt.Fprintln(os.Stderr, "mcpsnoop http: --target is required")
 				return exitCode(2)

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -150,6 +151,66 @@ func TestRootWithoutDashDashStopsAtFirstPositional(t *testing.T) {
 	want := []string{"node", "server.js", "--inspect"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("wrapped command = %v, want %v", got, want)
+	}
+}
+
+// A label names files: it flows verbatim into the session id and so into the
+// trace path under SessionsDir, so `--label ../../evil` would write the trace
+// outside the state dir and produce a session `open` cannot find again. It must
+// be rejected up front with a clear error, not sanitised into a different label
+// that would silently re-key the tool baseline.
+func TestRootRejectsPathHostileLabel(t *testing.T) {
+	for _, label := range []string{"../../evil", "srv/one", `srv\one`, "nul\x00label"} {
+		var got []string
+		restore := stubShim(&got)
+
+		code := execute([]string{"--label", label, "--", "node", "server.js"})
+		restore()
+		if code != 2 {
+			t.Fatalf("--label %q exit = %d, want 2", label, code)
+		}
+		if got != nil {
+			t.Fatalf("the shim must not run under a rejected label %q, ran %v", label, got)
+		}
+	}
+
+	// An ordinary label still wraps the command.
+	var got []string
+	defer stubShim(&got)()
+	if code := execute([]string{"--label", "server-everything", "--", "node", "server.js"}); code != 0 {
+		t.Fatalf("exit = %d, want 0 for a plain label", code)
+	}
+}
+
+// The same rule holds for a label read from .mcpsnoop.toml, which is exactly
+// the generated-or-shared file the check exists for.
+func TestRootRejectsPathHostileLabelFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".mcpsnoop.toml"), []byte("label = \"../../evil\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	var got []string
+	defer stubShim(&got)()
+	if code := execute([]string{"--", "node", "server.js"}); code != 2 {
+		t.Fatalf("exit = %d, want 2 for a hostile config label", code)
+	}
+	if got != nil {
+		t.Fatalf("the shim must not run under a rejected config label, ran %v", got)
+	}
+}
+
+func TestHTTPRejectsPathHostileLabel(t *testing.T) {
+	cmd := newHTTPCmd()
+	cmd.SetArgs([]string{"--label", "../../evil", "--target", "http://localhost:1/mcp"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	var code exitCode
+	if !errors.As(err, &code) || int(code) != 2 {
+		t.Fatalf("http --label ../../evil = %v, want exit code 2", err)
 	}
 }
 

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -201,7 +202,16 @@ func TestRootRejectsPathHostileLabelFromConfig(t *testing.T) {
 	}
 }
 
+// TestHTTPRejectsPathHostileLabel checks the http command applies the same rule
+// as the shim. It stubs the proxy rather than letting the command reach
+// RunHTTP: without the stub, a run where the check fails to fire binds the real
+// listen address and blocks until the package timeout, so the test that is meant
+// to report one bad label instead takes the whole package down with it.
 func TestHTTPRejectsPathHostileLabel(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	ran := false
+	defer stubHTTP(&ran)()
+
 	cmd := newHTTPCmd()
 	cmd.SetArgs([]string{"--label", "../../evil", "--target", "http://localhost:1/mcp"})
 	cmd.SilenceErrors = true
@@ -212,6 +222,19 @@ func TestHTTPRejectsPathHostileLabel(t *testing.T) {
 	if !errors.As(err, &code) || int(code) != 2 {
 		t.Fatalf("http --label ../../evil = %v, want exit code 2", err)
 	}
+	if ran {
+		t.Fatal("a rejected label must be refused before the proxy starts")
+	}
+}
+
+// stubHTTP replaces the proxy runner and returns a function restoring it.
+func stubHTTP(ran *bool) func() {
+	prev := runHTTPFn
+	runHTTPFn = func(context.Context, proxy.HTTPConfig) error {
+		*ran = true
+		return nil
+	}
+	return func() { runHTTPFn = prev }
 }
 
 func TestRootNoArgsRunsHubNotShim(t *testing.T) {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // maxSocketPathLen is a conservative unix-domain socket path limit. sun_path is
@@ -29,6 +30,27 @@ func CheckSocketPath(path string) error {
 	if len(path) > maxSocketPathLen {
 		return fmt.Errorf("socket path %q is %d bytes, over the %d-byte unix socket limit; set a shorter MCPSNOOP_HOME",
 			path, len(path), maxSocketPathLen)
+	}
+	return nil
+}
+
+// CheckLabel returns an actionable error when a label cannot safely name files
+// under the state directory. An explicit --label flows verbatim into the
+// session id and from there into SessionLogPath's file name, so a path
+// separator or a ".." would write the trace outside SessionsDir, and either
+// way produces a session that open and export cannot address again. labelFor
+// already strips separators when it derives a label from the wrapped command;
+// this is the same guarantee for the label the user supplies. Rejecting rather
+// than sanitising is deliberate: --label is documented as needing to be stable
+// and unique for baselines, and a silently rewritten label is neither.
+func CheckLabel(label string) error {
+	switch {
+	case strings.ContainsAny(label, `/\`):
+		return fmt.Errorf("label %q contains a path separator; a label names files under the mcpsnoop state dir", label)
+	case strings.Contains(label, ".."):
+		return fmt.Errorf("label %q contains %q; a label names files under the mcpsnoop state dir", label, "..")
+	case strings.ContainsRune(label, 0):
+		return fmt.Errorf("label contains a NUL byte; a label names files under the mcpsnoop state dir")
 	}
 	return nil
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 // maxSocketPathLen is a conservative unix-domain socket path limit. sun_path is
@@ -34,25 +35,62 @@ func CheckSocketPath(path string) error {
 	return nil
 }
 
+// maxLabelLen bounds a label so the file name it ends up in stays within the
+// 255-byte limit every mainstream filesystem enforces. The label is only part of
+// that name: newSessionID appends a pid and a nonce, and SessionLogPath appends
+// ".jsonl", so the budget has to leave room for both. 200 is comfortably clear
+// of the boundary, which matters because the pid width varies, so an unbounded
+// label can be accepted on one run and rejected on the next.
+//
+// Without this the failure is silent rather than loud. OpenFile returns
+// ENAMETOOLONG, the trace sink warns once and carries on, the process exits 0,
+// and the whole session goes unrecorded.
+const maxLabelLen = 200
+
 // CheckLabel returns an actionable error when a label cannot safely name files
 // under the state directory. An explicit --label flows verbatim into the
 // session id and from there into SessionLogPath's file name, so a path
-// separator or a ".." would write the trace outside SessionsDir, and either
-// way produces a session that open and export cannot address again. labelFor
-// already strips separators when it derives a label from the wrapped command;
-// this is the same guarantee for the label the user supplies. Rejecting rather
-// than sanitising is deliberate: --label is documented as needing to be stable
-// and unique for baselines, and a silently rewritten label is neither.
+// separator would write the trace outside SessionsDir, and the other cases here
+// produce a session that open and export cannot address again. labelFor already
+// strips separators when it derives a label from the wrapped command; this is
+// the same guarantee for the label the user supplies. Rejecting rather than
+// sanitising is deliberate: --label is documented as needing to be stable and
+// unique for baselines, and a silently rewritten label is neither.
+//
+// ".." is deliberately NOT rejected. Once separators are banned it cannot
+// traverse anything, and newSessionID always appends "-<pid>-<nonce>", so the
+// id is never the bare ".." that a Join would resolve. Rejecting it would turn
+// away ordinary values like "v1..v2" and "foo..bar" for no gain, and refusing
+// correct input is the failure mode this project keeps having to undo.
 func CheckLabel(label string) error {
 	switch {
 	case strings.ContainsAny(label, `/\`):
 		return fmt.Errorf("label %q contains a path separator; a label names files under the mcpsnoop state dir", label)
-	case strings.Contains(label, ".."):
-		return fmt.Errorf("label %q contains %q; a label names files under the mcpsnoop state dir", label, "..")
 	case strings.ContainsRune(label, 0):
 		return fmt.Errorf("label contains a NUL byte; a label names files under the mcpsnoop state dir")
+	case containsControl(label):
+		// A control character reaches the file name and the startup banner raw. A
+		// carriage return in particular rewrites the line the user is reading, so
+		// the banner can name a label the session does not have. The OTLP header
+		// flag already refuses CR and LF for the same reason.
+		return fmt.Errorf("label %q contains a control character; a label names files under the mcpsnoop state dir", label)
+	case strings.HasPrefix(label, "-"):
+		// The label becomes the session id, and the id is a positional argument to
+		// open, export and diff. One starting with a dash is parsed as a flag
+		// there, so the session can be recorded and then never addressed again,
+		// which is the harm this check exists to prevent.
+		return fmt.Errorf("label %q starts with a dash; the session id it forms would parse as a flag in mcpsnoop open and export", label)
+	case len(label) > maxLabelLen:
+		return fmt.Errorf("label is %d bytes, over the %d-byte limit; the session id it forms must still fit a file name", len(label), maxLabelLen)
 	}
 	return nil
+}
+
+// containsControl reports whether s holds a C0 or C1 control character. unicode
+// .IsControl covers both, which matters because a lone C1 byte is as damaging in
+// a terminal as an ESC.
+func containsControl(s string) bool {
+	return strings.ContainsFunc(s, unicode.IsControl)
 }
 
 // Base returns the mcpsnoop state directory, creating it if needed.

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -22,6 +22,36 @@ func TestCheckSocketPathExplainsOverLongPath(t *testing.T) {
 	}
 }
 
+// CheckLabel guards the one hole labelFor already closes for derived labels: an
+// explicit --label flows verbatim into the session id and so into the trace
+// file name, where a separator or ".." escapes SessionsDir entirely.
+func TestCheckLabelRejectsPathHostileValues(t *testing.T) {
+	bad := []string{
+		"../../evil",
+		"a/b",
+		`a\b`,
+		"..",
+		"prod..",
+		"nul\x00label",
+	}
+	for _, label := range bad {
+		err := CheckLabel(label)
+		if err == nil {
+			t.Fatalf("CheckLabel(%q) = nil, want an error", label)
+		}
+		if !strings.Contains(err.Error(), "state dir") {
+			t.Fatalf("CheckLabel(%q) = %q, the error should say why the label names files", label, err)
+		}
+	}
+	// The file name still holds real labels: dots, spaces, unicode, and an empty
+	// label (which means "derive one from the command") all pass.
+	for _, label := range []string{"", "server-everything", "index.js", "my server", "café", "v1.2.3"} {
+		if err := CheckLabel(label); err != nil {
+			t.Fatalf("CheckLabel(%q) = %v, want nil", label, err)
+		}
+	}
+}
+
 func TestToolBaselinesDirUsesConfiguredStateRoot(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("MCPSNOOP_HOME", root)

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -24,30 +24,59 @@ func TestCheckSocketPathExplainsOverLongPath(t *testing.T) {
 
 // CheckLabel guards the one hole labelFor already closes for derived labels: an
 // explicit --label flows verbatim into the session id and so into the trace
-// file name, where a separator or ".." escapes SessionsDir entirely.
+// file name, where a separator escapes SessionsDir entirely and the other cases
+// leave a session that open and export cannot address again.
 func TestCheckLabelRejectsPathHostileValues(t *testing.T) {
-	bad := []string{
-		"../../evil",
-		"a/b",
-		`a\b`,
-		"..",
-		"prod..",
-		"nul\x00label",
-	}
-	for _, label := range bad {
-		err := CheckLabel(label)
+	for _, tc := range []struct{ label, why string }{
+		{"../../evil", "traversal"},
+		{"a/b", "unix separator"},
+		{`a\b`, "windows separator"},
+		{"nul\x00label", "NUL reaches the file name"},
+		{"a\nb", "newline reaches the file name and the banner"},
+		{"a\rb", "a carriage return rewrites the banner line"},
+		{"red\x1b[31mX", "an escape sequence drives the terminal"},
+		{"-rf", "a leading dash parses as a flag in open and export"},
+		{strings.Repeat("a", maxLabelLen+1), "over the file name budget"},
+	} {
+		err := CheckLabel(tc.label)
 		if err == nil {
-			t.Fatalf("CheckLabel(%q) = nil, want an error", label)
-		}
-		if !strings.Contains(err.Error(), "state dir") {
-			t.Fatalf("CheckLabel(%q) = %q, the error should say why the label names files", label, err)
+			t.Fatalf("CheckLabel(%q) = nil, want an error (%s)", tc.label, tc.why)
 		}
 	}
-	// The file name still holds real labels: dots, spaces, unicode, and an empty
-	// label (which means "derive one from the command") all pass.
-	for _, label := range []string{"", "server-everything", "index.js", "my server", "café", "v1.2.3"} {
+
+	// The file name still holds real labels. Dots, spaces, unicode and an empty
+	// label (which means "derive one from the command") all pass, and so does a
+	// doubled dot: once separators are banned it cannot traverse, and refusing it
+	// would turn away ordinary version strings. This is the case the two
+	// competing fixes for this issue disagreed on, so it is pinned here.
+	for _, label := range []string{
+		"", "server-everything", "index.js", "my server", "café", "v1.2.3",
+		"...", "foo..bar", "v1..v2", "prod..", "..",
+		strings.Repeat("a", maxLabelLen),
+	} {
 		if err := CheckLabel(label); err != nil {
 			t.Fatalf("CheckLabel(%q) = %v, want nil", label, err)
+		}
+	}
+}
+
+// TestCheckLabelKeepsADoubledDotContained is the reason "\u002e\u002e" is accepted rather
+// than refused. The predicate alone does not prove containment, so this walks the
+// value through the real path builder the way a session does.
+func TestCheckLabelKeepsADoubledDotContained(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", root)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	for _, label := range []string{"..", "...", "foo..bar"} {
+		// newSessionID appends "-<pid>-<nonce>", which is what makes the id safe.
+		sessionID := label + "-4242-deadbeefcafe"
+		got := SessionLogPath(sessionID)
+		if want := filepath.Join(SessionsDir(), sessionID+".jsonl"); got != want {
+			t.Fatalf("SessionLogPath(%q) = %q, want %q", sessionID, got, want)
+		}
+		if !strings.HasPrefix(filepath.Clean(got), filepath.Clean(SessionsDir())+string(filepath.Separator)) {
+			t.Fatalf("label %q escaped the sessions dir: %s", label, got)
 		}
 	}
 }


### PR DESCRIPTION
## What

`labelFor` strips path separators when it derives a label from the wrapped command, but an explicit `--label` was used verbatim. The label flows into the session id and from there into `paths.SessionLogPath`'s file name, so `mcpsnoop --label ../../evil -- node server.js` wrote its trace outside the sessions directory, and any label with a separator silently produced a session that `mcpsnoop open <id>` could not find again. Same for `mcpsnoop http --label`, and for a label read from a generated or shared `.mcpsnoop.toml`.

## How

`paths.CheckLabel` rejects labels containing path separators, `..`, or a NUL byte with a clear, actionable error, following the `CheckSocketPath` precedent of validating in the package that owns the paths. Both the root command and `http` validate after `applyConfig`, so a config-file label is held to the same rule as the flag, and the shim never starts under a bad label (exit 2, the usage-error code).

Rejecting rather than sanitising is deliberate: `--label` is documented as needing to be stable and unique for baselines, and a silently rewritten label is neither.

Ordinary labels are untouched: dots, spaces, and unicode still pass, and an empty label still falls back to deriving one from the command or target host.

## Tests

- paths: hostile values (`../../evil`, `a/b`, `a\b`, `..`, `prod..`, NUL) are rejected with an error that says why; realistic labels (`index.js`, `my server`, `café`, `v1.2.3`, empty) pass.
- cmd: the root command exits 2 and never runs the shim for a hostile `--label` or a hostile label from `.mcpsnoop.toml`; `http --label` is rejected the same way; a plain label still wraps the command.

`gofmt`, `go vet ./...`, and `go test ./...` are clean.

Closes #155
