### PR TITLE
fix: track cancelled calls and late results

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop` | open the live TUI |
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, har, or otlp |
-| `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, or hung calls |
+| `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, or late results |
 | `mcpsnoop baseline` | inspect, accept, or reset trusted tool definitions |
 | `mcpsnoop diff` | compare tools and calls across two captured sessions |
 | `mcpsnoop open` | open a saved session in the TUI |
@@ -223,12 +223,14 @@ matches the method, tool, id, and payload.
 | `task:` | task id | `task:01J...` |
 | `dir:` | direction (`c2s`, `s2c`) | `dir:s2c` |
 | `kind:` | frame type (`req`, `resp`, `notify`, `stderr`, `invalid`) | `kind:invalid` |
-| `status:` | call outcome (`ok`, `error`, `cancelled`, `pending`, `bad`, `warn`, `mismatch`) | `status:error` |
+| `status:` | call outcome (`ok`, `error`, `cancel`, `late`, `cancelled`, `pending`, `bad`, `warn`, `mismatch`, or an HTTP status like `401`) | `status:error` |
 
 Stack tokens to get specific.
 
 ```text
 tool:search status:pending        # in-flight calls to one search tool
+status:cancel                     # calls the client gave up on (status:cancelled is a cancelled task)
+status:late                       # results that arrived after the cancellation
 method:tools/call status:error    # tool calls that failed
 dir:s2c kind:req                  # server-initiated requests (servers before 2026-07-28)
 ```

--- a/README.md
+++ b/README.md
@@ -360,17 +360,19 @@ leave the capture incomplete, tool-definition drift, or use of deprecated
 protocol features.
 
 ```bash
-mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending,drift,deprecated,incomplete] [session-id|log.jsonl|-]
+mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending,late-result,drift,deprecated,incomplete] [session-id|log.jsonl|-]
 ```
 
 The three default signals (error, invalid, warn) fail the check. Add `pending`
-to gate on calls that never got a response, `mismatch` to gate specifically on a
+to gate on calls that never got a response, `late-result` to gate on responses
+that arrived after cancellation, `mismatch` to gate specifically on a
 routing header (Mcp-Method or Mcp-Name) disagreeing with the body, `drift` to gate
 on tool definitions changing after approval, `deprecated` to gate on features
 the spec has deprecated, or `incomplete` to gate on captures with dropped frames.
 Pass a comma-separated subset to select only the
 conditions relevant to a job. Omit the session to check the newest capture, or use
-`-` to read JSONL from stdin.
+`-` to read JSONL from stdin. Late results are reported as `late_results` without
+affecting the default error, invalid, or warning signals.
 The dropped-frame count travels with the artifacts too, so a capture that
 understates itself says so wherever it is opened: `missing_frames` in the JSON
 export, `log.comment` in HAR, and the `mcpsnoop.session.missing_frames` resource

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -20,12 +20,13 @@ const (
 	checkWarn       checkSignal = "warn"
 	checkMismatch   checkSignal = "mismatch"
 	checkPending    checkSignal = "pending"
+	checkLateResult checkSignal = "late-result"
 	checkDrift      checkSignal = "drift"
 	checkDeprecated checkSignal = "deprecated"
 	checkIncomplete checkSignal = "incomplete"
 )
 
-var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated, checkIncomplete}
+var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkLateResult, checkDrift, checkDeprecated, checkIncomplete}
 
 type checkOutputFormat string
 
@@ -41,6 +42,7 @@ type checkSummary struct {
 	warnings        int
 	mismatches      int
 	pending         int
+	lateResults     int
 	deprecated      int
 	missingFrames   uint64
 	drift           store.ToolDrift
@@ -54,7 +56,7 @@ func newCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check [session-id|log.jsonl|-]",
 		Short: "Fail when a captured session violates a signal or an assertion",
-		Long:  "Check a captured session against signals (errors, invalid frames, warnings, routing-header mismatches, calls that never got a response, dropped frames that leave the capture incomplete, tool-definition drift) and assertions (a tool-call latency budget, and tools that must or must not have been called). With no session, the newest session log is checked. Use - to read from stdin.",
+		Long:  "Check a captured session against signals (errors, invalid frames, warnings, routing-header mismatches, calls that never got a response, results that arrived after cancellation, dropped frames that leave the capture incomplete, tool-definition drift) and assertions (a tool-call latency budget, and tools that must or must not have been called). With no session, the newest session log is checked. Use - to read from stdin.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			signals, err := parseCheckSignals(failOn)
@@ -102,8 +104,8 @@ func newCheckCmd() *cobra.Command {
 				}
 			} else {
 				for i, summary := range summaries {
-					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d deprecated=%d missing_frames=%d\n",
-						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.deprecated, summary.missingFrames)
+					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d late_results=%d deprecated=%d missing_frames=%d\n",
+						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.lateResults, summary.deprecated, summary.missingFrames)
 					if summary.baselineCreated {
 						// No baseline existed, so this run trusted the current definitions
 						// rather than verifying them. Say so, or an ephemeral CI reads green
@@ -138,7 +140,7 @@ func newCheckCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().SortFlags = false
-	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift, deprecated, incomplete")
+	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, late-result, drift, deprecated, incomplete")
 	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text or junit")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
 	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
@@ -177,9 +179,7 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 		var worstDuration time.Duration
 		var worstTool string
 		for _, c := range calls {
-			// Only a call that actually got a response has a real latency. Pending and
-			// superseded calls never did, so they are not judged here.
-			if !c.IsTool || !c.Done() || c.State == store.Superseded {
+			if !c.IsTool || !c.Done() || c.State == store.Superseded || (c.State == store.Cancelled && !c.LateResult) {
 				continue
 			}
 			duration := c.Duration()
@@ -219,10 +219,10 @@ func parseCheckSignals(value string) (map[checkSignal]bool, error) {
 	for _, part := range strings.Split(value, ",") {
 		signal := checkSignal(strings.TrimSpace(part))
 		switch signal {
-		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated, checkIncomplete:
+		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkLateResult, checkDrift, checkDeprecated, checkIncomplete:
 			signals[signal] = true
 		default:
-			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, drift, deprecated, or incomplete, got %q", part)
+			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, late-result, drift, deprecated, or incomplete, got %q", part)
 		}
 	}
 	return signals, nil
@@ -256,7 +256,13 @@ func loadCheckSession(cmd *cobra.Command, arg string) (*store.Store, string, err
 func summarizeCheck(st *store.Store, baselines *toolbaseline.Manager) []checkSummary {
 	var summaries []checkSummary
 	for _, header := range st.Sessions() {
-		summary := checkSummary{sessionID: header.ID, errors: header.Errors, pending: header.Pending, missingFrames: header.MissingFrames}
+		summary := checkSummary{
+			sessionID:     header.ID,
+			errors:        header.Errors,
+			pending:       header.Pending,
+			lateResults:   header.LateResults,
+			missingFrames: header.MissingFrames,
+		}
 		if _, ok := st.ToolDefinitions(header.ID); ok {
 			report, created, err := toolbaseline.ObserveSession(baselines, st, header.ID)
 			if err != nil {
@@ -309,6 +315,8 @@ func (s checkSummary) count(signal checkSignal) int {
 		return s.mismatches
 	case checkPending:
 		return s.pending
+	case checkLateResult:
+		return s.lateResults
 	case checkDrift:
 		// A baseline error is not drift, but it means drift could not be verified,
 		// so count it as a drift failure for a run that selected the drift signal.

--- a/cmd/mcpsnoop/check_junit.go
+++ b/cmd/mcpsnoop/check_junit.go
@@ -148,6 +148,8 @@ func checkSignalFailureReason(sessionID string, signal checkSignal, count int) s
 		singular, plural = "routing mismatch", "routing mismatches"
 	case checkPending:
 		singular, plural = "pending call", "pending calls"
+	case checkLateResult:
+		singular, plural = "late result", "late results"
 	case checkDrift:
 		singular, plural = "tool definition change", "tool definition changes"
 	case checkDeprecated:

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -23,11 +23,40 @@ func TestCheckFailsOnSelectedSessionSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0 missing_frames=0\ncheck failed: error,invalid,warn\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 late_results=0 deprecated=0 missing_frames=0\ncheck failed: error,invalid,warn\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
 		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestCheckReportsLateResultsAndGatesOnlyWhenSelected(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"slow"}}`),
+		checkEnvelope(2, proxy.ClientToServer, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}`),
+		checkEnvelope(3, proxy.ServerToClient, `{"jsonrpc":"2.0","id":7,"result":{"content":[]}}`),
+	)
+
+	code, stdout, stderr := executeCheck(t, []string{"-"}, log)
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "late_results=1") || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("default late-result check = code %d stdout %q stderr %q", code, stdout, stderr)
+	}
+
+	code, stdout, stderr = executeCheck(t, []string{"--fail-on", "late-result", "-"}, log)
+	if code != 1 || stderr != "" || !strings.Contains(stdout, "check failed: late-result") {
+		t.Fatalf("selected late-result check = code %d stdout %q stderr %q", code, stdout, stderr)
+	}
+
+	code, stdout, stderr = executeCheck(t, []string{"--format", "junit", "--fail-on", "late-result", "-"}, log)
+	if code != 1 || stderr != "" {
+		t.Fatalf("late-result junit = code %d stderr %q", code, stderr)
+	}
+	for _, want := range []string{`name="s1/late-result"`, `type="mcpsnoop.check.late-result"`, "1 late result"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("junit stdout missing %q\n%s", want, stdout)
+		}
 	}
 }
 
@@ -39,7 +68,7 @@ func TestCheckFailsOnlyOnSelectedSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 because the fixture contains an invalid frame", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0 missing_frames=0\ncheck failed: invalid\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 late_results=0 deprecated=0 missing_frames=0\ncheck failed: invalid\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -54,7 +83,7 @@ func TestCheckIgnoresUnselectedSignals(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0 missing_frames=0\ncheck passed\n" {
+	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0 late_results=0 deprecated=0 missing_frames=0\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -73,7 +102,7 @@ func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0 missing_frames=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
+	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0 late_results=0 deprecated=0 missing_frames=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -92,8 +121,8 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	const want = `<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="mcpsnoop check" tests="9" failures="3" errors="0" skipped="0" time="0">
-  <testsuite name="s1" tests="9" failures="3" errors="0" skipped="0" time="0">
+<testsuites name="mcpsnoop check" tests="10" failures="3" errors="0" skipped="0" time="0">
+  <testsuite name="s1" tests="10" failures="3" errors="0" skipped="0" time="0">
     <testcase classname="mcpsnoop.check" name="s1/error" time="0">
       <failure message="session s1 has 2 errors" type="mcpsnoop.check.error">session s1 has 2 errors</failure>
     </testcase>
@@ -105,6 +134,7 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
     </testcase>
     <testcase classname="mcpsnoop.check" name="s1/mismatch" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/pending" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/late-result" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/drift" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/deprecated" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/incomplete" time="0"></testcase>
@@ -128,7 +158,7 @@ func TestCheckJUnitHonorsFailOn(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 because errors are not selected", code)
 	}
-	for _, want := range []string{`tests="9"`, `failures="0"`, `name="s1/error"`} {
+	for _, want := range []string{`tests="10"`, `failures="0"`, `name="s1/error"`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -100,6 +100,7 @@ type SessionSummary struct {
 	Notifications int       `json:"notifications"`
 	Errors        int       `json:"errors"`
 	Pending       int       `json:"pending"`
+	LateResults   int       `json:"late_results"`
 	// MissingFrames counts envelopes dropped upstream, inferred from Seq gaps.
 	// A non-zero value means the capture is incomplete.
 	MissingFrames uint64 `json:"missing_frames"`
@@ -115,24 +116,27 @@ type CapabilitiesExport struct {
 }
 
 type CallExport struct {
-	Index      int             `json:"index"`
-	ID         string          `json:"id"`
-	Method     string          `json:"method"`
-	Direction  proxy.Direction `json:"direction"`
-	State      string          `json:"state"`
-	Status     string          `json:"status"`
-	IsTool     bool            `json:"is_tool"`
-	ToolName   string          `json:"tool_name,omitempty"`
-	IsError    bool            `json:"is_error"`
-	ToolError  bool            `json:"tool_error"`
-	TaskID     string          `json:"task_id,omitempty"`
-	TaskStatus string          `json:"task_status,omitempty"`
-	StartedAt  time.Time       `json:"started_at"`
-	EndedAt    *time.Time      `json:"ended_at,omitempty"`
-	DurationMS *float64        `json:"duration_ms,omitempty"`
-	Params     json.RawMessage `json:"params,omitempty"`
-	Result     json.RawMessage `json:"result,omitempty"`
-	Error      *proxy.RPCError `json:"error,omitempty"`
+	Index        int             `json:"index"`
+	ID           string          `json:"id"`
+	Method       string          `json:"method"`
+	Direction    proxy.Direction `json:"direction"`
+	State        string          `json:"state"`
+	Status       string          `json:"status"`
+	IsTool       bool            `json:"is_tool"`
+	ToolName     string          `json:"tool_name,omitempty"`
+	IsError      bool            `json:"is_error"`
+	ToolError    bool            `json:"tool_error"`
+	TaskID       string          `json:"task_id,omitempty"`
+	TaskStatus   string          `json:"task_status,omitempty"`
+	StartedAt    time.Time       `json:"started_at"`
+	EndedAt      *time.Time      `json:"ended_at,omitempty"`
+	CancelledAt  *time.Time      `json:"cancelled_at,omitempty"`
+	CancelReason string          `json:"cancel_reason,omitempty"`
+	LateResult   bool            `json:"late_result,omitempty"`
+	DurationMS   *float64        `json:"duration_ms,omitempty"`
+	Params       json.RawMessage `json:"params,omitempty"`
+	Result       json.RawMessage `json:"result,omitempty"`
+	Error        *proxy.RPCError `json:"error,omitempty"`
 	// ErrorName is the specification's name for Error.Code, absent when the code
 	// is one the spec leaves to implementations. A sibling rather than a field
 	// inside Error, so the error object stays the wire shape.
@@ -140,14 +144,15 @@ type CallExport struct {
 }
 
 type EventExport struct {
-	Seq       uint64          `json:"seq"`
-	Timestamp time.Time       `json:"timestamp"`
-	Direction proxy.Direction `json:"direction"`
-	Kind      string          `json:"kind"`
-	Method    string          `json:"method,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Warning   string          `json:"warning,omitempty"`
-	Mismatch  bool            `json:"mismatch,omitempty"`
+	Seq         uint64          `json:"seq"`
+	Timestamp   time.Time       `json:"timestamp"`
+	Direction   proxy.Direction `json:"direction"`
+	Kind        string          `json:"kind"`
+	Method      string          `json:"method,omitempty"`
+	ID          string          `json:"id,omitempty"`
+	Warning     string          `json:"warning,omitempty"`
+	Observation string          `json:"observation,omitempty"`
+	Mismatch    bool            `json:"mismatch,omitempty"`
 	// Status is the HTTP status the frame arrived on and AuthChallenge that
 	// response's WWW-Authenticate header, both absent on stdio.
 	Status        int    `json:"http_status,omitempty"`
@@ -327,6 +332,7 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 			Notifications: header.Notifications,
 			Errors:        header.Errors,
 			Pending:       header.Pending,
+			LateResults:   header.LateResults,
 			MissingFrames: header.MissingFrames,
 		},
 		Calls:  outCalls,
@@ -518,9 +524,18 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 		if call.DurationMS != nil {
 			attrs = append(attrs, otlpDouble("mcpsnoop.call.duration_ms", *call.DurationMS))
 		}
+		if call.CancelledAt != nil {
+			attrs = append(attrs, otlpString("mcpsnoop.call.cancelled_at", call.CancelledAt.Format(time.RFC3339Nano)))
+		}
+		if call.CancelReason != "" {
+			attrs = append(attrs, otlpString("mcpsnoop.call.cancel_reason", call.CancelReason))
+		}
+		if call.LateResult {
+			attrs = append(attrs, otlpBool("mcpsnoop.call.late_result", true))
+		}
 		status := "STATUS_CODE_OK"
-		if call.State == "pending" || call.State == "superseded" {
-			status = "STATUS_CODE_UNSET" // no definitive outcome, never answered
+		if call.State == "pending" || call.State == "superseded" || call.Status == "call_cancelled" || call.Status == "late_result" {
+			status = "STATUS_CODE_UNSET"
 		}
 		if call.IsError {
 			status = "STATUS_CODE_ERROR"
@@ -547,6 +562,7 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 			otlpString("service.name", "mcpsnoop"),
 			otlpString("mcpsnoop.session.id", data.Session.ID),
 			otlpString("mcpsnoop.session.label", data.Session.Label),
+			otlpInt("mcpsnoop.session.late_results", int64(data.Session.LateResults)),
 			// Emitted even when zero. Absence would be ambiguous between a capture
 			// that dropped nothing and one exported before this attribute existed,
 			// and the whole point of the count is that the span total can be
@@ -758,6 +774,10 @@ func exportCall(index int, c store.CallView) CallExport {
 		status = "streaming"
 	case c.State == store.Superseded:
 		status = "superseded"
+	case c.State == store.Cancelled && c.LateResult:
+		status = "late_result"
+	case c.State == store.Cancelled:
+		status = "call_cancelled"
 	case c.TaskStatus == "cancelled":
 		// Terminal and without a result, so not ok, but the user stopped the work on
 		// purpose rather than hitting an error. Its own status ahead of Failed(),
@@ -767,27 +787,31 @@ func exportCall(index int, c store.CallView) CallExport {
 		status = "error"
 	}
 	out := CallExport{
-		Index:      index,
-		ID:         c.ID,
-		Method:     c.Method,
-		Direction:  c.ReqDir,
-		State:      c.State.String(),
-		Status:     status,
-		IsTool:     c.IsTool,
-		ToolName:   c.ToolName,
-		IsError:    c.Errored, // the "something went wrong" axis, so a cancel is not flagged
-		ToolError:  c.ToolErr,
-		TaskID:     c.TaskID,
-		TaskStatus: c.TaskStatus,
-		StartedAt:  c.Start,
-		Params:     c.Params,
-		Result:     c.Result,
-		Error:      c.Err,
-		ErrorName:  errorName(c.Err),
+		Index:        index,
+		ID:           c.ID,
+		Method:       c.Method,
+		Direction:    c.ReqDir,
+		State:        c.State.String(),
+		Status:       status,
+		IsTool:       c.IsTool,
+		ToolName:     c.ToolName,
+		IsError:      c.Errored,
+		ToolError:    c.ToolErr,
+		TaskID:       c.TaskID,
+		TaskStatus:   c.TaskStatus,
+		StartedAt:    c.Start,
+		CancelReason: c.CancelReason,
+		LateResult:   c.LateResult,
+		Params:       c.Params,
+		Result:       c.Result,
+		Error:        c.Err,
+		ErrorName:    errorName(c.Err),
 	}
-	// A superseded call was never answered; its stored end is the moment the id was
-	// reused, not a latency, so omit the duration the way a pending call does.
-	if c.Done() && c.State != store.Superseded {
+	if !c.CancelledAt.IsZero() {
+		cancelledAt := c.CancelledAt
+		out.CancelledAt = &cancelledAt
+	}
+	if c.Done() && c.State != store.Superseded && (c.State != store.Cancelled || c.LateResult) {
 		end := c.End
 		dur := float64(c.End.Sub(c.Start)) / float64(time.Millisecond)
 		out.EndedAt = &end
@@ -805,6 +829,7 @@ func exportEvent(ev store.EventView, callIndex map[string]int) EventExport {
 		Method:            ev.Method,
 		ID:                ev.ID,
 		Warning:           ev.Warning,
+		Observation:       ev.Observation,
 		Mismatch:          ev.RoutingMismatch,
 		Status:            ev.HTTPStatus,
 		AuthChallenge:     ev.AuthChallenge,
@@ -829,8 +854,8 @@ func writeText(w io.Writer, data SessionExport) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(w, "frames: %d  calls: %d  requests: %d  responses: %d  errors: %d  pending: %d\n\n",
-		len(data.Events), len(data.Calls), data.Session.Requests, data.Session.Responses, data.Session.Errors, data.Session.Pending)
+	_, err = fmt.Fprintf(w, "frames: %d  calls: %d  requests: %d  responses: %d  errors: %d  pending: %d  late results: %d\n\n",
+		len(data.Events), len(data.Calls), data.Session.Requests, data.Session.Responses, data.Session.Errors, data.Session.Pending, data.Session.LateResults)
 	if err != nil {
 		return err
 	}
@@ -844,6 +869,9 @@ func writeText(w io.Writer, data SessionExport) error {
 		}
 		if ev.Warning != "" {
 			title += " warning=" + ev.Warning
+		}
+		if ev.Observation != "" {
+			title += " observation=" + ev.Observation
 		}
 		if ev.Truncated {
 			title += " truncated"

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -198,6 +198,84 @@ func TestBuildKeepsNullIDCallsDistinct(t *testing.T) {
 	}
 }
 
+func TestBuildExportsCallCancellationAndLateResult(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cancelled-call.jsonl")
+	t0 := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	cancelledAt := t0.Add(250 * time.Millisecond)
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"slow"}}`),
+	})
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: cancelledAt,
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7,"reason":"moved on"}}`),
+	})
+
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cancelled.Session.Pending != 0 || cancelled.Session.LateResults != 0 || len(cancelled.Calls) != 1 {
+		t.Fatalf("cancelled summary/calls = %+v %+v", cancelled.Session, cancelled.Calls)
+	}
+	call := cancelled.Calls[0]
+	if call.State != "cancelled" || call.Status != "call_cancelled" {
+		t.Fatalf("cancelled state/status = %q/%q", call.State, call.Status)
+	}
+	if call.CancelledAt == nil || *call.CancelledAt != cancelledAt || call.CancelReason != "moved on" {
+		t.Fatalf("cancelled metadata = %v %q", call.CancelledAt, call.CancelReason)
+	}
+	if call.EndedAt != nil || call.DurationMS != nil || call.LateResult || len(call.Result) != 0 {
+		t.Fatalf("unanswered cancellation exported as %+v", call)
+	}
+
+	st.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 3, TS: t0.Add(time.Second),
+		Direction: proxy.ServerToClient,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","id":7,"result":{"content":[]}}`),
+	})
+	late, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call = late.Calls[0]
+	if late.Session.LateResults != 1 || call.Status != "late_result" || !call.LateResult {
+		t.Fatalf("late result summary/call = %+v %+v", late.Session, call)
+	}
+	if call.EndedAt == nil || call.DurationMS == nil || *call.DurationMS != 1000 {
+		t.Fatalf("late result timing = ended %v duration %v", call.EndedAt, call.DurationMS)
+	}
+	if len(late.Events) != 3 || late.Events[2].Observation != "result arrived 750ms after cancellation" {
+		t.Fatalf("late result event = %+v", late.Events)
+	}
+
+	var text bytes.Buffer
+	if err := Write(&text, late, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"late results: 1", "status=late_result duration_ms=1000", "observation=result arrived 750ms after cancellation"} {
+		if !strings.Contains(text.String(), want) {
+			t.Fatalf("text export missing %q\n%s", want, text.String())
+		}
+	}
+
+	var otlp bytes.Buffer
+	if err := Write(&otlp, late, Options{Format: FormatOTLP}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"mcpsnoop.session.late_results", "mcpsnoop.call.cancelled_at", "mcpsnoop.call.cancel_reason", "mcpsnoop.call.late_result", "STATUS_CODE_UNSET"} {
+		if !strings.Contains(otlp.String(), want) {
+			t.Fatalf("OTLP export missing %q\n%s", want, otlp.String())
+		}
+	}
+}
+
 func TestBuildExportsCancelledTaskWithoutFlaggingAnError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cancel.jsonl")
 	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)

--- a/internal/exporter/har.go
+++ b/internal/exporter/har.go
@@ -204,6 +204,10 @@ func harStatus(status string) (int, string) {
 		return 200, "OK"
 	case "error":
 		return 500, "Error"
+	case "late_result":
+		return 200, "Late Result"
+	case "call_cancelled":
+		return 0, "Cancelled"
 	case "":
 		return 0, "No Response"
 	default:

--- a/internal/exporter/har_test.go
+++ b/internal/exporter/har_test.go
@@ -114,8 +114,9 @@ func TestHARMapsCallOutcomeToStatus(t *testing.T) {
 	}
 }
 
-// Every tools/call would otherwise share one URL, which is the column a HAR
-// viewer is scanned by.
+// TestHARDistinguishesCancelledCallsAndLateResults. A HAR viewer reads the status
+// column, so a call the client gave up on and a result that arrived after it must
+// not both render as the 200 an ordinary call gets.
 func TestHARDistinguishesCancelledCallsAndLateResults(t *testing.T) {
 	start := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
 	duration := 1000.0
@@ -134,6 +135,8 @@ func TestHARDistinguishesCancelledCallsAndLateResults(t *testing.T) {
 	}
 }
 
+// Every tools/call would otherwise share one URL, which is the column a HAR
+// viewer is scanned by.
 func TestHARURLCarriesLabelAndTool(t *testing.T) {
 	got := writeHARForTest(t, harSession())
 	if url := got.Log.Entries[0].Request.URL; url != "mcp://filesystem/tools/call/search" {

--- a/internal/exporter/har_test.go
+++ b/internal/exporter/har_test.go
@@ -116,6 +116,24 @@ func TestHARMapsCallOutcomeToStatus(t *testing.T) {
 
 // Every tools/call would otherwise share one URL, which is the column a HAR
 // viewer is scanned by.
+func TestHARDistinguishesCancelledCallsAndLateResults(t *testing.T) {
+	start := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	duration := 1000.0
+	got := writeHARForTest(t, SessionExport{
+		Session: SessionSummary{ID: "s1"},
+		Calls: []CallExport{
+			{ID: "1", Method: "tools/call", Status: "call_cancelled", StartedAt: start},
+			{ID: "2", Method: "tools/call", Status: "late_result", StartedAt: start, DurationMS: &duration, Result: json.RawMessage(`{"content":[]}`)},
+		},
+	})
+	if response := got.Log.Entries[0].Response; response.Status != 0 || response.StatusText != "Cancelled" {
+		t.Fatalf("cancelled HAR response = %+v", response)
+	}
+	if response := got.Log.Entries[1].Response; response.Status != 200 || response.StatusText != "Late Result" {
+		t.Fatalf("late HAR response = %+v", response)
+	}
+}
+
 func TestHARURLCarriesLabelAndTool(t *testing.T) {
 	got := writeHARForTest(t, harSession())
 	if url := got.Log.Entries[0].Request.URL; url != "mcp://filesystem/tools/call/search" {

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -37,6 +37,7 @@ main { padding:18px 24px 40px; max-width:1180px; margin:0 auto; }
 .status.error { color:var(--err); }
 .status.warn { color:var(--warn); }
 .status.superseded { color:var(--warn); }
+.status.call_cancelled, .status.late_result { color:var(--warn); }
 .status.pending { color:var(--pending); }
 .status.bad { color:var(--invalid); }
 /* Per-event tone by kind/status, matching the TUI stream colors. */
@@ -87,6 +88,7 @@ document.getElementById("summary").innerHTML = [
   ["Notifications", data.session.notifications],
   ["Errors", data.session.errors],
   ["Pending", data.session.pending],
+  ["Late results", data.session.late_results],
   ["Protocol", data.capabilities?.protocol_version || ""]
 ].map(([k,v]) => "<div class=\"pill\">" + esc(k) + "<br><b>" + esc(v) + "</b></div>").join("");
 const calls = data.calls || [];
@@ -118,12 +120,15 @@ const matchStatus = (ev, call, v) => {
   if (!call) return false;
   if (["err", "error", "fail", "failed"].includes(v)) return call.status === "error";
   if (["pending", "pend", "inflight"].includes(v)) return call.status === "pending";
+  if (["cancel", "call_cancelled", "call-cancelled"].includes(v)) return call.status === "call_cancelled";
+  if (["late", "late_result", "late-result"].includes(v)) return call.status === "late_result";
+  if (["cancelled", "canceled"].includes(v)) return call.status === "cancelled";
   if (["ok", "success"].includes(v)) return call.status === "ok";
   return false;
 };
 const bareMatch = (ev, call, q) =>
   norm(ev.method).includes(q) || norm(ev.id).includes(q) || norm(ev.text).includes(q) ||
-  norm(compact(ev.raw)).includes(q) || (call ? norm(call.tool_name).includes(q) : false);
+  norm(ev.observation).includes(q) || norm(compact(ev.raw)).includes(q) || (call ? norm(call.tool_name).includes(q) : false);
 const matchToken = (ev, call, tok) => {
   const i = tok.indexOf(":");
   if (i > 0) {
@@ -158,9 +163,7 @@ const toneOf = (ev, call) => {
   if (ev.kind === "request") return "req";
   if (ev.kind === "response") {
     if (call && call.status === "error") return "error";
-    // A cancelled task delivered no result but is not an error, so it reads as a
-    // caution like the TUI row, reusing the warn tone rather than success green.
-    if (call && call.status === "cancelled") return "warn";
+    if (call && ["cancelled", "call_cancelled", "late_result"].includes(call.status)) return "warn";
     return "resp";
   }
   return "resp";
@@ -175,7 +178,7 @@ const statusOf = (ev, call) => {
     if (call.status === "error") return "error";
     return call.status;
   }
-  return call.status === "pending" || call.status === "superseded" ? call.status : "";
+  return ["pending", "superseded", "call_cancelled", "late_result"].includes(call.status) ? call.status : "";
 };
 const renderEvent = (ev) => {
   const call = ev.call_index == null ? null : calls[ev.call_index];
@@ -184,6 +187,7 @@ const renderEvent = (ev) => {
   const raw = ev.text || textOf(ev.raw);
   const warning = ev.warning ? "<details open><summary>Warning</summary><pre>" + esc(ev.warning) + "</pre></details>" : "";
   const deprecated = ev.deprecated ? "<details open><summary>Deprecated</summary><pre>" + esc(ev.deprecated) + "</pre></details>" : "";
+  const observation = ev.observation ? "<details open><summary>Observation</summary><pre>" + esc(ev.observation) + "</pre></details>" : "";
   const callBlock = call ? "<details><summary>Correlated call</summary><pre>" + esc(JSON.stringify(call, null, 2)) + "</pre></details>" : "";
   return "<article class=\"event tone-" + tone + "\">" +
     "<div class=\"head\">" +
@@ -195,6 +199,7 @@ const renderEvent = (ev) => {
     "</div>" +
     warning +
     deprecated +
+    observation +
     "<details open><summary>Frame</summary><pre>" + esc(raw) + "</pre></details>" +
     callBlock +
   "</article>";

--- a/internal/exporter/html_test.go
+++ b/internal/exporter/html_test.go
@@ -135,11 +135,9 @@ func TestHTMLSurfacesSupersededStatus(t *testing.T) {
 	}
 }
 
-// TestWriteHTMLStillEscapesMarkup. The HTML export is the one writer that must
-// keep escaping: its payload lands in template.JS inside a script block, where
-// template.JS disables the contextual escaping html/template would apply, and a
-// tool result containing </script> would otherwise close the element and run as
-// markup. Wire fidelity loses to stored XSS in a file opened in a browser.
+// TestHTMLSurfacesCallCancellationStatuses. A cancelled call and a late result
+// each need their own status token and their own CSS rule, or both render as an
+// ordinary row in the one export people forward to somebody else.
 func TestHTMLSurfacesCallCancellationStatuses(t *testing.T) {
 	cancelledIndex, lateIndex := 0, 1
 	data := SessionExport{
@@ -171,6 +169,11 @@ func TestHTMLSurfacesCallCancellationStatuses(t *testing.T) {
 	}
 }
 
+// TestWriteHTMLStillEscapesMarkup. The HTML export is the one writer that must
+// keep escaping. Its payload lands in template.JS inside a script block, where
+// template.JS disables the contextual escaping html/template would apply, and a
+// tool result containing </script> would otherwise close the element and run as
+// markup. Wire fidelity loses to stored XSS in a file opened in a browser.
 func TestWriteHTMLStillEscapesMarkup(t *testing.T) {
 	data := SessionExport{
 		Session: SessionSummary{ID: "s1"},

--- a/internal/exporter/html_test.go
+++ b/internal/exporter/html_test.go
@@ -126,7 +126,7 @@ func TestHTMLSurfacesSupersededStatus(t *testing.T) {
 	}
 	// statusOf surfaces superseded on a request row while ok still yields an empty
 	// cell (the ternary returns "" for anything else).
-	if !strings.Contains(html, `call.status === "pending" || call.status === "superseded" ? call.status : ""`) {
+	if !strings.Contains(html, `["pending", "superseded", "call_cancelled", "late_result"].includes(call.status) ? call.status : ""`) {
 		t.Fatal("statusOf does not surface the superseded status on a request row")
 	}
 	// The CSS rule that colors it (as warn) must exist.
@@ -140,6 +140,37 @@ func TestHTMLSurfacesSupersededStatus(t *testing.T) {
 // template.JS disables the contextual escaping html/template would apply, and a
 // tool result containing </script> would otherwise close the element and run as
 // markup. Wire fidelity loses to stored XSS in a file opened in a browser.
+func TestHTMLSurfacesCallCancellationStatuses(t *testing.T) {
+	cancelledIndex, lateIndex := 0, 1
+	data := SessionExport{
+		Session: SessionSummary{ID: "s1", LateResults: 1},
+		Calls: []CallExport{
+			{Index: cancelledIndex, ID: "1", Method: "tools/call", Status: "call_cancelled"},
+			{Index: lateIndex, ID: "2", Method: "tools/call", Status: "late_result", LateResult: true},
+		},
+		Events: []EventExport{
+			{Seq: 1, Kind: "request", CallIndex: &cancelledIndex},
+			{Seq: 2, Kind: "response", CallIndex: &lateIndex, Observation: "result arrived after cancellation"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatHTML}); err != nil {
+		t.Fatal(err)
+	}
+	html := buf.String()
+	for _, want := range []string{
+		`"status":"call_cancelled"`,
+		`"status":"late_result"`,
+		`"observation":"result arrived after cancellation"`,
+		`["Late results", data.session.late_results]`,
+		`.status.call_cancelled, .status.late_result`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("HTML missing %q", want)
+		}
+	}
+}
+
 func TestWriteHTMLStillEscapesMarkup(t *testing.T) {
 	data := SessionExport{
 		Session: SessionSummary{ID: "s1"},

--- a/internal/sessiondiff/diff.go
+++ b/internal/sessiondiff/diff.go
@@ -117,7 +117,11 @@ func statusRank(status string) int {
 	switch status {
 	case "error":
 		return 2
-	case "pending":
+	case "pending", "call_cancelled", "late_result":
+		// A call the client gave up on, and a result that arrived after it did,
+		// both end without the answer the caller wanted. Ranking them with ok made
+		// a run that went from ok to late_result print the change and still exit 0,
+		// so the line a human reads and the code a CI job reads disagreed.
 		return 1
 	default: // ok, and anything unexpected
 		return 0

--- a/internal/sessiondiff/diff_test.go
+++ b/internal/sessiondiff/diff_test.go
@@ -183,3 +183,27 @@ func driftOf(kind store.ToolDriftKind, name string) store.ToolDrift {
 	d.Add(kind, name)
 	return d
 }
+
+// TestStatusRankCoversCancellationAndLateResults. A run that goes from ok to a
+// call the client gave up on, or to a result that arrived after it did, is a
+// regression. Ranking the two new statuses with ok made diff print the change and
+// still exit 0, so the line a human reads and the code a CI job reads disagreed.
+func TestStatusRankCoversCancellationAndLateResults(t *testing.T) {
+	for _, tc := range []struct {
+		status string
+		want   int
+	}{
+		{"ok", 0},
+		{"pending", 1},
+		{"call_cancelled", 1},
+		{"late_result", 1},
+		{"error", 2},
+	} {
+		if got := statusRank(tc.status); got != tc.want {
+			t.Errorf("statusRank(%q) = %d, want %d", tc.status, got, tc.want)
+		}
+	}
+	if statusRank("call_cancelled") <= statusRank("ok") {
+		t.Fatal("a cancelled call must rank worse than ok, or the exit code stays 0")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,13 @@ const (
 	// Superseded means the request's id was reused by a later in-flight request, so
 	// this one can never be matched to a response. It is no longer pending.
 	Superseded
+	// Cancelled means a notifications/cancelled named this request, so it settled
+	// without the answer the caller wanted. It is no longer pending, and it is not
+	// an error, since the client stopping work on purpose is not something going
+	// wrong. Reachable on stdio only: on Streamable HTTP closing the response
+	// stream is itself the cancellation signal and, in the spec's words, "No
+	// notifications/cancelled message is required or expected", so mcpsnoop never
+	// sees one there.
 	Cancelled
 	// Streaming means a long-lived stream request (subscriptions/listen) whose
 	// response arrives only when the stream ends. It is open but not pending.
@@ -575,7 +582,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 				}]); note != "" {
 					ev.warning = appendWarning(ev.warning, note)
 				}
-				if c := sess.closeStreamingCall(id, e.ConnID, e.TS); c != nil {
+				if c := sess.closeStreamingCall(id, e.ConnID, e.TS, reason); c != nil {
 					ev.call = c
 				} else if c := sess.cancelCall(id, e.Direction, e.ConnID, e.TS, reason); c != nil {
 					ev.call = c
@@ -860,12 +867,33 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		if c.lateResult {
 			return c, false
 		}
+		// The response to a torn-down subscription is the graceful closure the spec
+		// asks the server for, "it SHOULD respond to the original
+		// subscriptions/listen request with an empty result before closing the
+		// stream". That is the intended end of the exchange, so it is neither a
+		// late result nor the duplicate this branch used to report.
+		if c.method == "subscriptions/listen" {
+			c.end = ts
+			c.result = msg.Result
+			c.err = msg.Error
+			return c, true
+		}
 		c.end = ts
 		c.result = msg.Result
 		c.err = msg.Error
 		c.toolErr = isToolError(msg.Result)
+		// Late or not, an error is an error. Leaving errored false made a real
+		// -32603 arriving after a cancellation read as errors=0 and pass a default
+		// check run, which is the one thing the error axis exists to stop. The
+		// state stays Cancelled, because that is what happened to the call; the
+		// axis says what the answer contained.
+		c.errored = msg.Error != nil || c.toolErr
 		c.lateResult = true
 		sess.lateResults++
+		// The payload is still the server's answer, so what it declares has to
+		// land. Without this a late tools/list left the tool inventory empty and
+		// `check --fail-on drift` compared nothing and printed green.
+		sess.applyResponseSideEffects(c, msg)
 		return c, true
 	}
 	if c.state != Pending && c.state != Streaming {
@@ -912,6 +940,15 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 	if wasPending {
 		sess.pending--
 	}
+	sess.applyResponseSideEffects(c, msg)
+	return c, true
+}
+
+// applyResponseSideEffects folds a result into the session state it describes.
+// Shared by the ordinary path and the late one, because a response that arrived
+// after a cancellation is still the server's answer and still declares what the
+// server has.
+func (sess *session) applyResponseSideEffects(c *call, msg proxy.RPCMessage) {
 	switch c.method {
 	case "initialize":
 		sess.caps.applyResponse(msg.Result)
@@ -920,7 +957,6 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 	case "tools/list":
 		sess.applyToolsList(c.params, msg.Result)
 	}
-	return c, true
 }
 
 type taskState struct {
@@ -1488,9 +1524,22 @@ func cancelledRequest(params json.RawMessage) (string, string) {
 	return string(bytes.TrimSpace(p.RequestID)), p.Reason
 }
 
+// cancelCall settles a request the client gave up on. The key is built bare
+// rather than through requestCallKey because a cancellation naming a null id
+// could not say which of several such requests it meant, and #209 made those
+// deliberately unreachable by id alone.
 func (sess *session) cancelCall(id string, dir proxy.Direction, conn string, ts time.Time, reason string) *call {
 	c := sess.calls[callKey{dir: dir, id: id, conn: conn}]
 	if c == nil || c.state != Pending {
+		return nil
+	}
+	// A call whose result was a task handle is only nominally pending; the work
+	// continues under its taskId and its terminal state arrives through
+	// notifications/tasks. Taking it here settled the call early and threw that
+	// state away, so a task that ended failed reported errors=0. The spec puts
+	// this case among the cancellations a server may ignore, "Processing has
+	// already completed", and cancelling the work itself is tasks/cancel.
+	if c.taskID != "" {
 		return nil
 	}
 	c.state = Cancelled
@@ -1500,13 +1549,24 @@ func (sess *session) cancelCall(id string, dir proxy.Direction, conn string, ts 
 	return c
 }
 
-func (sess *session) closeStreamingCall(id, conn string, ts time.Time) *call {
+// closeStreamingCall settles the long-lived call a notifications/cancelled names.
+// It is only ever reached from that notification, so the outcome is a
+// cancellation rather than a completion, whoever sent it. A server tearing down a
+// subscription is the one cancellation the spec asks a server for, and a client
+// ending its own subscription on stdio sends the same notification. The graceful
+// empty result that a server SHOULD send afterwards arrives separately and is
+// handled in completeCall.
+//
+// No pending slot is released, because a Streaming call never took one.
+func (sess *session) closeStreamingCall(id, conn string, ts time.Time, reason string) *call {
 	for _, dir := range []proxy.Direction{proxy.ClientToServer, proxy.ServerToClient} {
 		key := callKey{dir: dir, id: id, conn: conn}
 		c := sess.calls[key]
 		if c != nil && c.state == Streaming {
 			c.end = ts
-			c.state = Completed
+			c.state = Cancelled
+			c.cancelledAt = ts
+			c.cancelReason = reason
 			return c
 		}
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,7 @@ const (
 	// Superseded means the request's id was reused by a later in-flight request, so
 	// this one can never be matched to a response. It is no longer pending.
 	Superseded
+	Cancelled
 	// Streaming means a long-lived stream request (subscriptions/listen) whose
 	// response arrives only when the stream ends. It is open but not pending.
 	Streaming
@@ -47,6 +48,8 @@ func (s CallState) String() string {
 		return "failed"
 	case Superseded:
 		return "superseded"
+	case Cancelled:
+		return "cancelled"
 	case Streaming:
 		return "streaming"
 	default:
@@ -125,19 +128,22 @@ type callKey struct {
 
 // call is the mutable internal record for one request/response pair.
 type call struct {
-	requestSeq uint64
-	id         string
-	method     string
-	reqDir     proxy.Direction
-	params     json.RawMessage
-	result     json.RawMessage
-	err        *proxy.RPCError
-	start      time.Time
-	end        time.Time
-	state      CallState
-	isTool     bool
-	toolName   string
-	toolErr    bool // result.isError == true (MCP tool-level failure)
+	requestSeq   uint64
+	id           string
+	method       string
+	reqDir       proxy.Direction
+	params       json.RawMessage
+	result       json.RawMessage
+	err          *proxy.RPCError
+	start        time.Time
+	end          time.Time
+	state        CallState
+	cancelledAt  time.Time
+	cancelReason string
+	lateResult   bool
+	isTool       bool
+	toolName     string
+	toolErr      bool // result.isError == true (MCP tool-level failure)
 	// errored is the "something went wrong" axis: a protocol error, a tool-level
 	// error, or a task that ended failed. It drives the session error counter and
 	// the CI gate, and is deliberately distinct from the Failed state, which also
@@ -182,6 +188,7 @@ type event struct {
 	raw                json.RawMessage
 	text               string
 	warning            string
+	observation        string
 	mcpMethod          string // Mcp-Method routing header (HTTP transport, SEP-2243)
 	mcpName            string // Mcp-Name routing header
 	mcpProtocolVersion string // MCP-Protocol-Version request header
@@ -254,7 +261,7 @@ type session struct {
 	awaiting []*call
 	events   []*event
 
-	requests, responses, notifications, errors, pending int
+	requests, responses, notifications, errors, pending, lateResults int
 
 	lastSeq uint64 // highest per-session Seq seen, for gap detection
 	missing uint64 // envelopes dropped upstream, inferred from Seq gaps
@@ -406,6 +413,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.ConnID, e.TS, msg)
 		ev.call = c
+		if matched && c != nil && c.lateResult {
+			ev.observation = "result arrived " + e.TS.Sub(c.cancelledAt).Round(time.Millisecond).String() + " after cancellation"
+		}
 		if c != nil && c.state != Pending && c.state != Streaming {
 			sess.closeProgressToken(c.progressToken)
 		}
@@ -559,13 +569,17 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			}
 		}
 		if msg.Method == "notifications/cancelled" {
-			if id := cancelledRequestID(msg.Params); id != "" {
+			if id, reason := cancelledRequest(msg.Params); id != "" {
 				if note := serverCancelWarning(e.Direction, sess.calls[callKey{
 					dir: opposite(e.Direction), id: id, conn: e.ConnID,
 				}]); note != "" {
 					ev.warning = appendWarning(ev.warning, note)
 				}
-				sess.closeStreamingCall(id, e.ConnID, e.TS)
+				if c := sess.closeStreamingCall(id, e.ConnID, e.TS); c != nil {
+					ev.call = c
+				} else if c := sess.cancelCall(id, e.Direction, e.ConnID, e.TS, reason); c != nil {
+					ev.call = c
+				}
 			}
 		}
 		if msg.Method == "notifications/tasks" {
@@ -835,13 +849,24 @@ func requestCallKey(id string, rawID json.RawMessage, e proxy.Envelope) callKey 
 	return key
 }
 
-// completeCall matches a response to its pending request. The bool reports
-// whether it completed a pending call, where false means the response was unmatched or
-// a duplicate of an already-answered id. Caller holds the lock.
+// completeCall matches a response to a request. The bool is false for an
+// unmatched response or a duplicate of an already-observed result. Caller holds the lock.
 func (sess *session) completeCall(id string, respDir proxy.Direction, conn string, ts time.Time, msg proxy.RPCMessage) (*call, bool) {
 	c := sess.calls[callKey{dir: opposite(respDir), id: id, conn: conn}]
 	if c == nil {
 		return nil, false // unmatched response (request missed or before backfill)
+	}
+	if c.state == Cancelled {
+		if c.lateResult {
+			return c, false
+		}
+		c.end = ts
+		c.result = msg.Result
+		c.err = msg.Error
+		c.toolErr = isToolError(msg.Result)
+		c.lateResult = true
+		sess.lateResults++
+		return c, true
 	}
 	if c.state != Pending && c.state != Streaming {
 		return c, false // already answered, a duplicate or late response must not recount
@@ -1444,34 +1469,48 @@ func isStreamOpeningMethod(method string) bool {
 	return method == "subscriptions/listen"
 }
 
-// cancelledRequestID is the id a notifications/cancelled names, in the form the
+// cancelledRequest returns the id a notifications/cancelled names, in the form the
 // store keys calls by. That form is the raw JSON text of the id, because Ingest
 // keys a call on string(msg.ID), so a string id keeps its quotes. Decoding into a
 // Go string here would strip them and never match the key, and a string id is
 // what the specification's own cancellation example uses.
-func cancelledRequestID(params json.RawMessage) string {
+func cancelledRequest(params json.RawMessage) (string, string) {
 	if len(params) == 0 {
-		return ""
+		return "", ""
 	}
 	var p struct {
 		RequestID json.RawMessage `json:"requestId"`
+		Reason    string          `json:"reason"`
 	}
 	if json.Unmarshal(params, &p) != nil {
-		return ""
+		return "", ""
 	}
-	return string(bytes.TrimSpace(p.RequestID))
+	return string(bytes.TrimSpace(p.RequestID)), p.Reason
 }
 
-func (sess *session) closeStreamingCall(id, conn string, ts time.Time) {
+func (sess *session) cancelCall(id string, dir proxy.Direction, conn string, ts time.Time, reason string) *call {
+	c := sess.calls[callKey{dir: dir, id: id, conn: conn}]
+	if c == nil || c.state != Pending {
+		return nil
+	}
+	c.state = Cancelled
+	c.cancelledAt = ts
+	c.cancelReason = reason
+	sess.pending--
+	return c
+}
+
+func (sess *session) closeStreamingCall(id, conn string, ts time.Time) *call {
 	for _, dir := range []proxy.Direction{proxy.ClientToServer, proxy.ServerToClient} {
 		key := callKey{dir: dir, id: id, conn: conn}
 		c := sess.calls[key]
 		if c != nil && c.state == Streaming {
 			c.end = ts
 			c.state = Completed
-			return
+			return c
 		}
 	}
+	return nil
 }
 
 func operationName(msg proxy.RPCMessage) string {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -164,6 +164,76 @@ func resp(seq uint64, ts time.Time, dir proxy.Direction, id, body string) proxy.
 	return proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: ts, Direction: dir, Raw: json.RawMessage(raw)}
 }
 
+func TestCancellationSettlesPendingCall(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, `"job-1"`, "tools/call", `{"name":"slow"}`))
+	cancelledAt := t0.Add(250 * time.Millisecond)
+	cancel := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: cancelledAt,
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"job-1","reason":"no longer needed"}}`),
+	})
+
+	if cancel.Call == nil || cancel.Call.State != Cancelled {
+		t.Fatalf("cancelled call = %+v", cancel.Call)
+	}
+	if cancel.Call.CancelledAt != cancelledAt || cancel.Call.CancelReason != "no longer needed" {
+		t.Fatalf("cancellation metadata = %s %q", cancel.Call.CancelledAt, cancel.Call.CancelReason)
+	}
+	if cancel.Call.LateResult || cancel.Call.Duration() != 0 {
+		t.Fatalf("unanswered cancellation has late=%v duration=%s", cancel.Call.LateResult, cancel.Call.Duration())
+	}
+	if cancel.Warning != "" {
+		t.Fatalf("cancellation warning = %q, want none", cancel.Warning)
+	}
+	header := s.Sessions()[0]
+	if header.Pending != 0 || header.Errors != 0 || header.LateResults != 0 {
+		t.Fatalf("session counts = pending %d errors %d late %d", header.Pending, header.Errors, header.LateResults)
+	}
+	if got := s.Timeline("s1")[0].Call.State; got != Cancelled {
+		t.Fatalf("request state = %s, want cancelled", got)
+	}
+}
+
+func TestLateResponseAfterCancellationRemainsAnObservation(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, "7", "tools/call", `{"name":"slow"}`))
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(250 * time.Millisecond),
+		Direction: proxy.ClientToServer,
+		Raw:       json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}`),
+	})
+	late := s.Ingest(resp(3, t0.Add(time.Second), proxy.ServerToClient, "7", `"result":{"content":[]}`))
+
+	if late.Call == nil || late.Call.State != Cancelled || !late.Call.LateResult {
+		t.Fatalf("late response call = %+v", late.Call)
+	}
+	if late.Observation != "result arrived 750ms after cancellation" || late.Warning != "" {
+		t.Fatalf("late response observation=%q warning=%q", late.Observation, late.Warning)
+	}
+	if string(late.Call.Result) != `{"content":[]}` || late.Call.Duration() != time.Second {
+		t.Fatalf("late result=%s duration=%s", late.Call.Result, late.Call.Duration())
+	}
+	header := s.Sessions()[0]
+	if header.Pending != 0 || header.Errors != 0 || header.LateResults != 1 {
+		t.Fatalf("session counts = pending %d errors %d late %d", header.Pending, header.Errors, header.LateResults)
+	}
+	summary, ok := s.ToolSummary("s1")
+	if !ok || len(summary.Tools) != 1 || summary.Tools[0].P50 != time.Second {
+		t.Fatalf("tool summary = %+v, ok=%v", summary, ok)
+	}
+
+	duplicate := s.Ingest(resp(4, t0.Add(2*time.Second), proxy.ServerToClient, "7", `"result":{"content":["again"]}`))
+	if !strings.Contains(duplicate.Warning, "duplicate response") {
+		t.Fatalf("duplicate warning = %q", duplicate.Warning)
+	}
+	if got := s.Sessions()[0].LateResults; got != 1 {
+		t.Fatalf("late results = %d, want 1", got)
+	}
+}
+
 func TestReusedRequestIdKeepsPendingCounterAndTimelineInSync(t *testing.T) {
 	s := New()
 	t0 := time.Now()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1865,8 +1865,12 @@ func TestSubscriptionsListenClosesOnCancelledNotification(t *testing.T) {
 		t.Fatalf("pending = %d, want 0 after the server closes the stream", h.Pending)
 	}
 	events := s.Timeline("s1")
-	if events[0].Call == nil || events[0].Call.State != Completed {
-		t.Fatalf("listen call should be completed after notifications/cancelled, got %v", events[0].Call.State)
+	// The teardown is a cancellation, not a completion. What completes the call is
+	// the graceful empty result the server SHOULD send after it, which arrives on
+	// its own frame and is covered by
+	// TestGracefulSubscriptionClosureIsNotALateResult.
+	if events[0].Call == nil || events[0].Call.State != Cancelled {
+		t.Fatalf("listen call should be cancelled after notifications/cancelled, got %v", events[0].Call.State)
 	}
 }
 
@@ -1894,8 +1898,14 @@ func TestSubscriptionsListenClosesOnAStringRequestID(t *testing.T) {
 			})
 
 			events := s.Timeline("s1")
-			if events[0].Call == nil || events[0].Call.State != Completed {
-				t.Fatalf("the teardown should close the stream, got %v", events[0].Call.State)
+			// A teardown is a cancellation rather than a completion, and it carries
+			// the reason the server gave. The graceful empty result the server SHOULD
+			// send afterwards is the completion signal, and it arrives separately.
+			if events[0].Call == nil || events[0].Call.State != Cancelled {
+				t.Fatalf("the teardown should cancel the stream, got %v", events[0].Call.State)
+			}
+			if events[0].Call.CancelReason != "shutting down" {
+				t.Fatalf("cancel reason = %q, want the server's own", events[0].Call.CancelReason)
 			}
 			if h := s.Sessions()[0]; h.Pending != 0 {
 				t.Fatalf("pending = %d, want 0", h.Pending)
@@ -2256,5 +2266,153 @@ func TestNullResultResponseNamesTheRealViolation(t *testing.T) {
 		`"error":{"code":-32700,"message":"parse error"}`))
 	if strings.Contains(errored.Warning, "id is null") {
 		t.Fatalf("an error response may omit the id, got %q", errored.Warning)
+	}
+}
+
+// TestLateResultKeepsTheErrorAxis. A cancellation settles the call, but the
+// answer that arrives afterwards is still the server's answer, and an error in
+// it is still an error. Leaving it off the error axis made a real -32603 read as
+// errors=0 and pass a default check run, which is a regression against the
+// behaviour before cancellation had a state of its own.
+func TestLateResultKeepsTheErrorAxis(t *testing.T) {
+	for _, tc := range []struct {
+		name, response string
+		wantErrored    bool
+	}{
+		{"protocol error", `"error":{"code":-32603,"message":"boom"}`, true},
+		{"tool error", `"result":{"isError":true,"content":[]}`, true},
+		{"an ordinary late result", `"result":{"content":[]}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			t0 := time.Now()
+			s.Ingest(req(1, t0, proxy.ClientToServer, "7", "tools/call", `{"name":"slow"}`))
+			s.Ingest(notif(2, t0, proxy.ClientToServer, "notifications/cancelled", `{"requestId":7}`))
+			s.Ingest(resp(3, t0.Add(time.Second), proxy.ServerToClient, "7", tc.response))
+
+			calls := s.Calls("s1")
+			if len(calls) != 1 || calls[0].State != Cancelled || !calls[0].LateResult {
+				t.Fatalf("call = %+v, want one cancelled call with a late result", calls)
+			}
+			if calls[0].Errored != tc.wantErrored {
+				t.Fatalf("errored = %v, want %v", calls[0].Errored, tc.wantErrored)
+			}
+			want := 0
+			if tc.wantErrored {
+				want = 1
+			}
+			if got := s.Sessions()[0].Errors; got != want {
+				t.Fatalf("session errors = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestCancelLeavesATaskAugmentedCallAlone. A tools/call answered with a task
+// handle stays Pending on purpose while the work continues under its taskId, and
+// its terminal state arrives through notifications/tasks. Settling it on a
+// cancellation threw that state away, so a task that ended failed reported
+// errors=0. The spec puts this among the cancellations a server may ignore,
+// "Processing has already completed", and cancelling the work is tasks/cancel.
+func TestCancelLeavesATaskAugmentedCallAlone(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "3", "tools/call", `{"name":"slow"}`))
+	s.Ingest(resp(2, t0, proxy.ServerToClient, "3", `"result":{"resultType":"task","taskId":"t1","status":"working"}`))
+	s.Ingest(notif(3, t0, proxy.ClientToServer, "notifications/cancelled", `{"requestId":3}`))
+	s.Ingest(notif(4, t0.Add(time.Second), proxy.ServerToClient, "notifications/tasks",
+		`{"taskId":"t1","status":"failed","error":{"code":-32603,"message":"boom"}}`))
+
+	calls := s.Calls("s1")
+	if len(calls) != 1 {
+		t.Fatalf("calls = %+v, want one", calls)
+	}
+	if calls[0].State == Cancelled {
+		t.Fatal("a cancellation must not settle a call whose work continues under a task")
+	}
+	if calls[0].TaskStatus != "failed" || !calls[0].Errored {
+		t.Fatalf("call = %+v, want the failed task state to have landed", calls[0])
+	}
+	if got := s.Sessions()[0].Errors; got != 1 {
+		t.Fatalf("session errors = %d, want 1", got)
+	}
+}
+
+// TestLateResultStillDeclaresWhatTheServerHas. The payload of a late response is
+// still the server's answer. Dropping the per-method side effects left a late
+// tools/list with an empty inventory, and `check --fail-on drift` then compared
+// nothing and printed green.
+func TestLateResultStillDeclaresWhatTheServerHas(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{}`))
+	s.Ingest(notif(2, t0, proxy.ClientToServer, "notifications/cancelled", `{"requestId":1}`))
+	s.Ingest(resp(3, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"tools":[{"name":"search","inputSchema":{"type":"object"}}],"resultType":"complete"}`))
+
+	defs, ok := s.ToolDefinitions("s1")
+	if !ok || len(defs) != 1 {
+		t.Fatalf("tool definitions = %v %d, want the late listing to have landed", ok, len(defs))
+	}
+}
+
+// TestGracefulSubscriptionClosureIsNotALateResult. A server tearing down a
+// subscription sends notifications/cancelled and then, per the spec, "SHOULD
+// respond to the original subscriptions/listen request with an empty result
+// before closing the stream". That result is the intended end of the exchange, so
+// it must be neither a late result nor the duplicate the response branch used to
+// report on it.
+func TestGracefulSubscriptionClosureIsNotALateResult(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "subscriptions/listen",
+		`{"notifications":{"toolsListChanged":true}}`))
+	s.Ingest(notif(2, t0.Add(time.Second), proxy.ServerToClient, "notifications/cancelled",
+		`{"requestId":1,"reason":"shutdown"}`))
+	ev := s.Ingest(resp(3, t0.Add(2*time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"complete"}`))
+
+	if ev.Warning != "" {
+		t.Fatalf("the graceful closure must be silent, got %q", ev.Warning)
+	}
+	calls := s.Calls("s1")
+	if len(calls) != 1 || calls[0].State != Cancelled || calls[0].LateResult {
+		t.Fatalf("call = %+v, want one cancelled call with no late result", calls)
+	}
+	if h := s.Sessions()[0]; h.LateResults != 0 {
+		t.Fatalf("late results = %d, want 0", h.LateResults)
+	}
+}
+
+// TestPercentilesSkipCallsThatNeverAnswered. A superseded or cancelled call has
+// no end, so its duration is a negative epoch span. Letting either into the
+// aggregate put -2562047h47m16.854775808s into the per-tool percentiles and the
+// slowest-calls list. A cancelled call whose result arrived late does have a real
+// duration and must still count.
+func TestPercentilesSkipCallsThatNeverAnswered(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+	s.Ingest(notif(2, t0, proxy.ClientToServer, "notifications/cancelled", `{"requestId":1}`))
+	s.Ingest(req(3, t0, proxy.ClientToServer, "2", "tools/call", `{"name":"slow"}`))
+	s.Ingest(notif(4, t0, proxy.ClientToServer, "notifications/cancelled", `{"requestId":2}`))
+	s.Ingest(resp(5, t0.Add(2*time.Second), proxy.ServerToClient, "2", `"result":{"content":[]}`))
+
+	summary, ok := s.ToolSummary("s1")
+	if !ok || len(summary.Tools) != 1 {
+		t.Fatalf("summary = %+v", summary)
+	}
+	tool := summary.Tools[0]
+	if tool.P50 < 0 || tool.P95 < 0 || tool.P99 < 0 {
+		t.Fatalf("a call that never answered reached the percentiles: %+v", tool)
+	}
+	// Only the one that did answer contributes, and it contributes its real span.
+	if tool.P50 != 2*time.Second {
+		t.Fatalf("p50 = %v, want the late result's own 2s", tool.P50)
+	}
+	for _, slow := range summary.Slowest {
+		if slow.Duration < 0 {
+			t.Fatalf("slowest calls carry a negative duration: %+v", slow)
+		}
 	}
 }

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -26,12 +26,15 @@ type CallView struct {
 	// Errored is the "something went wrong" axis, distinct from Failed(): a
 	// cancelled task is Failed() (it delivered nothing) but not Errored (the user
 	// stopped it on purpose). The session error counter and the CI gate read this.
-	Errored    bool
-	Start      time.Time
-	End        time.Time
-	State      CallState
-	TaskID     string
-	TaskStatus string
+	Errored      bool
+	Start        time.Time
+	End          time.Time
+	State        CallState
+	CancelledAt  time.Time
+	CancelReason string
+	LateResult   bool
+	TaskID       string
+	TaskStatus   string
 }
 
 // Failed reports a protocol error, a tool-level error (result.isError), or any
@@ -43,12 +46,15 @@ type CallView struct {
 // alongside an error or a tool error.
 func (c CallView) Failed() bool { return c.Err != nil || c.ToolErr || c.State == Failed }
 
-// Done reports whether a response has arrived.
+// Done reports whether the call is no longer open.
 func (c CallView) Done() bool { return c.State != Pending && c.State != Streaming }
 
-// Duration is the request→response latency, or elapsed-so-far while the call is
-// still open, which covers both a pending request and a live stream.
+// Duration is the request-to-response latency, zero for a settled call without a
+// response, or elapsed time for a call that is still open.
 func (c CallView) Duration() time.Duration {
+	if c.State == Cancelled && !c.LateResult {
+		return 0
+	}
 	if c.Done() {
 		return c.End.Sub(c.Start)
 	}
@@ -100,6 +106,7 @@ type EventView struct {
 	// CacheStaleRefetch is set when a client re-fetches inside a declared ttlMs
 	// window. Structured like Deprecated and never fails check.
 	CacheStaleRefetch string
+	Observation       string
 	Call              *CallView // set for request/response events
 	TaskCall          *CallView // originating call for a tasks/* lifecycle frame
 	TaskID            string
@@ -126,6 +133,7 @@ type SessionHeader struct {
 	HasToolDrift         bool
 	HasToolBaselineError bool
 	MissingFrames        uint64 // envelopes dropped upstream, inferred from Seq gaps
+	LateResults          int
 }
 
 // ToolDefinition is the contract a server advertised for one MCP tool.
@@ -373,6 +381,7 @@ func (e *event) view(_ *session) EventView {
 		Deprecated:         e.deprecated,
 		CacheHint:          e.cacheHint,
 		CacheStaleRefetch:  e.cacheStaleRefetch,
+		Observation:        e.observation,
 		TaskID:             e.taskID,
 		MRTRRoot:           e.mrtrRoot,
 		MRTRStateIssue:     e.mrtrStateIssue,
@@ -390,22 +399,25 @@ func (e *event) view(_ *session) EventView {
 
 func (c *call) view() CallView {
 	return CallView{
-		RequestSeq: c.requestSeq,
-		ID:         c.id,
-		Method:     c.method,
-		ReqDir:     c.reqDir,
-		IsTool:     c.isTool,
-		ToolName:   c.toolName,
-		Params:     c.params,
-		Result:     c.result,
-		Err:        c.err,
-		ToolErr:    c.toolErr,
-		Errored:    c.errored,
-		Start:      c.start,
-		End:        c.end,
-		State:      c.state,
-		TaskID:     c.taskID,
-		TaskStatus: c.taskStatus,
+		RequestSeq:   c.requestSeq,
+		ID:           c.id,
+		Method:       c.method,
+		ReqDir:       c.reqDir,
+		IsTool:       c.isTool,
+		ToolName:     c.toolName,
+		Params:       c.params,
+		Result:       c.result,
+		Err:          c.err,
+		ToolErr:      c.toolErr,
+		Errored:      c.errored,
+		Start:        c.start,
+		End:          c.end,
+		State:        c.state,
+		CancelledAt:  c.cancelledAt,
+		CancelReason: c.cancelReason,
+		LateResult:   c.lateResult,
+		TaskID:       c.taskID,
+		TaskStatus:   c.taskStatus,
 	}
 }
 
@@ -430,6 +442,7 @@ func (s *Store) Sessions() []SessionHeader {
 			HasToolDrift:         sess.toolDrift.Count() > 0,
 			HasToolBaselineError: sess.toolDrift.BaselineError != "",
 			MissingFrames:        sess.missing,
+			LateResults:          sess.lateResults,
 		})
 	}
 	return out
@@ -712,9 +725,7 @@ func (s *Store) ToolSummary(sessionID string) (SessionToolSummary, bool) {
 			agg.stats.Pending++
 			continue
 		}
-		if c.state == Superseded {
-			// Its id was reused, so it was never answered. It still counts as a call
-			// (like a pending one), but has no real latency to feed the percentiles.
+		if c.state == Superseded || (c.state == Cancelled && !c.lateResult) {
 			continue
 		}
 		if c.errored {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1040,6 +1040,9 @@ func statusRank(e store.EventView) int {
 	if e.Call != nil && e.Call.Failed() {
 		return 4
 	}
+	if e.Call != nil && e.Call.State == store.Cancelled {
+		return 3
+	}
 	if e.Warning != "" || e.Truncated || e.Deprecated != "" || e.CacheStaleRefetch != "" {
 		return 3
 	}
@@ -1124,6 +1127,7 @@ func eventSubstr(e store.EventView, q string) bool {
 		strings.Contains(strings.ToLower(e.ID), q) ||
 		strings.Contains(strings.ToLower(e.Text), q) ||
 		strings.Contains(strings.ToLower(e.Warning), q) ||
+		strings.Contains(strings.ToLower(e.Observation), q) ||
 		strings.Contains(strings.ToLower(string(e.Raw)), q) {
 		return true
 	}
@@ -1205,6 +1209,10 @@ func (m *Model) matchStatus(e store.EventView, v string) bool {
 	case "cancelled", "canceled":
 		// The row already labels a cancelled task "cancelled"; find it the same way.
 		return e.Call.TaskStatus == "cancelled"
+	case "cancel", "call_cancelled", "call-cancelled":
+		return e.Call.State == store.Cancelled && !e.Call.LateResult
+	case "late", "late_result", "late-result":
+		return e.Call.State == store.Cancelled && e.Call.LateResult
 	case "pending", "pend", "inflight":
 		return e.Call.State == store.Pending
 	case "ok", "success":

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1203,11 +1203,15 @@ func (m *Model) matchStatus(e store.EventView, v string) bool {
 	}
 	switch v {
 	case "err", "error", "fail", "failed":
-		// The "something went wrong" axis, not the Failed state: a cancelled call is
-		// Failed() but not an error, so it belongs under status:cancelled, not here.
+		// The "something went wrong" axis rather than the Failed state. A call the
+		// client gave up on is Failed() without being an error, so it belongs under
+		// status:cancel. A late result that carried an error does land here, since
+		// the axis follows what the answer contained.
 		return e.Call.Errored
 	case "cancelled", "canceled":
-		// The row already labels a cancelled task "cancelled"; find it the same way.
+		// A cancelled task, which is a different thing from a cancelled call and one
+		// letter apart from it. The row labels this one "cancelled" and the call
+		// "cancel", so each token finds what its own row says.
 		return e.Call.TaskStatus == "cancelled"
 	case "cancel", "call_cancelled", "call-cancelled":
 		return e.Call.State == store.Cancelled && !e.Call.LateResult

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1862,3 +1862,52 @@ func TestReplayAsksBeforeRunningTheRecordedCommand(t *testing.T) {
 		t.Fatal("declining must not start a replay")
 	}
 }
+
+// TestCancelAndLateRowsAreSelectableByWhatTheySay. The row for a
+// notifications/cancelled frame labels itself, and status: has to find it by the
+// same word. Labelling every such frame "cancel" while the filter required a call
+// that was not yet a late result meant the token shown and the token that selects
+// disagreed as soon as the result turned up.
+func TestCancelAndLateRowsAreSelectableByWhatTheySay(t *testing.T) {
+	build := func(late bool) Model {
+		st := store.New()
+		t0 := time.Now()
+		st.Ingest(env(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"slow"}}`))
+		st.Ingest(env(2, proxy.ClientToServer, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}`))
+		if late {
+			st.Ingest(env(3, proxy.ServerToClient, `{"jsonrpc":"2.0","id":7,"result":{"content":[]}}`))
+		}
+		_ = t0
+		m := ready(t, st)
+		return drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	}
+
+	for _, tc := range []struct {
+		name, token string
+		late        bool
+	}{
+		{"cancelled", "cancel", false},
+		{"late result", "late", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := build(tc.late)
+			var labelled bool
+			for _, e := range m.full {
+				if e.Method != "notifications/cancelled" {
+					continue
+				}
+				labelled = true
+				// Both sides, the word the row prints and the word status: selects by.
+				if got := m.streamCells(e).status; got != tc.token {
+					t.Fatalf("the cancellation row says %q, want %q", got, tc.token)
+				}
+				if !m.matchStatus(e, tc.token) {
+					t.Fatalf("the row says %q but status:%s does not select it", tc.token, tc.token)
+				}
+			}
+			if !labelled {
+				t.Fatal("the cancellation frame is missing from the timeline")
+			}
+		})
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -125,6 +125,47 @@ func TestStatusFilterSeparatesCancelledFromError(t *testing.T) {
 	}
 }
 
+func TestCallCancellationRowsAndFilters(t *testing.T) {
+	m := Model{}
+	t0 := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	cancelledCall := &store.CallView{
+		ID: "7", Method: "tools/call", State: store.Cancelled,
+		Start: t0, CancelledAt: t0.Add(250 * time.Millisecond), CancelReason: "moved on",
+	}
+	request := store.EventView{Kind: store.EventRequest, Method: "tools/call", Call: cancelledCall}
+	if cells := m.streamCells(request); cells.status != "cancel" || cells.dur != "" {
+		t.Fatalf("cancelled request cells = %+v", cells)
+	}
+	cancel := store.EventView{Kind: store.EventNotification, Method: "notifications/cancelled", Call: cancelledCall}
+	if cells := m.streamCells(cancel); cells.status != "cancel" {
+		t.Fatalf("cancellation notification cells = %+v", cells)
+	}
+	if !m.matchToken(cancel, "status:cancel") || m.matchToken(cancel, "status:cancelled") || m.matchToken(cancel, "status:late") {
+		t.Fatal("call cancellation filter overlapped task cancellation or late result")
+	}
+
+	lateCall := &store.CallView{
+		ID: "7", Method: "tools/call", State: store.Cancelled, LateResult: true,
+		Start: t0, End: t0.Add(time.Second), Result: json.RawMessage(`{"content":[]}`),
+	}
+	late := store.EventView{
+		Kind: store.EventResponse, Call: lateCall,
+		Observation: "result arrived 750ms after cancellation",
+	}
+	cells := m.streamCells(late)
+	if cells.status != "late" || cells.dur != "1s" || !strings.Contains(cells.detail, late.Observation) {
+		t.Fatalf("late result cells = %+v", cells)
+	}
+	if !m.matchToken(late, "status:late-result") || m.matchToken(late, "status:cancel") || m.matchToken(late, "status:cancelled") {
+		t.Fatal("late result filter overlapped cancellation filters")
+	}
+	m.full = []store.EventView{request}
+	m.inspect = 0
+	if got := m.pairWidget(); !strings.Contains(got, "cancel") {
+		t.Fatalf("cancelled request pair widget = %q", got)
+	}
+}
+
 func drive(t *testing.T, m Model, msg tea.Msg) Model {
 	t.Helper()
 	tm, _ := m.Update(msg)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -660,6 +660,12 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			} else if e.Call.State == store.Superseded {
 				// Its id was reused while in flight, so it will never be answered.
 				c.status = "superseded"
+			} else if e.Call.State == store.Cancelled {
+				c.status = "cancel"
+				if e.Call.LateResult {
+					c.status = "late"
+					c.dur = e.Call.Duration().Round(time.Millisecond).String()
+				}
 			}
 		}
 	case store.EventResponse:
@@ -668,6 +674,16 @@ func (m Model) streamCells(e store.EventView) streamCell {
 		if e.Call != nil {
 			c.dur = e.Call.Duration().Round(time.Millisecond).String()
 			switch {
+			case e.Call.State == store.Cancelled && e.Call.LateResult:
+				c.status = "late"
+				switch {
+				case e.Call.Err != nil:
+					c.detail = rpcErrorText(*e.Call.Err)
+				case e.Call.ToolErr:
+					c.detail = toolErrorText(e.Call.Result)
+				default:
+					c.detail = compactJSON(e.Call.Result)
+				}
 			case e.Call.TaskID != "" && e.Call.State == store.Pending:
 				c.status = e.Call.TaskStatus
 				c.detail = compactJSON(e.Call.Result)
@@ -689,6 +705,9 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			if p, ok := parseProgress(e.Raw); ok {
 				c.progress = &p
 			}
+		}
+		if e.Method == "notifications/cancelled" && e.Call != nil {
+			c.status = "cancel"
 		}
 	case store.EventInvalid:
 		c.dir, c.method, c.status = "!", "invalid rpc", "bad"
@@ -750,6 +769,13 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = e.CacheStaleRefetch
 		} else {
 			c.detail = e.CacheStaleRefetch + " · " + c.detail
+		}
+	}
+	if e.Observation != "" {
+		if c.detail == "" {
+			c.detail = e.Observation
+		} else {
+			c.detail = e.Observation + " · " + c.detail
 		}
 	}
 	if !e.CacheHint.Empty() {
@@ -910,6 +936,8 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 			return m.styles.follow
 		case e.Call.State == store.Superseded:
 			return m.styles.warn // never answered, not a success
+		case e.Call.State == store.Cancelled:
+			return m.styles.warn
 		case e.Call.Failed():
 			return m.styles.respErr
 		default:
@@ -1166,6 +1194,9 @@ func (m Model) pairWidget() string {
 		}
 		if e.Call.State == store.Streaming {
 			return cur + arrow + m.styles.follow.Render("streaming")
+		}
+		if e.Call.State == store.Cancelled && !e.Call.LateResult {
+			return cur + arrow + m.styles.warn.Render("cancel")
 		}
 		if pi, ok := m.pairIndex(m.inspect); ok {
 			return cur + arrow + m.styles.req.Render(fmt.Sprintf("resp %d", m.full[pi].Seq))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -707,7 +707,13 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			}
 		}
 		if e.Method == "notifications/cancelled" && e.Call != nil {
+			// Labelled by the call's outcome rather than by the frame, so the token
+			// shown is the one status: selects. A cancellation whose result turned up
+			// afterwards reads "late" on both.
 			c.status = "cancel"
+			if e.Call.LateResult {
+				c.status = "late"
+			}
 		}
 	case store.EventInvalid:
 		c.dir, c.method, c.status = "!", "invalid rpc", "bad"
@@ -1012,7 +1018,7 @@ func (m Model) renderHelp() string {
 	filter := helpGroup{"STREAM FILTER QUERY", [][2]string{
 		{"<text>", "substring over method, tool, id, payload"},
 		{"tool:echo", "by tool name"},
-		{"status:err|warn|ok|pending|bad|mismatch", "by outcome"},
+		{"status:err|warn|ok|pending|cancel|late|bad|mismatch", "by outcome"},
 		{"kind:req|resp|notify|stderr|invalid", "by message type"},
 		{"dir:c2s|s2c", "by direction"},
 		{"method:tools/call", "by method"},


### PR DESCRIPTION
## What and why

Cancelled calls currently look successful, while a later conforming response looks hung. This records cancellation separately, preserves late results as observations, and carries those states through JSON, text, HTML, HAR, and OTLP exports.

The TUI shows `cancel` and `late` rows and filters, and `check` can opt into failing on late results with `--fail-on late-result`.

Fixes #198

Focused store, exporter, TUI, and CLI tests pass, along with `go vet ./...`. The full Windows run still hits existing Unix-only fixtures and filesystem assumptions.

## Checklist

- [ ] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed