### PR TITLE
feat(export): redact captured sessions on read

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,12 +284,19 @@ mcpsnoop export session.jsonl --redact-secrets --redact-key project_token -o sha
 mcpsnoop open session.jsonl --redact-path '$.params.arguments.password'
 ```
 
-These flags redact JSON-RPC payloads and stderr or other non-JSON text in the
-exported file or the in-memory TUI view. Envelope metadata such as server labels
-and captured HTTP headers is unchanged. The source JSONL is not rewritten, and
-`export` rejects an output that refers to the source file. Still use a separate
-output path, inspect the result before sharing it, and treat redaction as best
-effort.
+These flags rewrite the exported file or the in-memory TUI view, never the
+source JSONL. `export` refuses an output that names the same file as its input,
+and writes through a temporary file that is renamed into place, so a run that
+fails leaves the previous file whole.
+
+What each flag reaches differs, so check the result rather than assuming. All
+four scrub JSON-RPC payloads, and `--redact-key`, `--redact-path` and
+`--redact-secrets` reach only those. Only `--redact-value` also scrubs stderr,
+other non-JSON text, and the inside of a string. An `Mcp-Param-*` header is
+scrubbed alongside the body value it mirrors; the other envelope metadata,
+server labels, `Mcp-Name`, `Mcp-Method` and the HTTP status, is left as
+captured. Redaction is best effort, so use a separate output path and read the
+result before sharing it.
 
 ### Stream completed calls to an OTLP collector
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,21 @@ Omit `-o` to write to stdout, and omit the session to take the newest, or pass
 `-` to read JSONL from stdin. In the TUI, press `e` to export the selected
 session as HTML, or run `:export json|html|text|har|otlp [path]` from command mode.
 
+To scrub an existing capture before inspecting or sharing it, pass the same
+redaction flags used during capture to `export` or `open`:
+
+```bash
+mcpsnoop export session.jsonl --redact-secrets --redact-key project_token -o shared.json
+mcpsnoop open session.jsonl --redact-path '$.params.arguments.password'
+```
+
+These flags redact JSON-RPC payloads and stderr or other non-JSON text in the
+exported file or the in-memory TUI view. Envelope metadata such as server labels
+and captured HTTP headers is unchanged. The source JSONL is not rewritten, and
+`export` rejects an output that refers to the source file. Still use a separate
+output path, inspect the result before sharing it, and treat redaction as best
+effort.
+
 ### Stream completed calls to an OTLP collector
 
 Send spans while the proxy is running by pointing it at an OTLP/HTTP JSON

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -198,15 +198,16 @@ func redactConfig(commonSecrets bool, keys redactKeysFlag, values redactValuesFl
 
 func main() { os.Exit(execute(os.Args[1:])) }
 
-// runShimFn, runHubFn and runHTTPFn are indirected so tests can check how a
-// command routes without spawning a server, launching the TUI, or binding a
-// port. The http seam matters most: without it a test that reaches RunHTTP
-// binds the real --listen address and blocks until the package timeout, which
-// fails the whole package rather than the one test.
+// Runner functions are indirected so tests can check routing and loaded state
+// without spawning a server, launching the TUI, or binding a port. The HTTP
+// seam matters most: without it a test that reaches RunHTTP binds the real
+// --listen address and blocks until the package timeout, which fails the whole
+// package rather than the one test.
 var (
-	runShimFn = runShim
-	runHubFn  = runHub
-	runHTTPFn = proxy.RunHTTP
+	runShimFn    = runShim
+	runHubFn     = runHub
+	runHTTPFn    = proxy.RunHTTP
+	runOpenTUIFn = tui.RunOpen
 )
 
 // exitCode carries a command's process exit code out through cobra's error
@@ -416,7 +417,13 @@ func sessionNonce() string {
 
 // newExportCmd reads a persisted JSONL session and writes a portable export.
 func newExportCmd() *cobra.Command {
-	var formatFlag, outFlag string
+	var (
+		formatFlag, outFlag string
+		redactSecrets       bool
+		redactKeys          redactKeysFlag
+		redactValues        redactValuesFlag
+		redactPaths         redactPathsFlag
+	)
 	cmd := &cobra.Command{
 		Use:   "export [session-id|log.jsonl|-]",
 		Short: "Render a captured session to json, html, text, har, or otlp",
@@ -444,26 +451,57 @@ func newExportCmd() *cobra.Command {
 				}
 			}
 
+			var (
+				in     io.Reader
+				source string
+			)
+			if stdin {
+				in = cmd.InOrStdin()
+				source = "stdin"
+			} else {
+				f, err := os.Open(inPath)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+					return exitCode(1)
+				}
+				defer f.Close()
+				in = f
+				source = inPath
+			}
+
 			out := os.Stdout
 			if outFlag != "-" {
 				if err := os.MkdirAll(filepath.Dir(outFlag), 0o700); err != nil {
 					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
 					return exitCode(1)
 				}
-				f, err := os.OpenFile(outFlag, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+				f, err := os.OpenFile(outFlag, os.O_CREATE|os.O_WRONLY, 0o600)
 				if err != nil {
 					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
 					return exitCode(1)
 				}
 				defer f.Close()
+				same, err := sameOpenFile(in, f)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+					return exitCode(1)
+				}
+				if same {
+					fmt.Fprintln(os.Stderr, "mcpsnoop export: input and output refer to the same file")
+					return exitCode(1)
+				}
+				if err := f.Truncate(0); err != nil {
+					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+					return exitCode(1)
+				}
 				out = f
 			}
 
-			if stdin {
-				err = exporter.Export(cmd.InOrStdin(), "stdin", out, exporter.Options{Format: format})
-			} else {
-				err = exporter.ExportFile(inPath, out, exporter.Options{Format: format})
+			opts := exporter.Options{
+				Format:    format,
+				Redaction: redactConfig(redactSecrets, redactKeys, redactValues, redactPaths),
 			}
+			err = exporter.Export(in, source, out, opts)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
 				return exitCode(1)
@@ -474,7 +512,27 @@ func newExportCmd() *cobra.Command {
 	cmd.Flags().SortFlags = false
 	cmd.Flags().StringVarP(&formatFlag, "format", "T", "json", "output format, one of json, html, text, har, otlp")
 	cmd.Flags().StringVarP(&outFlag, "output", "o", "-", "output path, or - for stdout")
+	cmd.Flags().BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in captured JSON-RPC payloads")
+	cmd.Flags().Var(&redactKeys, "redact-key", "JSON key name to scrub in captured JSON-RPC payloads, repeat or comma-separated")
+	cmd.Flags().Var(&redactValues, "redact-value", "regular expression to scrub inside captured JSON-RPC string values, stderr, and non-JSON text, repeatable")
+	cmd.Flags().Var(&redactPaths, "redact-path", "JSONPath selecting values in captured JSON-RPC payloads to scrub, repeatable")
 	return cmd
+}
+
+func sameOpenFile(input io.Reader, output *os.File) (bool, error) {
+	inputFile, ok := input.(*os.File)
+	if !ok {
+		return false, nil
+	}
+	inputInfo, err := inputFile.Stat()
+	if err != nil {
+		return false, err
+	}
+	outputInfo, err := output.Stat()
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(inputInfo, outputInfo), nil
 }
 
 // runShim runs the transparent stdio proxy. It writes the durable session log
@@ -647,7 +705,13 @@ func runHub(historyLimit int) int {
 
 // newOpenCmd opens a persisted JSONL session directly in the TUI.
 func newOpenCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		redactSecrets bool
+		redactKeys    redactKeysFlag
+		redactValues  redactValuesFlag
+		redactPaths   redactPathsFlag
+	)
+	cmd := &cobra.Command{
 		Use:   "open [session-id|session.jsonl|-]",
 		Short: "Open a captured session in the TUI, or - to read from stdin",
 		Long:  "Open a captured session in the TUI. With no session, the newest session log is opened. Use - to read from stdin.",
@@ -657,13 +721,19 @@ func newOpenCmd() *cobra.Command {
 			if len(args) == 1 {
 				arg = args[0]
 			}
-			return codeOf(runOpen(arg))
+			return codeOf(runOpen(arg, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths)))
 		},
 	}
+	cmd.Flags().SortFlags = false
+	cmd.Flags().BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in captured JSON-RPC payloads")
+	cmd.Flags().Var(&redactKeys, "redact-key", "JSON key name to scrub in captured JSON-RPC payloads, repeat or comma-separated")
+	cmd.Flags().Var(&redactValues, "redact-value", "regular expression to scrub inside captured JSON-RPC string values, stderr, and non-JSON text, repeatable")
+	cmd.Flags().Var(&redactPaths, "redact-path", "JSONPath selecting values in captured JSON-RPC payloads to scrub, repeatable")
+	return cmd
 }
 
 // runOpen loads a session (id, path, or - for stdin) and shows it in the TUI.
-func runOpen(arg string) int {
+func runOpen(arg string, redaction proxy.RedactConfig) int {
 	inPath, usedStdin, err := resolveOpenSessionPath(arg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
@@ -683,10 +753,8 @@ func runOpen(arg string) int {
 		r = f
 	}
 
-	st := store.New()
-	if err := proxy.Decode(r, func(e proxy.Envelope) {
-		st.Ingest(e)
-	}); err != nil {
+	st, err := loadOpenStore(r, redaction)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 		return 1
 	}
@@ -705,13 +773,24 @@ func runOpen(arg string) int {
 			return 1
 		}
 	} else {
-		if err := tui.RunOpen(ctx, st); err != nil {
+		if err := runOpenTUIFn(ctx, st); err != nil {
 			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 			return 1
 		}
 	}
 
 	return 0
+}
+
+func loadOpenStore(r io.Reader, redaction proxy.RedactConfig) (*store.Store, error) {
+	st := store.New()
+	redactor := proxy.NewRedactor(redaction)
+	if err := proxy.Decode(r, func(e proxy.Envelope) {
+		st.Ingest(redactor.RedactEnvelope(e))
+	}); err != nil {
+		return nil, err
+	}
+	return st, nil
 }
 
 func resolveOpenSessionPath(arg string) (string, bool, error) {

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -469,19 +469,10 @@ func newExportCmd() *cobra.Command {
 				source = inPath
 			}
 
-			out := os.Stdout
+			var out io.Writer = os.Stdout
+			var target *exportTarget
 			if outFlag != "-" {
-				if err := os.MkdirAll(filepath.Dir(outFlag), 0o700); err != nil {
-					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
-					return exitCode(1)
-				}
-				f, err := os.OpenFile(outFlag, os.O_CREATE|os.O_WRONLY, 0o600)
-				if err != nil {
-					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
-					return exitCode(1)
-				}
-				defer f.Close()
-				same, err := sameOpenFile(in, f)
+				same, err := sameSource(in, inPath, outFlag)
 				if err != nil {
 					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
 					return exitCode(1)
@@ -490,21 +481,28 @@ func newExportCmd() *cobra.Command {
 					fmt.Fprintln(os.Stderr, "mcpsnoop export: input and output refer to the same file")
 					return exitCode(1)
 				}
-				if err := f.Truncate(0); err != nil {
+				target, err = openExportTarget(outFlag)
+				if err != nil {
 					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
 					return exitCode(1)
 				}
-				out = f
+				defer target.abort()
+				out = target
 			}
 
 			opts := exporter.Options{
 				Format:    format,
 				Redaction: redactConfig(redactSecrets, redactKeys, redactValues, redactPaths),
 			}
-			err = exporter.Export(in, source, out, opts)
-			if err != nil {
+			if err := exporter.Export(in, source, out, opts); err != nil {
 				fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
 				return exitCode(1)
+			}
+			if target != nil {
+				if err := target.commit(); err != nil {
+					fmt.Fprintln(os.Stderr, "mcpsnoop export:", err)
+					return exitCode(1)
+				}
 			}
 			return nil
 		},
@@ -519,20 +517,105 @@ func newExportCmd() *cobra.Command {
 	return cmd
 }
 
-func sameOpenFile(input io.Reader, output *os.File) (bool, error) {
-	inputFile, ok := input.(*os.File)
-	if !ok {
+// sameSource reports whether the export would write over the file it is reading.
+// Both sides are compared by stat, so two spellings of one path, a symlink and a
+// hard link all reach the same answer, and a stdin the shell redirected from a
+// real file is caught as well as a path given on the command line.
+//
+// A stdin arriving down a pipe cannot be traced back to a file, so this returns
+// false there and the answer for that case is elsewhere. The export is written
+// to a temporary file and renamed into place, which means the source is read in
+// full before the destination is touched, rather than being truncated out from
+// under the process still reading it.
+func sameSource(in io.Reader, inPath, outPath string) (bool, error) {
+	var (
+		inputInfo os.FileInfo
+		err       error
+	)
+	switch file, ok := in.(*os.File); {
+	case inPath != "":
+		inputInfo, err = os.Stat(inPath)
+	case ok:
+		inputInfo, err = file.Stat()
+	default:
 		return false, nil
 	}
-	inputInfo, err := inputFile.Stat()
 	if err != nil {
 		return false, err
 	}
-	outputInfo, err := output.Stat()
+	outputInfo, err := os.Stat(outPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	return os.SameFile(inputInfo, outputInfo), nil
+}
+
+// exportTarget is where an export is written. A regular file, or a path that
+// does not exist yet, is written through a temporary file beside it and renamed
+// into place once the whole export succeeded. That is what keeps a failed or
+// interrupted run from replacing a previous export with a stub, and it is the
+// only protection left when the source arrives down a pipe, since the same-file
+// check cannot see which file is behind stdin.
+//
+// Anything else, a device, a fifo, or the /dev/fd descriptor a shell builds for
+// `-o >(cmd)` and for `-o /dev/stdout` in a pipeline, is written straight
+// through. Those cannot be renamed over, and they cannot be truncated either,
+// which is what made an explicit Truncate refuse them with EINVAL where the
+// O_TRUNC it replaced had simply been ignored.
+type exportTarget struct {
+	file *os.File
+	temp string
+	dest string
+}
+
+func openExportTarget(path string) (*exportTarget, error) {
+	if info, err := os.Stat(path); err == nil && !info.Mode().IsRegular() {
+		file, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+		if err != nil {
+			return nil, err
+		}
+		return &exportTarget{file: file}, nil
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	// Created in the destination's own directory so the rename stays on one
+	// filesystem, and named with a leading dot so a half-written export does not
+	// look like a finished one to whatever is watching the directory.
+	file, err := os.CreateTemp(dir, ".mcpsnoop-export-*")
+	if err != nil {
+		return nil, err
+	}
+	return &exportTarget{file: file, temp: file.Name(), dest: path}, nil
+}
+
+func (t *exportTarget) Write(p []byte) (int, error) { return t.file.Write(p) }
+
+func (t *exportTarget) commit() error {
+	if err := t.file.Close(); err != nil {
+		return err
+	}
+	if t.temp == "" {
+		return nil
+	}
+	if err := os.Rename(t.temp, t.dest); err != nil {
+		return err
+	}
+	t.temp = ""
+	return nil
+}
+
+// abort is deferred unconditionally and does nothing once commit has run, so
+// every path out of the command cleans up after itself.
+func (t *exportTarget) abort() {
+	_ = t.file.Close()
+	if t.temp != "" {
+		_ = os.Remove(t.temp)
+	}
 }
 
 // runShim runs the transparent stdio proxy. It writes the durable session log

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -845,5 +846,134 @@ func assertRawTokenRedacted(t *testing.T, raw json.RawMessage) {
 	}
 	if params["keep"] != "visible" {
 		t.Fatalf("keep = %v, want visible", params["keep"])
+	}
+}
+
+// TestExportWritesToANonRegularOutput. Dropping O_TRUNC from the open so the
+// same-file check could run first turned an ignored flag into an explicit
+// ftruncate, and ftruncate refuses a pipe with EINVAL. That broke every shape a
+// shell builds a descriptor for, `-o /dev/stdout` inside a pipeline and
+// `-o >(cmd)` most of all, which worked on the commit before.
+func TestExportWritesToANonRegularOutput(t *testing.T) {
+	input, original := writeUnredactedSession(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	read := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		read <- b
+	}()
+
+	path := fmt.Sprintf("/dev/fd/%d", w.Fd())
+	code := execute([]string{"export", input, "--output", path})
+	_ = w.Close()
+	if code != 0 {
+		t.Fatalf("export to %s exit = %d, want 0", path, code)
+	}
+	if got := <-read; !json.Valid(got) {
+		t.Fatalf("export to a pipe wrote %d bytes and they are not the export:\n%s", len(got), got)
+	}
+	assertFileUnchanged(t, input, original)
+}
+
+// TestExportLeavesTheTargetAloneWhenItFails. The export is renamed into place
+// once it succeeds, so a run that dies partway leaves the previous file whole
+// rather than the stub an up-front truncate would have left.
+func TestExportLeavesTheTargetAloneWhenItFails(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "previous.json")
+	const previous = `{"kept":true}`
+	if err := os.WriteFile(output, []byte(previous), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	broken := filepath.Join(t.TempDir(), "broken.jsonl")
+	if err := os.WriteFile(broken, []byte("{not json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := execute([]string{"export", broken, "--output", output}); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != previous {
+		t.Fatalf("a failed export replaced the previous one: %q", got)
+	}
+	entries, err := os.ReadDir(filepath.Dir(output))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("a failed export left its temporary file behind: %v", entries)
+	}
+}
+
+// TestExportFromAPipeDoesNotZeroTheSource. The same-file check cannot see which
+// file is behind a pipe, so `cat log | mcpsnoop export - -o log` used to
+// truncate the log while cat was still reading it, leaving nothing at all and
+// blaming the input for being corrupt. Writing through a temporary file means
+// the source is read in full first.
+func TestExportFromAPipeDoesNotZeroTheSource(t *testing.T) {
+	// Bigger than a pipe buffer on purpose. Below that the writer finishes before
+	// the destination is touched and the bug hides, which is why a small fixture
+	// makes this test pass against the very code it is meant to catch.
+	input := filepath.Join(t.TempDir(), "big.jsonl")
+	var source []byte
+	for seq := 1; len(source) < 512*1024; seq++ {
+		line, err := json.Marshal(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "server", Seq: uint64(seq),
+			TS: time.Unix(1, 0), Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"lookup","arguments":{"pad":%q}}}`,
+				seq, strings.Repeat("x", 512))),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		source = append(append(source, line...), '\n')
+	}
+	if err := os.WriteFile(input, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Streamed off disk rather than out of memory, because that is what `cat log |`
+	// does and it is the whole mechanism. A writer holding its own copy never
+	// notices the file being truncated underneath it, so it would pass against the
+	// very code this test exists to catch.
+	streaming, err := os.Open(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer streaming.Close()
+	go func() {
+		defer w.Close()
+		_, _ = io.Copy(w, streaming)
+	}()
+
+	cmd := newExportCmd()
+	cmd.SetIn(r)
+	cmd.SetArgs([]string{"-", "--output", input})
+	cmd.SilenceErrors = true
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("export = %v, want success", err)
+	}
+	got, err := os.ReadFile(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("the source was zeroed out from under the reader")
+	}
+	if !json.Valid(got) {
+		t.Fatalf("the source holds neither its own contents nor a complete export:\n%s", got)
 	}
 }

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -19,6 +20,7 @@ import (
 	hubpkg "github.com/kerlenton/mcpsnoop/internal/hub"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/store"
 )
 
 func TestLabelFor(t *testing.T) {
@@ -316,6 +318,209 @@ func TestRedactKeysFlagConfigEnablesCommonSecretsPreset(t *testing.T) {
 	}
 	if got, want := cfg.Keys, []string{"custom_secret"}; !slices.Equal(got, want) {
 		t.Fatalf("keys = %v, want %v", got, want)
+	}
+}
+
+func TestExportRedactsCapturedSessionWithoutModifyingInput(t *testing.T) {
+	input, original := writeUnredactedSession(t)
+	output := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(output, bytes.Repeat([]byte("stale"), 2048), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"export", input, "--format", "json"}
+	args = append(args, capturedSessionRedactionFlags()...)
+	args = append(args, "--output", output)
+
+	if code := execute(args); code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(got) {
+		t.Fatalf("export did not replace the existing output cleanly:\n%s", got)
+	}
+	assertCapturedSessionRedacted(t, got)
+	assertFileUnchanged(t, input, original)
+}
+
+func TestExportRejectsSourceAsOutputWithoutModifyingInput(t *testing.T) {
+	t.Run("path", func(t *testing.T) {
+		input, original := writeUnredactedSession(t)
+		if code := execute([]string{"export", input, "--redact-secrets", "--output", input}); code != 1 {
+			t.Fatalf("exit = %d, want 1", code)
+		}
+		assertFileUnchanged(t, input, original)
+	})
+
+	t.Run("hard link", func(t *testing.T) {
+		input, original := writeUnredactedSession(t)
+		output := filepath.Join(t.TempDir(), "same-session.jsonl")
+		if err := os.Link(input, output); err != nil {
+			t.Skipf("hard links unavailable: %v", err)
+		}
+		if code := execute([]string{"export", input, "--redact-secrets", "--output", output}); code != 1 {
+			t.Fatalf("exit = %d, want 1", code)
+		}
+		assertFileUnchanged(t, input, original)
+	})
+
+	t.Run("stdin file", func(t *testing.T) {
+		input, original := writeUnredactedSession(t)
+		in, err := os.Open(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer in.Close()
+
+		cmd := newExportCmd()
+		cmd.SetIn(in)
+		cmd.SetArgs([]string{"-", "--redact-secrets", "--output", input})
+		cmd.SilenceErrors = true
+		err = cmd.Execute()
+		var code exitCode
+		if !errors.As(err, &code) || code != 1 {
+			t.Fatalf("error = %v, want exit status 1", err)
+		}
+		assertFileUnchanged(t, input, original)
+	})
+}
+
+func TestOpenRedactsCapturedSessionInMemoryWithoutModifyingInput(t *testing.T) {
+	input, original := writeUnredactedSession(t)
+	var opened *store.Store
+	previous := runOpenTUIFn
+	runOpenTUIFn = func(_ context.Context, st *store.Store) error {
+		opened = st
+		return nil
+	}
+	defer func() { runOpenTUIFn = previous }()
+
+	args := []string{"open", input}
+	args = append(args, capturedSessionRedactionFlags()...)
+	if code := execute(args); code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if opened == nil {
+		t.Fatal("open did not pass a store to the TUI")
+	}
+	events := opened.Timeline("s1")
+	if len(events) != 1 {
+		t.Fatalf("timeline has %d events, want 1", len(events))
+	}
+	assertCapturedSessionRedacted(t, events[0].Raw)
+	assertFileUnchanged(t, input, original)
+}
+
+func TestCapturedSessionReadDefaultsRemainUnredacted(t *testing.T) {
+	input, original := writeUnredactedSession(t)
+	output := filepath.Join(t.TempDir(), "session.json")
+	if code := execute([]string{"export", input, "--format", "json", "--output", output}); code != 0 {
+		t.Fatalf("export exit = %d, want 0", code)
+	}
+	exported, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{"common-secret", "key-secret", "value-only-789", "path-secret"} {
+		if !bytes.Contains(exported, []byte(secret)) {
+			t.Fatalf("default export omitted %q:\n%s", secret, exported)
+		}
+	}
+
+	var opened *store.Store
+	previous := runOpenTUIFn
+	runOpenTUIFn = func(_ context.Context, st *store.Store) error {
+		opened = st
+		return nil
+	}
+	defer func() { runOpenTUIFn = previous }()
+	if code := execute([]string{"open", input}); code != 0 {
+		t.Fatalf("open exit = %d, want 0", code)
+	}
+	if opened == nil {
+		t.Fatal("open did not pass a store to the TUI")
+	}
+	events := opened.Timeline("s1")
+	if len(events) != 1 {
+		t.Fatalf("timeline has %d events, want 1", len(events))
+	}
+	for _, secret := range []string{"common-secret", "key-secret", "value-only-789", "path-secret"} {
+		if !bytes.Contains(events[0].Raw, []byte(secret)) {
+			t.Fatalf("default open omitted %q:\n%s", secret, events[0].Raw)
+		}
+	}
+	assertFileUnchanged(t, input, original)
+}
+
+func TestCapturedSessionCommandsExposeRedactionFlags(t *testing.T) {
+	exportCmd, openCmd := newExportCmd(), newOpenCmd()
+	for _, flag := range []string{"redact-secrets", "redact-key", "redact-value", "redact-path"} {
+		if exportCmd.Flags().Lookup(flag) == nil {
+			t.Errorf("export command is missing --%s", flag)
+		}
+		if openCmd.Flags().Lookup(flag) == nil {
+			t.Errorf("open command is missing --%s", flag)
+		}
+	}
+}
+
+func writeUnredactedSession(t *testing.T) (string, []byte) {
+	t.Helper()
+	input := filepath.Join(t.TempDir(), "session.jsonl")
+	env := proxy.Envelope{
+		SessionID:   "s1",
+		ServerLabel: "server",
+		Seq:         1,
+		TS:          time.Unix(1, 0),
+		Direction:   proxy.ClientToServer,
+		Transport:   proxy.TransportStdio,
+		Raw:         json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lookup","arguments":{"authorization":"common-secret","project_token":"key-secret","note":"value-only-789","nested":{"private":"path-secret"},"keep":"visible"}}}`),
+	}
+	line, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := append(line, '\n')
+	if err := os.WriteFile(input, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return input, original
+}
+
+func capturedSessionRedactionFlags() []string {
+	return []string{
+		"--redact-secrets",
+		"--redact-key", "project_token",
+		"--redact-value", `value-only-[0-9]+`,
+		"--redact-path", "$.params.arguments.nested.private",
+	}
+}
+
+func assertCapturedSessionRedacted(t *testing.T, got []byte) {
+	t.Helper()
+	for _, secret := range []string{"common-secret", "key-secret", "value-only-789", "path-secret"} {
+		if bytes.Contains(got, []byte(secret)) {
+			t.Errorf("redacted view still contains %q:\n%s", secret, got)
+		}
+	}
+	if !bytes.Contains(got, []byte("[REDACTED]")) {
+		t.Errorf("redacted view does not contain the redaction marker:\n%s", got)
+	}
+	if !bytes.Contains(got, []byte("visible")) {
+		t.Errorf("redacted view omitted the safe value:\n%s", got)
+	}
+}
+
+func assertFileUnchanged(t *testing.T, path string, want []byte) {
+	t.Helper()
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, want) {
+		t.Fatal("read command modified the captured session")
 	}
 }
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -31,7 +31,8 @@ const (
 )
 
 type Options struct {
-	Format Format
+	Format    Format
+	Redaction proxy.RedactConfig
 }
 
 type SessionExport struct {
@@ -234,7 +235,12 @@ func LoadFile(path string) (*store.Store, string, error) {
 
 // Load reads a JSONL envelope stream into a store and returns its first session.
 func Load(r io.Reader, source string) (*store.Store, string, error) {
+	return load(r, source, proxy.RedactConfig{})
+}
+
+func load(r io.Reader, source string, redaction proxy.RedactConfig) (*store.Store, string, error) {
 	st := store.New()
+	redactor := proxy.NewRedactor(redaction)
 	var firstSession string
 	dec := json.NewDecoder(r)
 	for {
@@ -248,7 +254,7 @@ func Load(r io.Reader, source string) (*store.Store, string, error) {
 		if firstSession == "" {
 			firstSession = env.SessionID
 		}
-		st.Ingest(env)
+		st.Ingest(redactor.RedactEnvelope(env))
 	}
 	if firstSession == "" {
 		return nil, "", fmt.Errorf("%s: no envelopes found", source)
@@ -707,7 +713,7 @@ func ExportFile(inputPath string, w io.Writer, opts Options) error {
 // Export renders the session read from r, a JSONL envelope stream, to w. It is
 // the reader form of ExportFile, so a piped log ("-") exports like a file.
 func Export(r io.Reader, source string, w io.Writer, opts Options) error {
-	st, sessionID, err := Load(r, source)
+	st, sessionID, err := load(r, source, opts.Redaction)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- add the existing redaction flags to `export` and `open`
- apply redaction while decoding saved envelopes, without rewriting the source JSONL
- reject output paths that refer to the input file before truncation
- document that redaction covers JSON-RPC payloads and text, not envelope metadata

## Testing

- focused post-capture redaction and source-immutability regressions
- `go test -race ./cmd/mcpsnoop ./internal/exporter ./internal/proxy -count=1`
- `make check`
- `go build ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`

Closes https://github.com/kerlenton/mcpsnoop/issues/166
