### PR TITLE
fix(store): parse ttlMs/cacheScope and flag cache misuse

### DIFF
--- a/cmd/mcpsnoop/cache_check_test.go
+++ b/cmd/mcpsnoop/cache_check_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func TestCheckPassesForCacheStaleRefetch(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	now := time.Now()
+	writeCheckLog(t, paths.SessionLogPath("s1"),
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
+			Raw: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`),
+		},
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ServerToClient,
+			Raw: []byte(`{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","tools":[],"ttlMs":60000}}`),
+		},
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: now.Add(time.Second), Direction: proxy.ClientToServer,
+			Raw: []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`),
+		},
+	)
+
+	code, stdout, stderr := executeCheck(t, []string{"s1"}, "")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "check passed") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestCheckFailsForPublicScopeViolation(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	now := time.Now()
+	writeCheckLog(t, paths.SessionLogPath("s1"),
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: now, Direction: proxy.ClientToServer,
+			Raw: []byte(`{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///user/profile","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`),
+		},
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: now, Direction: proxy.ServerToClient,
+			Raw: []byte(`{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","contents":[{"uri":"file:///user/profile","text":"{\"userId\":\"123\"}"}],"cacheScope":"public"}}`),
+		},
+	)
+
+	code, stdout, stderr := executeCheck(t, []string{"s1"}, "")
+	if code == 0 {
+		t.Fatalf("exit = 0, want failure; stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "warnings=1") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -150,16 +150,30 @@ type EventExport struct {
 	Mismatch  bool            `json:"mismatch,omitempty"`
 	// Status is the HTTP status the frame arrived on and AuthChallenge that
 	// response's WWW-Authenticate header, both absent on stdio.
-	Status            int             `json:"http_status,omitempty"`
-	AuthChallenge     string          `json:"auth_challenge,omitempty"`
-	Truncated         bool            `json:"truncated,omitempty"`
-	Deprecated        string          `json:"deprecated,omitempty"`
-	CacheTTLMs        int             `json:"cache_ttl_ms,omitempty"`
+	Status        int    `json:"http_status,omitempty"`
+	AuthChallenge string `json:"auth_challenge,omitempty"`
+	Truncated     bool   `json:"truncated,omitempty"`
+	Deprecated    string `json:"deprecated,omitempty"`
+	// CacheTTLMs is a pointer so an explicit ttlMs of 0, which the spec defines as
+	// immediately stale, stays distinguishable from a server that declared none.
+	CacheTTLMs        *int            `json:"cache_ttl_ms,omitempty"`
 	CacheScope        string          `json:"cache_scope,omitempty"`
 	CacheStaleRefetch string          `json:"cache_stale_refetch,omitempty"`
 	CallIndex         *int            `json:"call_index,omitempty"`
 	Raw               json.RawMessage `json:"raw,omitempty"`
 	Text              string          `json:"text,omitempty"`
+}
+
+// cacheTTLExport keeps a declared ttlMs of 0 in the export. omitempty on a bare
+// int would drop it, which would render "immediately stale" as though the server
+// had declared nothing, the exact state the check beside it reports as a
+// violation.
+func cacheTTLExport(h store.CacheHint) *int {
+	if !h.TTLPresent {
+		return nil
+	}
+	ttl := h.TTLMs
+	return &ttl
 }
 
 func ParseFormat(s string) (Format, error) {
@@ -788,7 +802,7 @@ func exportEvent(ev store.EventView, callIndex map[string]int) EventExport {
 		AuthChallenge:     ev.AuthChallenge,
 		Truncated:         ev.Truncated,
 		Deprecated:        ev.Deprecated,
-		CacheTTLMs:        ev.CacheHint.TTLMs,
+		CacheTTLMs:        cacheTTLExport(ev.CacheHint),
 		CacheScope:        ev.CacheHint.Scope,
 		CacheStaleRefetch: ev.CacheStaleRefetch,
 		Raw:               ev.Raw,
@@ -832,7 +846,7 @@ func writeText(w io.Writer, data SessionExport) error {
 		if ev.CacheStaleRefetch != "" {
 			title += " cache_stale_refetch"
 		}
-		if ev.CacheTTLMs > 0 || ev.CacheScope != "" {
+		if ev.CacheTTLMs != nil || ev.CacheScope != "" {
 			title += " cache"
 		}
 		if ev.CallIndex != nil {

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -149,13 +149,16 @@ type EventExport struct {
 	Mismatch  bool            `json:"mismatch,omitempty"`
 	// Status is the HTTP status the frame arrived on and AuthChallenge that
 	// response's WWW-Authenticate header, both absent on stdio.
-	Status        int             `json:"http_status,omitempty"`
-	AuthChallenge string          `json:"auth_challenge,omitempty"`
-	Truncated     bool            `json:"truncated,omitempty"`
-	Deprecated    string          `json:"deprecated,omitempty"`
-	CallIndex     *int            `json:"call_index,omitempty"`
-	Raw           json.RawMessage `json:"raw,omitempty"`
-	Text          string          `json:"text,omitempty"`
+	Status            int             `json:"http_status,omitempty"`
+	AuthChallenge     string          `json:"auth_challenge,omitempty"`
+	Truncated         bool            `json:"truncated,omitempty"`
+	Deprecated        string          `json:"deprecated,omitempty"`
+	CacheTTLMs        int             `json:"cache_ttl_ms,omitempty"`
+	CacheScope        string          `json:"cache_scope,omitempty"`
+	CacheStaleRefetch string          `json:"cache_stale_refetch,omitempty"`
+	CallIndex         *int            `json:"call_index,omitempty"`
+	Raw               json.RawMessage `json:"raw,omitempty"`
+	Text              string          `json:"text,omitempty"`
 }
 
 func ParseFormat(s string) (Format, error) {
@@ -767,20 +770,23 @@ func exportCall(index int, c store.CallView) CallExport {
 
 func exportEvent(ev store.EventView, callIndex map[string]int) EventExport {
 	out := EventExport{
-		Seq:           ev.Seq,
-		Timestamp:     ev.TS,
-		Direction:     ev.Dir,
-		Kind:          eventKind(ev.Kind),
-		Method:        ev.Method,
-		ID:            ev.ID,
-		Warning:       ev.Warning,
-		Mismatch:      ev.RoutingMismatch,
-		Status:        ev.HTTPStatus,
-		AuthChallenge: ev.AuthChallenge,
-		Truncated:     ev.Truncated,
-		Deprecated:    ev.Deprecated,
-		Raw:           ev.Raw,
-		Text:          ev.Text,
+		Seq:               ev.Seq,
+		Timestamp:         ev.TS,
+		Direction:         ev.Dir,
+		Kind:              eventKind(ev.Kind),
+		Method:            ev.Method,
+		ID:                ev.ID,
+		Warning:           ev.Warning,
+		Mismatch:          ev.RoutingMismatch,
+		Status:            ev.HTTPStatus,
+		AuthChallenge:     ev.AuthChallenge,
+		Truncated:         ev.Truncated,
+		Deprecated:        ev.Deprecated,
+		CacheTTLMs:        ev.CacheHint.TTLMs,
+		CacheScope:        ev.CacheHint.Scope,
+		CacheStaleRefetch: ev.CacheStaleRefetch,
+		Raw:               ev.Raw,
+		Text:              ev.Text,
 	}
 	if ev.Call != nil {
 		if idx, ok := callIndex[callKey(*ev.Call)]; ok {
@@ -816,6 +822,12 @@ func writeText(w io.Writer, data SessionExport) error {
 		}
 		if ev.Deprecated != "" {
 			title += " deprecated"
+		}
+		if ev.CacheStaleRefetch != "" {
+			title += " cache_stale_refetch"
+		}
+		if ev.CacheTTLMs > 0 || ev.CacheScope != "" {
+			title += " cache"
 		}
 		if ev.CallIndex != nil {
 			c := data.Calls[*ev.CallIndex]

--- a/internal/store/cache.go
+++ b/internal/store/cache.go
@@ -1,0 +1,196 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// cacheRequiredFrom is the revision that added ttlMs and cacheScope (SEP-2549).
+const cacheRequiredFrom = "2026-07-28"
+
+type cacheEntry struct {
+	receivedAt time.Time
+	ttlMs      int
+	scope      string
+}
+
+// CacheHint surfaces ttlMs and cacheScope from a cacheable MCP result.
+type CacheHint struct {
+	TTLMs int
+	Scope string
+}
+
+func cacheableMethod(method string) bool {
+	switch method {
+	case "server/discover", "tools/list", "prompts/list",
+		"resources/list", "resources/templates/list", "resources/read":
+		return true
+	default:
+		return false
+	}
+}
+
+func cacheKey(method string, params json.RawMessage) string {
+	switch method {
+	case "tools/list", "prompts/list", "resources/list", "resources/templates/list":
+		var p struct {
+			Cursor string `json:"cursor"`
+		}
+		_ = json.Unmarshal(params, &p)
+		return method + "\x00" + p.Cursor
+	case "resources/read":
+		var p struct {
+			URI string `json:"uri"`
+		}
+		_ = json.Unmarshal(params, &p)
+		return method + "\x00" + p.URI
+	case "server/discover":
+		return method
+	default:
+		return ""
+	}
+}
+
+func parseCacheHints(result json.RawMessage) (CacheHint, bool) {
+	if len(result) == 0 {
+		return CacheHint{}, false
+	}
+	var fields struct {
+		TTLMs *int    `json:"ttlMs"`
+		Scope *string `json:"cacheScope"`
+	}
+	if json.Unmarshal(result, &fields) != nil {
+		return CacheHint{}, false
+	}
+	hint := CacheHint{}
+	found := false
+	if fields.TTLMs != nil && *fields.TTLMs > 0 {
+		hint.TTLMs = *fields.TTLMs
+		found = true
+	}
+	if fields.Scope != nil && *fields.Scope != "" {
+		hint.Scope = *fields.Scope
+		found = true
+	}
+	return hint, found
+}
+
+func isCompleteCacheableResult(result json.RawMessage) bool {
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(result, &fields) != nil {
+		return false
+	}
+	raw, ok := fields["resultType"]
+	if !ok {
+		return true
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return false
+	}
+	return value == "complete"
+}
+
+func publicScopeMislabelWarning(method string, params, result json.RawMessage, scope string) string {
+	if scope != "public" {
+		return ""
+	}
+	if method != "resources/read" {
+		return ""
+	}
+	var p struct {
+		URI string `json:"uri"`
+	}
+	_ = json.Unmarshal(params, &p)
+	uri := strings.ToLower(p.URI)
+	for _, marker := range []string{"user", "profile", "account", "me/", "/me", "private", "session"} {
+		if strings.Contains(uri, marker) {
+			return "cacheScope is public on a resource URI that looks user-specific"
+		}
+	}
+	var body map[string]json.RawMessage
+	if json.Unmarshal(result, &body) != nil {
+		return ""
+	}
+	if contents, ok := body["contents"]; ok {
+		var items []map[string]json.RawMessage
+		if json.Unmarshal(contents, &items) == nil {
+			for _, item := range items {
+				if text, ok := item["text"]; ok {
+					if looksUserSpecificJSON(text) {
+						return "cacheScope is public on a resource that looks user-specific"
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func looksUserSpecificJSON(raw json.RawMessage) bool {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(raw, &obj) != nil {
+		return false
+	}
+	for key := range obj {
+		lower := strings.ToLower(key)
+		switch lower {
+		case "userid", "user_id", "email", "accountid", "account_id",
+			"sessionid", "session_id", "accesstoken", "access_token",
+			"apitoken", "api_token", "password", "ssn":
+			return true
+		}
+	}
+	return false
+}
+
+func (sess *session) checkCacheStale(method string, params json.RawMessage, ts time.Time, protocolVersion string) string {
+	if !atLeastRevision(protocolVersion, cacheRequiredFrom) {
+		return ""
+	}
+	key := cacheKey(method, params)
+	if key == "" {
+		return ""
+	}
+	entry, ok := sess.cacheFresh[key]
+	if !ok || entry.ttlMs <= 0 {
+		return ""
+	}
+	deadline := entry.receivedAt.Add(time.Duration(entry.ttlMs) * time.Millisecond)
+	if !ts.Before(deadline) {
+		return ""
+	}
+	return "re-fetched inside declared ttlMs freshness window"
+}
+
+func (sess *session) recordCacheFromResponse(c *call, result json.RawMessage, ts time.Time) (CacheHint, string) {
+	if c == nil || !cacheableMethod(c.method) {
+		return CacheHint{}, ""
+	}
+	if !atLeastRevision(c.protocolVersion, cacheRequiredFrom) {
+		return CacheHint{}, ""
+	}
+	if !isCompleteCacheableResult(result) {
+		return CacheHint{}, ""
+	}
+	hint, found := parseCacheHints(result)
+	if !found {
+		return CacheHint{}, ""
+	}
+	if hint.TTLMs > 0 {
+		if sess.cacheFresh == nil {
+			sess.cacheFresh = make(map[string]cacheEntry)
+		}
+		sess.cacheFresh[cacheKey(c.method, c.params)] = cacheEntry{
+			receivedAt: ts,
+			ttlMs:      hint.TTLMs,
+			scope:      hint.Scope,
+		}
+	}
+	warning := publicScopeMislabelWarning(c.method, c.params, result, hint.Scope)
+	if hint.TTLMs > 0 || hint.Scope != "" {
+		return hint, warning
+	}
+	return CacheHint{}, warning
+}

--- a/internal/store/cache.go
+++ b/internal/store/cache.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -12,19 +13,38 @@ const cacheRequiredFrom = "2026-07-28"
 type cacheEntry struct {
 	receivedAt time.Time
 	ttlMs      int
-	scope      string
 }
 
 // CacheHint surfaces ttlMs and cacheScope from a cacheable MCP result.
+//
+// TTLPresent separates a server that declared 0, which the spec gives a meaning
+// of its own (immediately stale), from one that declared nothing, which on this
+// revision is a violation. Collapsing the two into a zero TTLMs made the
+// omission unreportable.
 type CacheHint struct {
-	TTLMs int
-	Scope string
+	TTLMs      int
+	TTLPresent bool
+	Scope      string
 }
+
+// Empty reports whether a result carried no caching hint at all.
+func (h CacheHint) Empty() bool { return !h.TTLPresent && h.Scope == "" }
 
 func cacheableMethod(method string) bool {
 	switch method {
 	case "server/discover", "tools/list", "prompts/list",
 		"resources/list", "resources/templates/list", "resources/read":
+		return true
+	default:
+		return false
+	}
+}
+
+// paginatedListMethod reports whether a cacheable method returns pages, which is
+// the set the one-scope-per-run rule applies to.
+func paginatedListMethod(method string) bool {
+	switch method {
+	case "tools/list", "prompts/list", "resources/list", "resources/templates/list":
 		return true
 	default:
 		return false
@@ -52,28 +72,86 @@ func cacheKey(method string, params json.RawMessage) string {
 	}
 }
 
-func parseCacheHints(result json.RawMessage) (CacheHint, bool) {
-	if len(result) == 0 {
-		return CacheHint{}, false
-	}
+// parseCacheHints reads the two hint fields and reports what the values
+// themselves violate.
+//
+// The fields are decoded one at a time, through the number grammar rather than
+// straight into an int. Decoding both behind one struct meant a ttlMs that Go
+// would not put in an int, such as the legal 60000.0 a server emits from a
+// duration in seconds, failed the whole decode and silently took the cacheScope
+// beside it away with every check that depended on it.
+func parseCacheHints(result json.RawMessage) (CacheHint, []string) {
 	var fields struct {
-		TTLMs *int    `json:"ttlMs"`
-		Scope *string `json:"cacheScope"`
+		TTLMs json.RawMessage `json:"ttlMs"`
+		Scope json.RawMessage `json:"cacheScope"`
 	}
-	if json.Unmarshal(result, &fields) != nil {
-		return CacheHint{}, false
+	if len(result) == 0 || json.Unmarshal(result, &fields) != nil {
+		return CacheHint{}, nil
 	}
-	hint := CacheHint{}
-	found := false
-	if fields.TTLMs != nil && *fields.TTLMs > 0 {
-		hint.TTLMs = *fields.TTLMs
-		found = true
+	var (
+		hint     CacheHint
+		warnings []string
+	)
+	if declared(fields.TTLMs) {
+		switch ttl, ok := cacheInteger(fields.TTLMs); {
+		case !ok:
+			warnings = append(warnings, "ttlMs is "+string(fields.TTLMs)+", which is not an integer")
+		case ttl < 0:
+			hint.TTLMs, hint.TTLPresent = ttl, true
+			warnings = append(warnings, "ttlMs is "+strconv.Itoa(ttl)+
+				", and 2026-07-28 requires a value of zero or more")
+		default:
+			hint.TTLMs, hint.TTLPresent = ttl, true
+		}
 	}
-	if fields.Scope != nil && *fields.Scope != "" {
-		hint.Scope = *fields.Scope
-		found = true
+	if declared(fields.Scope) {
+		var scope string
+		switch {
+		case json.Unmarshal(fields.Scope, &scope) != nil:
+			warnings = append(warnings, "cacheScope is "+string(fields.Scope)+", which is not a string")
+		case scope == "":
+			warnings = append(warnings, "cacheScope is empty, and 2026-07-28 defines only public and private")
+		default:
+			hint.Scope = scope
+			if scope != "public" && scope != "private" {
+				warnings = append(warnings, "cacheScope is "+strconv.Quote(scope)+
+					", and 2026-07-28 defines only public and private")
+			}
+		}
 	}
-	return hint, found
+	return hint, warnings
+}
+
+func declared(raw json.RawMessage) bool {
+	return len(raw) > 0 && string(raw) != "null"
+}
+
+// cacheInteger reads a JSON number that denotes an integer, accepting the
+// spellings JSON permits for one. 60000.0 and 6e4 are the same value as 60000
+// and satisfy the released schema, and a server generating them from a duration
+// is conforming.
+func cacheInteger(raw json.RawMessage) (int, bool) {
+	parsed := parseMCPInteger(string(raw))
+	if !parsed.integer || !parsed.safe {
+		return 0, false
+	}
+	value := int(parsed.value)
+	if int64(value) != parsed.value {
+		return 0, false
+	}
+	return value, true
+}
+
+// resultTypeIs reports whether a result declares exactly the given resultType.
+// Used rather than isCompleteCacheableResult where the distinction between a
+// declared "complete" and an absent resultType matters, because an absent one
+// already has a warning of its own on the same frame and one omission must not
+// be reported twice.
+func resultTypeIs(result json.RawMessage, want string) bool {
+	var fields struct {
+		ResultType string `json:"resultType"`
+	}
+	return json.Unmarshal(result, &fields) == nil && fields.ResultType == want
 }
 
 func isCompleteCacheableResult(result json.RawMessage) bool {
@@ -90,59 +168,6 @@ func isCompleteCacheableResult(result json.RawMessage) bool {
 		return false
 	}
 	return value == "complete"
-}
-
-func publicScopeMislabelWarning(method string, params, result json.RawMessage, scope string) string {
-	if scope != "public" {
-		return ""
-	}
-	if method != "resources/read" {
-		return ""
-	}
-	var p struct {
-		URI string `json:"uri"`
-	}
-	_ = json.Unmarshal(params, &p)
-	uri := strings.ToLower(p.URI)
-	for _, marker := range []string{"user", "profile", "account", "me/", "/me", "private", "session"} {
-		if strings.Contains(uri, marker) {
-			return "cacheScope is public on a resource URI that looks user-specific"
-		}
-	}
-	var body map[string]json.RawMessage
-	if json.Unmarshal(result, &body) != nil {
-		return ""
-	}
-	if contents, ok := body["contents"]; ok {
-		var items []map[string]json.RawMessage
-		if json.Unmarshal(contents, &items) == nil {
-			for _, item := range items {
-				if text, ok := item["text"]; ok {
-					if looksUserSpecificJSON(text) {
-						return "cacheScope is public on a resource that looks user-specific"
-					}
-				}
-			}
-		}
-	}
-	return ""
-}
-
-func looksUserSpecificJSON(raw json.RawMessage) bool {
-	var obj map[string]json.RawMessage
-	if json.Unmarshal(raw, &obj) != nil {
-		return false
-	}
-	for key := range obj {
-		lower := strings.ToLower(key)
-		switch lower {
-		case "userid", "user_id", "email", "accountid", "account_id",
-			"sessionid", "session_id", "accesstoken", "access_token",
-			"apitoken", "api_token", "password", "ssn":
-			return true
-		}
-	}
-	return false
 }
 
 func (sess *session) checkCacheStale(method string, params json.RawMessage, ts time.Time, protocolVersion string) string {
@@ -164,33 +189,95 @@ func (sess *session) checkCacheStale(method string, params json.RawMessage, ts t
 	return "re-fetched inside declared ttlMs freshness window"
 }
 
-func (sess *session) recordCacheFromResponse(c *call, result json.RawMessage, ts time.Time) (CacheHint, string) {
+// invalidateCache drops the freshness entries a change notification makes stale.
+// The spec says a relevant notification invalidates a cached response
+// immediately, and its own diagram is a list_changed followed by a re-fetch, so
+// without this the note fires on the flow the page draws as correct.
+func (sess *session) invalidateCache(method string, params json.RawMessage) {
+	var prefixes []string
+	switch method {
+	case "notifications/tools/list_changed":
+		prefixes = []string{"tools/list\x00"}
+	case "notifications/prompts/list_changed":
+		prefixes = []string{"prompts/list\x00"}
+	case "notifications/resources/list_changed":
+		prefixes = []string{"resources/list\x00", "resources/templates/list\x00"}
+	case "notifications/resources/updated":
+		var p struct {
+			URI string `json:"uri"`
+		}
+		if json.Unmarshal(params, &p) != nil || p.URI == "" {
+			return
+		}
+		delete(sess.cacheFresh, "resources/read\x00"+p.URI)
+		return
+	default:
+		return
+	}
+	// Every page of a run goes stale together, since the notification invalidates
+	// the listing rather than one cursor of it.
+	for key := range sess.cacheFresh {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				delete(sess.cacheFresh, key)
+			}
+		}
+	}
+}
+
+// checkCacheScopeAcrossPages enforces the one rule on this page that a wire
+// proxy is better placed to check than any single client, since the proxy sees
+// every page of a run. A cursorless request starts a new run and sets the scope
+// the rest of it must repeat; keying on the method alone without that reset
+// would report two independent single-page listings whose scope legitimately
+// differs, which is traffic the spec permits.
+func (sess *session) checkCacheScopeAcrossPages(c *call, scope string) string {
+	if !paginatedListMethod(c.method) {
+		return ""
+	}
+	if !hasListCursor(c.params) {
+		if sess.cacheListScope == nil {
+			sess.cacheListScope = make(map[string]string)
+		}
+		sess.cacheListScope[c.method] = scope
+		return ""
+	}
+	first, ok := sess.cacheListScope[c.method]
+	if !ok || first == "" || scope == "" || first == scope {
+		return ""
+	}
+	return "cacheScope " + strconv.Quote(scope) + " on a later page of " + c.method +
+		" disagrees with " + strconv.Quote(first) + " on the first, and 2026-07-28 requires one scope per list request"
+}
+
+func (sess *session) recordCacheFromResponse(c *call, result json.RawMessage, ts time.Time) (CacheHint, []string) {
 	if c == nil || !cacheableMethod(c.method) {
-		return CacheHint{}, ""
+		return CacheHint{}, nil
 	}
 	if !atLeastRevision(c.protocolVersion, cacheRequiredFrom) {
-		return CacheHint{}, ""
+		return CacheHint{}, nil
 	}
 	if !isCompleteCacheableResult(result) {
-		return CacheHint{}, ""
+		return CacheHint{}, nil
 	}
-	hint, found := parseCacheHints(result)
-	if !found {
-		return CacheHint{}, ""
+	hint, warnings := parseCacheHints(result)
+	// The spec makes the hints mandatory on a complete result of a cacheable
+	// operation, so their absence is the flattest violation on the page. Reported
+	// only when the result says "complete" outright: an absent resultType is its
+	// own violation with its own warning on this very frame, and saying it twice
+	// sends the reader after two problems where there is one.
+	if !hint.TTLPresent && resultTypeIs(result, "complete") {
+		warnings = append(warnings, "cacheable "+c.method+
+			" result declares no ttlMs, which 2026-07-28 requires")
+	}
+	if note := sess.checkCacheScopeAcrossPages(c, hint.Scope); note != "" {
+		warnings = append(warnings, note)
 	}
 	if hint.TTLMs > 0 {
 		if sess.cacheFresh == nil {
 			sess.cacheFresh = make(map[string]cacheEntry)
 		}
-		sess.cacheFresh[cacheKey(c.method, c.params)] = cacheEntry{
-			receivedAt: ts,
-			ttlMs:      hint.TTLMs,
-			scope:      hint.Scope,
-		}
+		sess.cacheFresh[cacheKey(c.method, c.params)] = cacheEntry{receivedAt: ts, ttlMs: hint.TTLMs}
 	}
-	warning := publicScopeMislabelWarning(c.method, c.params, result, hint.Scope)
-	if hint.TTLMs > 0 || hint.Scope != "" {
-		return hint, warning
-	}
-	return CacheHint{}, warning
+	return hint, warnings
 }

--- a/internal/store/cache_test.go
+++ b/internal/store/cache_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -11,20 +12,93 @@ import (
 
 const cacheMeta = `{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}`
 
+// notif is req without an id, which is what makes a frame a notification.
+func notif(seq uint64, ts time.Time, dir proxy.Direction, method, params string) proxy.Envelope {
+	raw := `{"jsonrpc":"2.0","method":` + strconv.Quote(method) + `,"params":` + params + `}`
+	return proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: ts, Direction: dir, Raw: json.RawMessage(raw)}
+}
+
 func TestParseCacheHints(t *testing.T) {
 	t.Parallel()
-	hint, ok := parseCacheHints(json.RawMessage(`{"resultType":"complete","tools":[],"ttlMs":30000,"cacheScope":"private"}`))
-	if !ok {
-		t.Fatal("expected cache hints")
-	}
-	if hint.TTLMs != 30000 || hint.Scope != "private" {
-		t.Fatalf("hint = %+v", hint)
-	}
-	if _, ok := parseCacheHints(json.RawMessage(`{"tools":[]}`)); ok {
-		t.Fatal("absent fields should not report hints")
-	}
-	if _, ok := parseCacheHints(json.RawMessage(`{"ttlMs":0,"cacheScope":""}`)); ok {
-		t.Fatal("zero ttl and empty scope should not report hints")
+	for _, tc := range []struct {
+		name, result string
+		wantTTL      int
+		wantPresent  bool
+		wantScope    string
+		wantWarning  string
+	}{
+		{
+			name:    "both fields",
+			result:  `{"resultType":"complete","tools":[],"ttlMs":30000,"cacheScope":"private"}`,
+			wantTTL: 30000, wantPresent: true, wantScope: "private",
+		},
+		{
+			name:   "absent fields",
+			result: `{"tools":[]}`,
+		},
+		// Zero is a value the spec gives a meaning to, immediately stale, so it has
+		// to survive as a declared zero rather than read as nothing declared.
+		{
+			name:    "explicit zero is declared",
+			result:  `{"ttlMs":0}`,
+			wantTTL: 0, wantPresent: true,
+		},
+		{
+			name:    "negative ttl is a violation and still reported",
+			result:  `{"ttlMs":-5,"cacheScope":"private"}`,
+			wantTTL: -5, wantPresent: true, wantScope: "private",
+			wantWarning: "requires a value of zero or more",
+		},
+		// A legal JSON spelling of an integer. Decoding both fields behind one int
+		// meant this failed the whole decode and took the cacheScope with it.
+		{
+			name:    "fractional spelling of an integer",
+			result:  `{"ttlMs":60000.0,"cacheScope":"private"}`,
+			wantTTL: 60000, wantPresent: true, wantScope: "private",
+		},
+		{
+			name:    "exponent spelling of an integer",
+			result:  `{"ttlMs":6e4,"cacheScope":"public"}`,
+			wantTTL: 60000, wantPresent: true, wantScope: "public",
+		},
+		{
+			name:        "ttl that is not an integer",
+			result:      `{"ttlMs":"soon","cacheScope":"private"}`,
+			wantScope:   "private",
+			wantWarning: "not an integer",
+		},
+		{
+			name:        "scope outside the two-value table",
+			result:      `{"ttlMs":1000,"cacheScope":"semi-public"}`,
+			wantTTL:     1000,
+			wantPresent: true,
+			wantScope:   "semi-public",
+			wantWarning: "only public and private",
+		},
+		{
+			name:        "empty scope",
+			result:      `{"ttlMs":1000,"cacheScope":""}`,
+			wantTTL:     1000,
+			wantPresent: true,
+			wantWarning: "only public and private",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hint, warnings := parseCacheHints(json.RawMessage(tc.result))
+			if hint.TTLMs != tc.wantTTL || hint.TTLPresent != tc.wantPresent || hint.Scope != tc.wantScope {
+				t.Fatalf("hint = %+v, want ttl=%d present=%v scope=%q",
+					hint, tc.wantTTL, tc.wantPresent, tc.wantScope)
+			}
+			if tc.wantWarning == "" {
+				if len(warnings) != 0 {
+					t.Fatalf("warnings = %v, want none", warnings)
+				}
+				return
+			}
+			if len(warnings) != 1 || !strings.Contains(warnings[0], tc.wantWarning) {
+				t.Fatalf("warnings = %v, want one containing %q", warnings, tc.wantWarning)
+			}
+		})
 	}
 }
 
@@ -36,19 +110,101 @@ func TestIngestSurfacesCacheHintsWithoutStaleRefetch(t *testing.T) {
 	if ev.CacheHint.TTLMs != 60000 || ev.CacheHint.Scope != "private" {
 		t.Fatalf("CacheHint = %+v", ev.CacheHint)
 	}
+	if ev.Warning != "" {
+		t.Fatalf("a conforming cacheable result must be silent, got %q", ev.Warning)
+	}
 	if ev.CacheStaleRefetch != "" {
 		t.Fatalf("response should not carry stale refetch observation: %q", ev.CacheStaleRefetch)
 	}
 }
 
-func TestIngestSurfacesCacheHintsOnToolsListResponse(t *testing.T) {
-	s := New()
-	now := time.Now()
-	s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", cacheMeta))
-	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"resultType":"complete","tools":[],"ttlMs":60000,"cacheScope":"private"}`))
-	if ev.CacheHint.TTLMs != 60000 || ev.CacheHint.Scope != "private" {
-		t.Fatalf("CacheHint = %+v", ev.CacheHint)
+// TestIngestWarnsOnAbsentCachingHints. The spec makes the hints mandatory on a
+// complete result of a cacheable operation, which is the flattest violation on
+// the page and the one a wire proxy sees for free.
+func TestIngestWarnsOnAbsentCachingHints(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, result string
+		want                 bool
+	}{
+		{"complete with no ttlMs", "tools/list", `"result":{"resultType":"complete","tools":[]}`, true},
+		{"complete with ttlMs", "tools/list", `"result":{"resultType":"complete","tools":[],"ttlMs":0}`, false},
+		// An absent resultType is its own violation with its own warning on this
+		// frame, so this one stays quiet rather than reporting the same omission
+		// under a second name.
+		{"no resultType at all", "tools/list", `"result":{"tools":[]}`, false},
+		{"interim result carries no hints", "resources/read", `"result":{"resultType":"input_required","contents":[]}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			now := time.Now()
+			params := cacheMeta
+			if tc.method == "resources/read" {
+				params = `{"uri":"file:///a",` + cacheMeta[1:]
+			}
+			s.Ingest(req(1, now, proxy.ClientToServer, "1", tc.method, params))
+			ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", tc.result))
+			if got := strings.Contains(ev.Warning, "declares no ttlMs"); got != tc.want {
+				t.Fatalf("warning = %q, want the missing-ttlMs report = %v", ev.Warning, tc.want)
+			}
+		})
 	}
+}
+
+// TestIngestWarnsOnCacheScopeChangingMidRun is the one rule here a proxy is
+// better placed to check than any client, because it sees every page of a run.
+func TestIngestWarnsOnCacheScopeChangingMidRun(t *testing.T) {
+	page := func(scope, cursor string) (string, string) {
+		params := cacheMeta
+		if cursor != "" {
+			params = `{"cursor":` + strconv.Quote(cursor) + `,` + cacheMeta[1:]
+		}
+		return params, `"result":{"resultType":"complete","tools":[],"ttlMs":1000,"cacheScope":"` + scope + `"}`
+	}
+
+	t.Run("later page disagrees", func(t *testing.T) {
+		s := New()
+		now := time.Now()
+		params, result := page("public", "")
+		s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", params))
+		s.Ingest(resp(2, now, proxy.ServerToClient, "1", result))
+		params, result = page("private", "p2")
+		s.Ingest(req(3, now, proxy.ClientToServer, "2", "tools/list", params))
+		ev := s.Ingest(resp(4, now, proxy.ServerToClient, "2", result))
+		if !strings.Contains(ev.Warning, "one scope per list request") {
+			t.Fatalf("a scope change mid-run must be reported, got %q", ev.Warning)
+		}
+	})
+
+	t.Run("later page agrees", func(t *testing.T) {
+		s := New()
+		now := time.Now()
+		params, result := page("public", "")
+		s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", params))
+		s.Ingest(resp(2, now, proxy.ServerToClient, "1", result))
+		params, result = page("public", "p2")
+		s.Ingest(req(3, now, proxy.ClientToServer, "2", "tools/list", params))
+		ev := s.Ingest(resp(4, now, proxy.ServerToClient, "2", result))
+		if ev.Warning != "" {
+			t.Fatalf("a run that keeps one scope must be silent, got %q", ev.Warning)
+		}
+	})
+
+	// Two independent listings, each one page. The spec constrains one list
+	// request, not the server forever, so a cursorless request has to start the
+	// run over or this reports traffic the spec permits.
+	t.Run("two independent listings may differ", func(t *testing.T) {
+		s := New()
+		now := time.Now()
+		params, result := page("public", "")
+		s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", params))
+		s.Ingest(resp(2, now, proxy.ServerToClient, "1", result))
+		params, result = page("private", "")
+		s.Ingest(req(3, now, proxy.ClientToServer, "2", "tools/list", params))
+		ev := s.Ingest(resp(4, now, proxy.ServerToClient, "2", result))
+		if ev.Warning != "" {
+			t.Fatalf("a fresh listing may declare its own scope, got %q", ev.Warning)
+		}
+	})
 }
 
 func TestIngestFlagsRefetchInsideTTL(t *testing.T) {
@@ -61,6 +217,34 @@ func TestIngestFlagsRefetchInsideTTL(t *testing.T) {
 	ev := s.Ingest(req(3, t1, proxy.ClientToServer, "2", "tools/list", cacheMeta))
 	if ev.CacheStaleRefetch == "" {
 		t.Fatal("expected stale refetch observation")
+	}
+}
+
+// TestIngestDoesNotFlagARefetchAfterListChanged. The spec says a relevant
+// notification invalidates the cached response immediately, and the caching
+// page's own diagram is a list_changed followed by exactly this re-fetch.
+func TestIngestDoesNotFlagARefetchAfterListChanged(t *testing.T) {
+	for _, tc := range []struct {
+		name, notification, method, params string
+		wantFlag                           bool
+	}{
+		{"tools", "notifications/tools/list_changed", "tools/list", cacheMeta, false},
+		{"prompts", "notifications/prompts/list_changed", "prompts/list", cacheMeta, false},
+		// A notification about something else leaves the entry fresh.
+		{"unrelated", "notifications/prompts/list_changed", "tools/list", cacheMeta, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			t0 := time.Now()
+			s.Ingest(req(1, t0, proxy.ClientToServer, "1", tc.method, tc.params))
+			s.Ingest(resp(2, t0, proxy.ServerToClient, "1", `"result":{"resultType":"complete","ttlMs":60000,"cacheScope":"public"}`))
+			s.Ingest(notif(3, t0.Add(time.Second), proxy.ServerToClient, tc.notification, `{}`))
+
+			ev := s.Ingest(req(4, t0.Add(2*time.Second), proxy.ClientToServer, "2", tc.method, tc.params))
+			if got := ev.CacheStaleRefetch != ""; got != tc.wantFlag {
+				t.Fatalf("stale refetch = %q, want flagged = %v", ev.CacheStaleRefetch, tc.wantFlag)
+			}
+		})
 	}
 }
 
@@ -90,22 +274,18 @@ func TestIngestCacheKeyIncludesCursor(t *testing.T) {
 	}
 }
 
-func TestIngestWarnsPublicScopeOnUserSpecificRead(t *testing.T) {
-	s := New()
-	now := time.Now()
-	s.Ingest(req(1, now, proxy.ClientToServer, "1", "resources/read", `{"uri":"file:///user/profile",`+cacheMeta[1:]))
-	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"resultType":"complete","contents":[{"uri":"file:///user/profile","text":"{\"userId\":\"123\"}"}],"cacheScope":"public"}`))
-	if !strings.Contains(ev.Warning, "user-specific") {
-		t.Fatalf("expected public scope warning, got %q", ev.Warning)
-	}
-}
-
+// TestCacheChecksJudgeTheRequestsOwnRevision. Every check here is gated on the
+// revision the request declared, never the session's, since a connection is not
+// a session and a client may interleave revisions.
 func TestIngestIgnoresCacheHintsBeforeRevision(t *testing.T) {
 	s := New()
 	now := time.Now()
 	s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", `{"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}`))
-	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"tools":[],"ttlMs":60000,"cacheScope":"private"}`))
-	if ev.CacheHint.TTLMs != 0 || ev.CacheHint.Scope != "" {
+	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"tools":[],"ttlMs":-5,"cacheScope":"semi-public"}`))
+	if !ev.CacheHint.Empty() {
 		t.Fatalf("pre-2026-07-28 revision should not surface cache hints: %+v", ev.CacheHint)
+	}
+	if ev.Warning != "" {
+		t.Fatalf("pre-2026-07-28 revision must not be judged by this revision's rules, got %q", ev.Warning)
 	}
 }

--- a/internal/store/cache_test.go
+++ b/internal/store/cache_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+const cacheMeta = `{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}`
+
+func TestParseCacheHints(t *testing.T) {
+	t.Parallel()
+	hint, ok := parseCacheHints(json.RawMessage(`{"resultType":"complete","tools":[],"ttlMs":30000,"cacheScope":"private"}`))
+	if !ok {
+		t.Fatal("expected cache hints")
+	}
+	if hint.TTLMs != 30000 || hint.Scope != "private" {
+		t.Fatalf("hint = %+v", hint)
+	}
+	if _, ok := parseCacheHints(json.RawMessage(`{"tools":[]}`)); ok {
+		t.Fatal("absent fields should not report hints")
+	}
+	if _, ok := parseCacheHints(json.RawMessage(`{"ttlMs":0,"cacheScope":""}`)); ok {
+		t.Fatal("zero ttl and empty scope should not report hints")
+	}
+}
+
+func TestIngestSurfacesCacheHintsWithoutStaleRefetch(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", cacheMeta))
+	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"resultType":"complete","tools":[],"ttlMs":60000,"cacheScope":"private"}`))
+	if ev.CacheHint.TTLMs != 60000 || ev.CacheHint.Scope != "private" {
+		t.Fatalf("CacheHint = %+v", ev.CacheHint)
+	}
+	if ev.CacheStaleRefetch != "" {
+		t.Fatalf("response should not carry stale refetch observation: %q", ev.CacheStaleRefetch)
+	}
+}
+
+func TestIngestSurfacesCacheHintsOnToolsListResponse(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", cacheMeta))
+	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"resultType":"complete","tools":[],"ttlMs":60000,"cacheScope":"private"}`))
+	if ev.CacheHint.TTLMs != 60000 || ev.CacheHint.Scope != "private" {
+		t.Fatalf("CacheHint = %+v", ev.CacheHint)
+	}
+}
+
+func TestIngestFlagsRefetchInsideTTL(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", cacheMeta))
+	s.Ingest(resp(2, t0, proxy.ServerToClient, "1", `"result":{"resultType":"complete","tools":[],"ttlMs":60000,"cacheScope":"private"}`))
+
+	t1 := t0.Add(10 * time.Second)
+	ev := s.Ingest(req(3, t1, proxy.ClientToServer, "2", "tools/list", cacheMeta))
+	if ev.CacheStaleRefetch == "" {
+		t.Fatal("expected stale refetch observation")
+	}
+}
+
+func TestIngestSilentAfterTTLExpires(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", cacheMeta))
+	s.Ingest(resp(2, t0, proxy.ServerToClient, "1", `"result":{"resultType":"complete","tools":[],"ttlMs":1000}`))
+
+	t1 := t0.Add(2 * time.Second)
+	ev := s.Ingest(req(3, t1, proxy.ClientToServer, "2", "tools/list", cacheMeta))
+	if ev.CacheStaleRefetch != "" {
+		t.Fatalf("expected no stale refetch after ttl, got %q", ev.CacheStaleRefetch)
+	}
+}
+
+func TestIngestCacheKeyIncludesCursor(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{"cursor":"a",`+cacheMeta[1:]))
+	s.Ingest(resp(2, t0, proxy.ServerToClient, "1", `"result":{"resultType":"complete","tools":[],"ttlMs":60000}`))
+
+	t1 := t0.Add(time.Second)
+	ev := s.Ingest(req(3, t1, proxy.ClientToServer, "2", "tools/list", `{"cursor":"b",`+cacheMeta[1:]))
+	if ev.CacheStaleRefetch != "" {
+		t.Fatalf("different cursor should be a separate cache key, got %q", ev.CacheStaleRefetch)
+	}
+}
+
+func TestIngestWarnsPublicScopeOnUserSpecificRead(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(req(1, now, proxy.ClientToServer, "1", "resources/read", `{"uri":"file:///user/profile",`+cacheMeta[1:]))
+	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"resultType":"complete","contents":[{"uri":"file:///user/profile","text":"{\"userId\":\"123\"}"}],"cacheScope":"public"}`))
+	if !strings.Contains(ev.Warning, "user-specific") {
+		t.Fatalf("expected public scope warning, got %q", ev.Warning)
+	}
+}
+
+func TestIngestIgnoresCacheHintsBeforeRevision(t *testing.T) {
+	s := New()
+	now := time.Now()
+	s.Ingest(req(1, now, proxy.ClientToServer, "1", "tools/list", `{"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}`))
+	ev := s.Ingest(resp(2, now, proxy.ServerToClient, "1", `"result":{"tools":[],"ttlMs":60000,"cacheScope":"private"}`))
+	if ev.CacheHint.TTLMs != 0 || ev.CacheHint.Scope != "" {
+		t.Fatalf("pre-2026-07-28 revision should not surface cache hints: %+v", ev.CacheHint)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -248,6 +248,9 @@ type session struct {
 
 	// cacheFresh records the most recent cacheable response per key (SEP-2549).
 	cacheFresh map[string]cacheEntry
+	// cacheListScope records the cacheScope the cursorless first page of a list
+	// run declared, which every later page of that run must repeat.
+	cacheListScope map[string]string
 }
 
 // Store is the concurrency-safe collector the hub feeds and the TUI reads.
@@ -375,12 +378,12 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		}
 		sess.paramHeaderInvalid = nil
 		if c != nil {
-			hint, scopeWarn := sess.recordCacheFromResponse(c, msg.Result, e.TS)
-			if hint.TTLMs > 0 || hint.Scope != "" {
+			hint, cacheWarnings := sess.recordCacheFromResponse(c, msg.Result, e.TS)
+			if !hint.Empty() {
 				ev.cacheHint = hint
 			}
-			if scopeWarn != "" {
-				ev.warning = appendWarning(ev.warning, scopeWarn)
+			for _, note := range cacheWarnings {
+				ev.warning = appendWarning(ev.warning, note)
 			}
 		}
 		if c != nil && c.taskID != "" {
@@ -470,6 +473,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.method = msg.Method
 		ev.warning = validationWarning(msg)
 		sess.notifications++
+		sess.invalidateCache(msg.Method, msg.Params)
 		if msg.Method == "notifications/cancelled" {
 			if id := cancelledRequestID(msg.Params); id != "" {
 				sess.closeStreamingCall(id, e.TS)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -179,6 +179,8 @@ type event struct {
 	mismatch           bool   // a routing header disagrees with the body (structured flag for warning)
 	truncated          bool   // the observed copy was capped at the frame-size limit
 	deprecated         string // a deprecated MCP feature was used (structured, not a protocol warning)
+	cacheHint          CacheHint
+	cacheStaleRefetch  string // client re-fetched inside a declared ttlMs window (structured, not a protocol warning)
 	call               *call  // set for request/response events
 	taskCall           *call  // originating call for a task lifecycle frame
 	taskID             string
@@ -236,6 +238,9 @@ type session struct {
 
 	lastSeq uint64 // highest per-session Seq seen, for gap detection
 	missing uint64 // envelopes dropped upstream, inferred from Seq gaps
+
+	// cacheFresh records the most recent cacheable response per key (SEP-2549).
+	cacheFresh map[string]cacheEntry
 }
 
 // Store is the concurrency-safe collector the hub feeds and the TUI reads.
@@ -354,6 +359,15 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		if note := missingResultTypeWarning(msg, c); note != "" {
 			ev.warning = appendWarning(ev.warning, note)
 		}
+		if c != nil {
+			hint, scopeWarn := sess.recordCacheFromResponse(c, msg.Result, e.TS)
+			if hint.TTLMs > 0 || hint.Scope != "" {
+				ev.cacheHint = hint
+			}
+			if scopeWarn != "" {
+				ev.warning = appendWarning(ev.warning, scopeWarn)
+			}
+		}
 		if c != nil && c.taskID != "" {
 			ev.taskID = c.taskID
 			if c.method != "tools/call" {
@@ -430,6 +444,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		}
 		if msg.Method == "initialize" {
 			sess.caps.applyRequest(msg.Params)
+		}
+		if ev.mrtrRoot == "" && cacheableMethod(msg.Method) {
+			if note := sess.checkCacheStale(msg.Method, msg.Params, e.TS, requestProtocolVersion(msg.Params, e.MCPProtocolVersion)); note != "" {
+				ev.cacheStaleRefetch = note
+			}
 		}
 	case msg.Method != "":
 		ev.kind = EventNotification

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -90,9 +90,14 @@ type EventView struct {
 	// Deprecated carries a heads-up when a frame uses a feature deprecated in the
 	// 2026-07-28 MCP release. It is structured like Truncated and never fails check.
 	Deprecated string
-	Call       *CallView // set for request/response events
-	TaskCall   *CallView // originating call for a tasks/* lifecycle frame
-	TaskID     string
+	// CacheHint surfaces ttlMs and cacheScope from a cacheable result (SEP-2549).
+	CacheHint CacheHint
+	// CacheStaleRefetch is set when a client re-fetches inside a declared ttlMs
+	// window. Structured like Deprecated and never fails check.
+	CacheStaleRefetch string
+	Call              *CallView // set for request/response events
+	TaskCall          *CallView // originating call for a tasks/* lifecycle frame
+	TaskID            string
 	// MRTRRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
 	MRTRRoot string
@@ -359,6 +364,8 @@ func (e *event) view(_ *session) EventView {
 		RoutingMismatch:    e.mismatch,
 		Truncated:          e.truncated,
 		Deprecated:         e.deprecated,
+		CacheHint:          e.cacheHint,
+		CacheStaleRefetch:  e.cacheStaleRefetch,
 		TaskID:             e.taskID,
 		MRTRRoot:           e.mrtrRoot,
 		MRTRStateIssue:     e.mrtrStateIssue,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -896,7 +896,7 @@ func countStreamSignals(events []store.EventView) streamSignalCounts {
 	var c streamSignalCounts
 	for _, e := range events {
 		switch {
-		case e.Kind != store.EventInvalid && (e.Warning != "" || e.Truncated || e.Deprecated != ""):
+		case e.Kind != store.EventInvalid && (e.Warning != "" || e.Truncated || e.Deprecated != "" || e.CacheStaleRefetch != ""):
 			c.warn++
 		case e.Kind == store.EventInvalid:
 			c.bad++
@@ -978,7 +978,7 @@ func statusRank(e store.EventView) int {
 	if e.Call != nil && e.Call.Failed() {
 		return 4
 	}
-	if e.Warning != "" || e.Truncated || e.Deprecated != "" {
+	if e.Warning != "" || e.Truncated || e.Deprecated != "" || e.CacheStaleRefetch != "" {
 		return 3
 	}
 	if e.Call == nil {
@@ -1118,7 +1118,7 @@ func (m *Model) matchStatus(e store.EventView, v string) bool {
 	if v == "warn" || v == "warning" {
 		// A capped observation reads as a warning in the row, so status:warn finds it
 		// too, even though it rides a structured flag rather than the warning text.
-		return e.Warning != "" || e.Truncated || e.Deprecated != ""
+		return e.Warning != "" || e.Truncated || e.Deprecated != "" || e.CacheStaleRefetch != ""
 	}
 	if v == "mismatch" {
 		// A routing header disagreeing with the body (Mcp-Method/Mcp-Name, SEP-2243).

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -738,6 +738,22 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = e.Deprecated + " · " + c.detail
 		}
 	}
+	if e.CacheStaleRefetch != "" {
+		c.status = "warn"
+		if c.detail == "" {
+			c.detail = e.CacheStaleRefetch
+		} else {
+			c.detail = e.CacheStaleRefetch + " · " + c.detail
+		}
+	}
+	if e.CacheHint.TTLMs > 0 || e.CacheHint.Scope != "" {
+		msg := formatCacheHint(e.CacheHint)
+		if c.detail == "" {
+			c.detail = msg
+		} else {
+			c.detail = msg + " · " + c.detail
+		}
+	}
 	if e.TaskID != "" {
 		link := "task " + e.TaskID
 		if e.TaskCall != nil {
@@ -875,6 +891,9 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 		return m.styles.warn
 	}
 	if e.Deprecated != "" {
+		return m.styles.warn
+	}
+	if e.CacheStaleRefetch != "" {
 		return m.styles.warn
 	}
 	if e.Call != nil {
@@ -2237,4 +2256,15 @@ func softWrap(s string, width int) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+func formatCacheHint(h store.CacheHint) string {
+	switch {
+	case h.TTLMs > 0 && h.Scope != "":
+		return fmt.Sprintf("cache ttlMs=%d cacheScope=%s", h.TTLMs, h.Scope)
+	case h.TTLMs > 0:
+		return fmt.Sprintf("cache ttlMs=%d", h.TTLMs)
+	default:
+		return fmt.Sprintf("cache cacheScope=%s", h.Scope)
+	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -746,7 +746,7 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = e.CacheStaleRefetch + " · " + c.detail
 		}
 	}
-	if e.CacheHint.TTLMs > 0 || e.CacheHint.Scope != "" {
+	if !e.CacheHint.Empty() {
 		msg := formatCacheHint(e.CacheHint)
 		if c.detail == "" {
 			c.detail = msg
@@ -2261,11 +2261,13 @@ func softWrap(s string, width int) string {
 	return strings.Join(lines, "\n")
 }
 
+// formatCacheHint renders what the server declared, including a ttlMs of 0,
+// which the spec gives the meaning "immediately stale" rather than "unset".
 func formatCacheHint(h store.CacheHint) string {
 	switch {
-	case h.TTLMs > 0 && h.Scope != "":
+	case h.TTLPresent && h.Scope != "":
 		return fmt.Sprintf("cache ttlMs=%d cacheScope=%s", h.TTLMs, h.Scope)
-	case h.TTLMs > 0:
+	case h.TTLPresent:
 		return fmt.Sprintf("cache ttlMs=%d", h.TTLMs)
 	default:
 		return fmt.Sprintf("cache cacheScope=%s", h.Scope)


### PR DESCRIPTION
## Summary

Parse SEP-2549 `ttlMs` and `cacheScope` from cacheable MCP list/read responses, surface them on timeline events, and add two observations:

- **Structured observation** when a client re-fetches inside the declared freshness window (`CacheStaleRefetch`, warn colour, does not fail default `check`)
- **Protocol warning** when `cacheScope: "public"` is declared on a `resources/read` response that looks user-specific

## Motivation

mcpsnoop sees the timing of every call and is well placed to spot cache misuse that would otherwise be invisible. Fixes #160.

## Changes

- `internal/store/cache.go` — parse cache hints, track freshness per cache key, detect stale refetch and public-scope mislabelling
- `internal/store/store.go` — session `cacheFresh` state and ingest hooks
- `internal/store/views.go` — `CacheHint` and `CacheStaleRefetch` on `EventView`
- `internal/tui/` — show cache metadata in detail; only stale refetch uses warn styling
- `internal/exporter/exporter.go` — export cache fields
- Tests in `cache_test.go` and `cache_check_test.go`

## Tests

- `go test -race ./internal/store/... ./cmd/mcpsnoop/... ./internal/exporter/...`
- All new cache tests pass; pre-existing TUI colour tests fail in this headless environment on main as well

## Notes

- Public-scope detection is intentionally conservative/heuristic (URI markers + obvious per-user JSON keys)
- Cache hint surfacing is informational in the TUI detail panel; only misuse observations use warn styling

Fixes #160