### PR TITLE
fix: validate and separate null request IDs

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -937,7 +937,7 @@ func eventKind(k store.EventKind) string {
 }
 
 func callKey(c store.CallView) string {
-	return string(c.ReqDir) + "\x00" + c.ID
+	return strconv.FormatUint(c.RequestSeq, 10)
 }
 
 func formatDuration(ms *float64) string {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -163,6 +163,41 @@ func TestBuildExportsSupersededCallNotAsOk(t *testing.T) {
 	}
 }
 
+func TestBuildKeepsNullIDCallsDistinct(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "null-id.jsonl")
+	t0 := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "files", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"read_file"}}`),
+	})
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "files", Seq: 2, TS: t0.Add(time.Second),
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"write_file"}}`),
+	})
+
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Calls) != 2 || len(out.Events) != 2 {
+		t.Fatalf("calls/events = %d/%d, want 2/2", len(out.Calls), len(out.Events))
+	}
+	for i, want := range []string{"read_file", "write_file"} {
+		if out.Events[i].CallIndex == nil || *out.Events[i].CallIndex != i {
+			t.Fatalf("event %d call index = %v, want %d", i, out.Events[i].CallIndex, i)
+		}
+		if out.Calls[i].ToolName != want {
+			t.Fatalf("call %d tool = %q, want %q", i, out.Calls[i].ToolName, want)
+		}
+	}
+}
+
 func TestBuildExportsCancelledTaskWithoutFlaggingAnError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cancel.jsonl")
 	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -112,6 +112,7 @@ func httpFailed(status int) bool { return status >= 400 }
 // the opposite direction with the same id.
 type callKey struct {
 	dir proxy.Direction
+	seq uint64
 	id  string
 	// conn separates the id spaces of two clients that share one proxy process.
 	// JSON-RPC scopes id uniqueness to the sender, "the ID MUST NOT match the ID
@@ -124,18 +125,19 @@ type callKey struct {
 
 // call is the mutable internal record for one request/response pair.
 type call struct {
-	id       string
-	method   string
-	reqDir   proxy.Direction
-	params   json.RawMessage
-	result   json.RawMessage
-	err      *proxy.RPCError
-	start    time.Time
-	end      time.Time
-	state    CallState
-	isTool   bool
-	toolName string
-	toolErr  bool // result.isError == true (MCP tool-level failure)
+	requestSeq uint64
+	id         string
+	method     string
+	reqDir     proxy.Direction
+	params     json.RawMessage
+	result     json.RawMessage
+	err        *proxy.RPCError
+	start      time.Time
+	end        time.Time
+	state      CallState
+	isTool     bool
+	toolName   string
+	toolErr    bool // result.isError == true (MCP tool-level failure)
 	// errored is the "something went wrong" axis: a protocol error, a tool-level
 	// error, or a task that ended failed. It drives the session error counter and
 	// the CI gate, and is deliberately distinct from the Failed state, which also
@@ -494,7 +496,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			// A continuation, not a new call. Mapping the retry id onto the same
 			// call object lets completeCall find it, so the operation keeps one
 			// pending slot and one duration however many round trips it takes.
-			sess.calls[callKey{dir: e.Direction, id: ev.id, conn: e.ConnID}] = root
+			sess.calls[requestCallKey(ev.id, msg.ID, e)] = root
 			root.mrtrState, root.mrtrKeys = "", ""
 			root.mrtrHasState = false
 			sess.unpark(root)
@@ -781,7 +783,7 @@ func (s *Store) sessionFor(e proxy.Envelope) *session {
 // a still-pending call for the same id and direction, meaning the client reused
 // an id while its earlier request was in flight. Caller holds the write lock.
 func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope) (*call, bool) {
-	key := callKey{dir: e.Direction, id: id, conn: e.ConnID}
+	key := requestCallKey(id, msg.ID, e)
 	prev, ok := sess.calls[key]
 	reused := ok && (prev.state == Pending || prev.state == Streaming)
 	if reused {
@@ -801,12 +803,13 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		prev.end = e.TS
 	}
 	c := &call{
-		id:     id,
-		method: msg.Method,
-		reqDir: e.Direction,
-		params: msg.Params,
-		start:  e.TS,
-		state:  Pending,
+		requestSeq: e.Seq,
+		id:         id,
+		method:     msg.Method,
+		reqDir:     e.Direction,
+		params:     msg.Params,
+		start:      e.TS,
+		state:      Pending,
 	}
 	if isStreamOpeningMethod(msg.Method) {
 		c.state = Streaming
@@ -822,6 +825,14 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 	c.protocolVersion = requestProtocolVersion(msg.Params, e.MCPProtocolVersion)
 	sess.calls[key] = c
 	return c, reused
+}
+
+func requestCallKey(id string, rawID json.RawMessage, e proxy.Envelope) callKey {
+	key := callKey{dir: e.Direction, id: id, conn: e.ConnID}
+	if bytes.Equal(bytes.TrimSpace(rawID), []byte("null")) {
+		key.seq = e.Seq
+	}
+	return key
 }
 
 // completeCall matches a response to its pending request. The bool reports
@@ -1589,6 +1600,9 @@ func validationWarning(msg proxy.RPCMessage) string {
 	case msg.JSONRPC != "2.0":
 		warning = appendWarning(warning, "jsonrpc must be 2.0")
 	}
+	if idWarning := requestIDWarning(msg); idWarning != "" {
+		warning = appendWarning(warning, idWarning)
+	}
 	if msg.Method == "" && len(msg.ID) > 0 {
 		if len(msg.Result) == 0 && msg.Error == nil {
 			warning = appendWarning(warning, "response has neither result nor error")
@@ -1598,6 +1612,42 @@ func validationWarning(msg proxy.RPCMessage) string {
 		}
 	}
 	return warning
+}
+
+func requestIDWarning(msg proxy.RPCMessage) string {
+	if msg.Method == "" || len(msg.ID) == 0 {
+		return ""
+	}
+	decoder := json.NewDecoder(bytes.NewReader(msg.ID))
+	decoder.UseNumber()
+	var id any
+	if decoder.Decode(&id) != nil {
+		return ""
+	}
+	switch value := id.(type) {
+	case string:
+		return ""
+	case json.Number:
+		if requestIDIsInteger(string(value)) {
+			return ""
+		}
+		return "request id has type non-integer number; MCP requires a string or integer id"
+	case nil:
+		return "request id is null; MCP requires a string or integer id"
+	case bool:
+		return "request id has type boolean; MCP requires a string or integer id"
+	case []any:
+		return "request id has type array; MCP requires a string or integer id"
+	default:
+		return "request id has type object; MCP requires a string or integer id"
+	}
+}
+
+func requestIDIsInteger(id string) bool {
+	id = strings.TrimPrefix(id, "-")
+	return id != "" && strings.IndexFunc(id, func(r rune) bool {
+		return r < '0' || r > '9'
+	}) == -1
 }
 
 // resultTypeRequiredFrom is the revision that made resultType mandatory on every

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1604,6 +1604,15 @@ func validationWarning(msg proxy.RPCMessage) string {
 		warning = appendWarning(warning, idWarning)
 	}
 	if msg.Method == "" && len(msg.ID) > 0 {
+		// A result MUST carry the same id as its request, so a null one names no
+		// request at all. An error response is exempt, since the spec lets it omit
+		// the id "in error cases where the ID could not be read due a malformed
+		// request", which is exactly what a null id says. Reported here because the
+		// correlation failure downstream reads as a missing frame, which sends the
+		// reader after the wrong problem.
+		if len(msg.Result) > 0 && bytes.Equal(bytes.TrimSpace(msg.ID), []byte("null")) {
+			warning = appendWarning(warning, "result response id is null; it names no request")
+		}
 		if len(msg.Result) == 0 && msg.Error == nil {
 			warning = appendWarning(warning, "response has neither result nor error")
 		}
@@ -1628,10 +1637,15 @@ func requestIDWarning(msg proxy.RPCMessage) string {
 	case string:
 		return ""
 	case json.Number:
-		if requestIDIsInteger(string(value)) {
+		// Judged on the value rather than the spelling. JSON has several ways to
+		// write one integer, and JSON Schema's own "integer" matches any number
+		// with a zero fractional part, so 1.0 and 1e3 are the ids 1 and 1000. A
+		// client whose serializer round-trips an id through a float is conforming,
+		// and refusing it would warn on correct traffic.
+		if parseMCPInteger(string(value)).integer {
 			return ""
 		}
-		return "request id has type non-integer number; MCP requires a string or integer id"
+		return "request id " + string(value) + " is not an integer; MCP requires a string or integer id"
 	case nil:
 		return "request id is null; MCP requires a string or integer id"
 	case bool:
@@ -1641,13 +1655,6 @@ func requestIDWarning(msg proxy.RPCMessage) string {
 	default:
 		return "request id has type object; MCP requires a string or integer id"
 	}
-}
-
-func requestIDIsInteger(id string) bool {
-	id = strings.TrimPrefix(id, "-")
-	return id != "" && strings.IndexFunc(id, func(r rune) bool {
-		return r < '0' || r > '9'
-	}) == -1
 }
 
 // resultTypeRequiredFrom is the revision that made resultType mandatory on every

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -236,8 +236,16 @@ func TestInvalidRequestIDTypesWarn(t *testing.T) {
 	}{
 		{"string", `"abc"`, ""},
 		{"integer", "42", ""},
+		{"negative integer", "-7", ""},
+		// JSON has several spellings for one integer, and JSON Schema's own
+		// "integer" matches any number with a zero fractional part. A client whose
+		// serializer round-trips an id through a float is conforming, so judging the
+		// spelling rather than the value would warn on correct traffic.
+		{"integer written as a float", "1.0", ""},
+		{"integer written with an exponent", "1e3", ""},
+		{"integer past the safe range", "12345678901234567890", ""},
 		{"null", "null", "request id is null; MCP requires a string or integer id"},
-		{"fraction", "1.5", "request id has type non-integer number; MCP requires a string or integer id"},
+		{"fraction", "1.5", "request id 1.5 is not an integer; MCP requires a string or integer id"},
 		{"boolean", "true", "request id has type boolean; MCP requires a string or integer id"},
 		{"array", "[]", "request id has type array; MCP requires a string or integer id"},
 		{"object", "{}", "request id has type object; MCP requires a string or integer id"},
@@ -2157,5 +2165,26 @@ func TestTwoClientsThroughOneProxyKeepSeparateIDSpaces(t *testing.T) {
 	s2.Ingest(conn(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{}`), "10.0.0.1:5001"))
 	if ev := s2.Ingest(conn(req(2, t0, proxy.ClientToServer, "1", "tools/list", `{}`), "10.0.0.1:5001")); ev.Warning == "" {
 		t.Fatal("one sender reusing an id in flight must still be reported")
+	}
+}
+
+// TestNullResultResponseNamesTheRealViolation. Separating null-id requests means
+// a null-id response matches none of them, and "response id has no matching
+// request" then sends the reader after a frame that is not missing. The result
+// carrying a null id is the actual violation, since the spec requires a result to
+// carry the same id as its request. An error response stays exempt, because the
+// spec lets one omit the id "in error cases where the ID could not be read due a
+// malformed request".
+func TestNullResultResponseNamesTheRealViolation(t *testing.T) {
+	s := New()
+	ev := s.Ingest(resp(1, time.Now(), proxy.ServerToClient, "null", `"result":{}`))
+	if !strings.Contains(ev.Warning, "result response id is null") {
+		t.Fatalf("warning = %q, want the null result id named", ev.Warning)
+	}
+
+	errored := New().Ingest(resp(1, time.Now(), proxy.ServerToClient, "null",
+		`"error":{"code":-32700,"message":"parse error"}`))
+	if strings.Contains(errored.Warning, "id is null") {
+		t.Fatalf("an error response may omit the id, got %q", errored.Warning)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -196,6 +196,71 @@ func TestReusedRequestIdKeepsPendingCounterAndTimelineInSync(t *testing.T) {
 	}
 }
 
+func TestNullRequestIDsRemainDistinct(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	first := s.Ingest(req(1, t0, proxy.ClientToServer, "null", "tools/call", `{"name":"read_file"}`))
+	second := s.Ingest(req(2, t0.Add(time.Millisecond), proxy.ClientToServer, "null", "tools/call", `{"name":"write_file"}`))
+
+	want := "request id is null; MCP requires a string or integer id"
+	if first.Warning != want || second.Warning != want {
+		t.Fatalf("null id warnings = %q and %q, want %q", first.Warning, second.Warning, want)
+	}
+	if strings.Contains(second.Warning, "reuses an id") {
+		t.Fatalf("null ids must not be treated as reusable identifiers: %q", second.Warning)
+	}
+	response := s.Ingest(resp(3, t0.Add(2*time.Millisecond), proxy.ServerToClient, "null", `"error":{"code":-32700,"message":"parse error"}`))
+	if !strings.Contains(response.Warning, "no matching request") {
+		t.Fatalf("null response warning = %q, want an unmatched response", response.Warning)
+	}
+	if got := s.Sessions()[0].Pending; got != 2 {
+		t.Fatalf("pending = %d, want 2", got)
+	}
+	calls := s.Calls("s1")
+	if len(calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(calls))
+	}
+	if calls[0].State != Pending || calls[1].State != Pending {
+		t.Fatalf("null id calls should both remain pending: %+v", calls)
+	}
+	if calls[0].ToolName != "read_file" || calls[1].ToolName != "write_file" {
+		t.Fatalf("tool names = %q and %q", calls[0].ToolName, calls[1].ToolName)
+	}
+}
+
+func TestInvalidRequestIDTypesWarn(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"string", `"abc"`, ""},
+		{"integer", "42", ""},
+		{"null", "null", "request id is null; MCP requires a string or integer id"},
+		{"fraction", "1.5", "request id has type non-integer number; MCP requires a string or integer id"},
+		{"boolean", "true", "request id has type boolean; MCP requires a string or integer id"},
+		{"array", "[]", "request id has type array; MCP requires a string or integer id"},
+		{"object", "{}", "request id has type object; MCP requires a string or integer id"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := New()
+			ev := s.Ingest(req(1, time.Now(), proxy.ClientToServer, test.id, "ping", ""))
+			if ev.Warning != test.want {
+				t.Fatalf("warning = %q, want %q", ev.Warning, test.want)
+			}
+		})
+	}
+}
+
+func TestNullErrorResponseDoesNotUseRequestIDWarning(t *testing.T) {
+	s := New()
+	ev := s.Ingest(resp(1, time.Now(), proxy.ServerToClient, "null", `"error":{"code":-32700,"message":"parse error"}`))
+	if strings.Contains(ev.Warning, "request id") {
+		t.Fatalf("null error response got request warning %q", ev.Warning)
+	}
+}
+
 func TestSessionReportsSeqGapAsMissingFrames(t *testing.T) {
 	now := time.Now()
 

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -13,15 +13,16 @@ import (
 
 // CallView is an immutable snapshot of a correlated request/response pair.
 type CallView struct {
-	ID       string
-	Method   string
-	ReqDir   proxy.Direction
-	IsTool   bool
-	ToolName string
-	Params   json.RawMessage
-	Result   json.RawMessage
-	Err      *proxy.RPCError
-	ToolErr  bool // result.isError == true
+	RequestSeq uint64
+	ID         string
+	Method     string
+	ReqDir     proxy.Direction
+	IsTool     bool
+	ToolName   string
+	Params     json.RawMessage
+	Result     json.RawMessage
+	Err        *proxy.RPCError
+	ToolErr    bool // result.isError == true
 	// Errored is the "something went wrong" axis, distinct from Failed(): a
 	// cancelled task is Failed() (it delivered nothing) but not Errored (the user
 	// stopped it on purpose). The session error counter and the CI gate read this.
@@ -389,6 +390,7 @@ func (e *event) view(_ *session) EventView {
 
 func (c *call) view() CallView {
 	return CallView{
+		RequestSeq: c.requestSeq,
 		ID:         c.id,
 		Method:     c.method,
 		ReqDir:     c.reqDir,


### PR DESCRIPTION
## What and why

Warn when requests use IDs outside MCP's string and integer types. Null IDs now remain separate pending calls, and exported events keep the right call and tool name. Closes #197.

## Checklist

- [ ] `make check` passes (Windows vet, staticcheck, build, and the changed package tests pass; the full race suite runs in CI)
- [x] Added or updated tests for the change, where it makes sense
- [x] README/docs are not needed for this protocol-validation fix
