### PR TITLE
fix(store): settle a cancelled call instead of reading it as a clean success

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,13 +360,14 @@ leave the capture incomplete, tool-definition drift, or use of deprecated
 protocol features.
 
 ```bash
-mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending,drift,deprecated,incomplete] [session-id|log.jsonl|-]
+mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending,late,drift,deprecated,incomplete] [session-id|log.jsonl|-]
 ```
 
 The three default signals (error, invalid, warn) fail the check. Add `pending`
 to gate on calls that never got a response, `mismatch` to gate specifically on a
-routing header (Mcp-Method or Mcp-Name) disagreeing with the body, `drift` to gate
-on tool definitions changing after approval, `deprecated` to gate on features
+routing header (Mcp-Method or Mcp-Name) disagreeing with the body, `late` to gate
+on a result that arrived after the host had already cancelled the call, `drift` to
+gate on tool definitions changing after approval, `deprecated` to gate on features
 the spec has deprecated, or `incomplete` to gate on captures with dropped frames.
 Pass a comma-separated subset to select only the
 conditions relevant to a job. Omit the session to check the newest capture, or use
@@ -391,6 +392,19 @@ numeric-equivalent safe integers are handled without string-comparison false
 positives. Unknown parameter headers and sessions without a matching tool
 definition remain observational only. Existing key- and value-based redaction
 also applies to captured parameter-header values before they reach a sink.
+
+A `notifications/cancelled` naming an open request settles that call: it stops
+counting toward `pending` (so a conforming cancellation no longer looks like a
+hang), it is counted as `cancelled` on the summary line, and it carries the
+host's `reason` into the export and the TUI. That is an observation, not a
+failure — the specification's Timing Considerations bless the race — so the
+default run stays green whether the server obeyed the cancel or answered anyway.
+The export gives the two shapes their own statuses, `cancelled_request` for a
+call nobody ever answered and `cancelled_late_result` for one the server answered
+after the host had stopped listening, and the response frame carries a
+`late_result` note with the gap. `--fail-on late` is the opt-in gate for that
+second shape, for anyone who wants CI to catch work that completed into a void.
+
 Use `--format junit` to write one JUnit `<testcase>` per signal and session;
 failures follow the same `--fail-on` selection as the text output.
 

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -15,17 +15,21 @@ import (
 type checkSignal string
 
 const (
-	checkError      checkSignal = "error"
-	checkInvalid    checkSignal = "invalid"
-	checkWarn       checkSignal = "warn"
-	checkMismatch   checkSignal = "mismatch"
-	checkPending    checkSignal = "pending"
+	checkError    checkSignal = "error"
+	checkInvalid  checkSignal = "invalid"
+	checkWarn     checkSignal = "warn"
+	checkMismatch checkSignal = "mismatch"
+	checkPending  checkSignal = "pending"
+	// checkLate is a result that arrived after its call had already been
+	// cancelled. Opt-in only: the spec's Timing Considerations bless the race, so
+	// a default run reports the cancel and stays green.
+	checkLate       checkSignal = "late"
 	checkDrift      checkSignal = "drift"
 	checkDeprecated checkSignal = "deprecated"
 	checkIncomplete checkSignal = "incomplete"
 )
 
-var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated, checkIncomplete}
+var checkSignalOrder = []checkSignal{checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkLate, checkDrift, checkDeprecated, checkIncomplete}
 
 type checkOutputFormat string
 
@@ -41,6 +45,8 @@ type checkSummary struct {
 	warnings        int
 	mismatches      int
 	pending         int
+	cancelled       int
+	lateResults     int
 	deprecated      int
 	missingFrames   uint64
 	drift           store.ToolDrift
@@ -54,7 +60,7 @@ func newCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check [session-id|log.jsonl|-]",
 		Short: "Fail when a captured session violates a signal or an assertion",
-		Long:  "Check a captured session against signals (errors, invalid frames, warnings, routing-header mismatches, calls that never got a response, dropped frames that leave the capture incomplete, tool-definition drift) and assertions (a tool-call latency budget, and tools that must or must not have been called). With no session, the newest session log is checked. Use - to read from stdin.",
+		Long:  "Check a captured session against signals (errors, invalid frames, warnings, routing-header mismatches, calls that never got a response, results that arrived after their call was cancelled, dropped frames that leave the capture incomplete, tool-definition drift) and assertions (a tool-call latency budget, and tools that must or must not have been called). With no session, the newest session log is checked. Use - to read from stdin.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			signals, err := parseCheckSignals(failOn)
@@ -102,8 +108,8 @@ func newCheckCmd() *cobra.Command {
 				}
 			} else {
 				for i, summary := range summaries {
-					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d deprecated=%d missing_frames=%d\n",
-						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.deprecated, summary.missingFrames)
+					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d cancelled=%d deprecated=%d missing_frames=%d\n",
+						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.cancelled, summary.deprecated, summary.missingFrames)
 					if summary.baselineCreated {
 						// No baseline existed, so this run trusted the current definitions
 						// rather than verifying them. Say so, or an ephemeral CI reads green
@@ -138,7 +144,7 @@ func newCheckCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().SortFlags = false
-	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift, deprecated, incomplete")
+	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, late, drift, deprecated, incomplete")
 	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text or junit")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
 	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
@@ -177,9 +183,16 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 		var worstDuration time.Duration
 		var worstTool string
 		for _, c := range calls {
-			// Only a call that actually got a response has a real latency. Pending and
-			// superseded calls never did, so they are not judged here.
-			if !c.IsTool || !c.Done() || c.State == store.Superseded {
+			// Only a call that actually got a response has a real latency. Pending,
+			// superseded and never-answered cancelled calls did not, so they are not
+			// judged here. The last clause preserves the budget rather than changing
+			// it: settling a cancel makes the call Done(), and its stored end is when
+			// the cancel landed, so without the skip a capture that used to be exempt
+			// as pending would start failing on a number that is not a latency. A
+			// cancelled call that did get a late answer is still judged; that duration
+			// is real.
+			if !c.IsTool || !c.Done() || c.State == store.Superseded ||
+				(c.State == store.Cancelled && !c.LateResult) {
 				continue
 			}
 			duration := c.Duration()
@@ -219,10 +232,10 @@ func parseCheckSignals(value string) (map[checkSignal]bool, error) {
 	for _, part := range strings.Split(value, ",") {
 		signal := checkSignal(strings.TrimSpace(part))
 		switch signal {
-		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkDrift, checkDeprecated, checkIncomplete:
+		case checkError, checkInvalid, checkWarn, checkMismatch, checkPending, checkLate, checkDrift, checkDeprecated, checkIncomplete:
 			signals[signal] = true
 		default:
-			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, drift, deprecated, or incomplete, got %q", part)
+			return nil, fmt.Errorf("--fail-on must contain error, invalid, warn, mismatch, pending, late, drift, deprecated, or incomplete, got %q", part)
 		}
 	}
 	return signals, nil
@@ -269,6 +282,17 @@ func summarizeCheck(st *store.Store, baselines *toolbaseline.Manager) []checkSum
 				summary.baselineCreated = created
 			}
 		}
+		// Counted from the calls rather than from a new session counter, so there is
+		// one place that decides what a cancelled call is.
+		for _, c := range st.Calls(header.ID) {
+			if c.State != store.Cancelled {
+				continue
+			}
+			summary.cancelled++
+			if c.LateResult {
+				summary.lateResults++
+			}
+		}
 		for _, event := range st.Timeline(header.ID) {
 			if event.Kind == store.EventInvalid {
 				summary.invalid++
@@ -309,6 +333,10 @@ func (s checkSummary) count(signal checkSignal) int {
 		return s.mismatches
 	case checkPending:
 		return s.pending
+	case checkLate:
+		// Only the late-result shape gates. A cancel with no answer is exactly what
+		// the spec asks a server to do, so it is reported and never failed on.
+		return s.lateResults
 	case checkDrift:
 		// A baseline error is not drift, but it means drift could not be verified,
 		// so count it as a drift failure for a run that selected the drift signal.

--- a/cmd/mcpsnoop/check_junit.go
+++ b/cmd/mcpsnoop/check_junit.go
@@ -148,6 +148,8 @@ func checkSignalFailureReason(sessionID string, signal checkSignal, count int) s
 		singular, plural = "routing mismatch", "routing mismatches"
 	case checkPending:
 		singular, plural = "pending call", "pending calls"
+	case checkLate:
+		singular, plural = "result after a cancel", "results after a cancel"
 	case checkDrift:
 		singular, plural = "tool definition change", "tool definition changes"
 	case checkDeprecated:

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -23,7 +23,7 @@ func TestCheckFailsOnSelectedSessionSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0 missing_frames=0\ncheck failed: error,invalid,warn\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 cancelled=0 deprecated=0 missing_frames=0\ncheck failed: error,invalid,warn\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -39,7 +39,7 @@ func TestCheckFailsOnlyOnSelectedSignals(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1 because the fixture contains an invalid frame", code)
 	}
-	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 deprecated=0 missing_frames=0\ncheck failed: invalid\n" {
+	if stdout != "session s1: errors=2 invalid=1 warnings=1 mismatches=0 pending=1 cancelled=0 deprecated=0 missing_frames=0\ncheck failed: invalid\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -54,7 +54,7 @@ func TestCheckIgnoresUnselectedSignals(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0 missing_frames=0\ncheck passed\n" {
+	if stdout != "session s1: errors=2 invalid=0 warnings=0 mismatches=0 pending=0 cancelled=0 deprecated=0 missing_frames=0\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -73,7 +73,7 @@ func TestCheckPassesCleanSessionFromStdin(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0 deprecated=0 missing_frames=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
+	if stdout != "session s1: errors=0 invalid=0 warnings=0 mismatches=0 pending=0 cancelled=0 deprecated=0 missing_frames=0\nrecorded first-seen tool baseline (trusted, not verified)\ncheck passed\n" {
 		t.Fatalf("stdout = %q", stdout)
 	}
 	if stderr != "" {
@@ -92,8 +92,8 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
 		t.Fatalf("exit = %d, want 1", code)
 	}
 	const want = `<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="mcpsnoop check" tests="9" failures="3" errors="0" skipped="0" time="0">
-  <testsuite name="s1" tests="9" failures="3" errors="0" skipped="0" time="0">
+<testsuites name="mcpsnoop check" tests="10" failures="3" errors="0" skipped="0" time="0">
+  <testsuite name="s1" tests="10" failures="3" errors="0" skipped="0" time="0">
     <testcase classname="mcpsnoop.check" name="s1/error" time="0">
       <failure message="session s1 has 2 errors" type="mcpsnoop.check.error">session s1 has 2 errors</failure>
     </testcase>
@@ -105,6 +105,7 @@ func TestCheckWritesJUnitGolden(t *testing.T) {
     </testcase>
     <testcase classname="mcpsnoop.check" name="s1/mismatch" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/pending" time="0"></testcase>
+    <testcase classname="mcpsnoop.check" name="s1/late" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/drift" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/deprecated" time="0"></testcase>
     <testcase classname="mcpsnoop.check" name="s1/incomplete" time="0"></testcase>
@@ -128,7 +129,7 @@ func TestCheckJUnitHonorsFailOn(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 because errors are not selected", code)
 	}
-	for _, want := range []string{`tests="9"`, `failures="0"`, `name="s1/error"`} {
+	for _, want := range []string{`tests="10"`, `failures="0"`, `name="s1/error"`} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("stdout missing %q\n%s", want, stdout)
 		}
@@ -272,6 +273,118 @@ func TestCheckFailsOnHungCall(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "check passed") {
 		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// cancelCaptureLog is the issue's repro as JSONL: a tools/call the host gives up
+// on 160ms in, with the server either ignoring the cancel and answering 450ms
+// later or obeying it and never answering.
+func cancelCaptureLog(t *testing.T, serverAnswers bool) string {
+	t.Helper()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	at := func(seq uint64, dir proxy.Direction, offset time.Duration, raw string) proxy.Envelope {
+		e := checkEnvelope(seq, dir, raw)
+		e.TS = t0.Add(offset)
+		return e
+	}
+	envelopes := []proxy.Envelope{
+		at(1, proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"slow_job"}}`),
+		at(2, proxy.ClientToServer, 160*time.Millisecond,
+			`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":3,"reason":"Request timed out"}}`),
+	}
+	if serverAnswers {
+		envelopes = append(envelopes, at(3, proxy.ServerToClient, 610*time.Millisecond,
+			`{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"done"}]}}`))
+	}
+	return encodeCheckLog(t, envelopes...)
+}
+
+// TestCheckReportsACancelWithoutFailingByDefault is the issue's headline: both
+// captures must stay green on a default run (the spec blesses the race), while
+// the summary line finally says a cancel happened at all.
+func TestCheckReportsACancelWithoutFailingByDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		serverAnswers bool
+	}{
+		{"server ignored the cancel", true},
+		{"server obeyed the cancel", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MCPSNOOP_HOME", t.TempDir())
+			code, stdout, stderr := executeCheck(t, []string{"-"}, cancelCaptureLog(t, tc.serverAnswers))
+			if code != 0 {
+				t.Fatalf("exit = %d, want 0: a cancel is an observation, not a violation\n%s", code, stdout)
+			}
+			if !strings.Contains(stdout, "pending=0 cancelled=1") {
+				t.Fatalf("summary should report the cancel and no pending call, got %q", stdout)
+			}
+			if !strings.Contains(stdout, "check passed") || stderr != "" {
+				t.Fatalf("stdout = %q stderr = %q", stdout, stderr)
+			}
+		})
+	}
+}
+
+// TestCheckPendingSignalSurvivesAConformingCancel. The issue's second half: a
+// server that obeys the cancel used to leave the call pending forever, so the
+// one signal a user would reach for to catch a hung server could never be
+// switched on. A genuinely unanswered call must still trip it.
+func TestCheckPendingSignalSurvivesAConformingCancel(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	code, stdout, _ := executeCheck(t, []string{"--fail-on", "pending", "-"}, cancelCaptureLog(t, false))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0: a cancelled call is settled, not hung\n%s", code, stdout)
+	}
+
+	hung := encodeCheckLog(t, checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hang"}}`))
+	code, stdout, _ = executeCheck(t, []string{"--fail-on", "pending", "-"}, hung)
+	if code != 1 || !strings.Contains(stdout, "check failed: pending") {
+		t.Fatalf("a real hang must still trip the signal, got exit %d\n%s", code, stdout)
+	}
+}
+
+// TestCheckLateSignalGatesOnlyTheLateResult. Opt-in, and only for the shape the
+// reporter asked to be able to catch: work that completed after the host had
+// already been told it timed out.
+func TestCheckLateSignalGatesOnlyTheLateResult(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	code, stdout, _ := executeCheck(t, []string{"--fail-on", "late", "-"}, cancelCaptureLog(t, true))
+	if code != 1 || !strings.Contains(stdout, "check failed: late") {
+		t.Fatalf("exit = %d, want 1 for a result that arrived after the cancel\n%s", code, stdout)
+	}
+
+	code, stdout, _ = executeCheck(t, []string{"--fail-on", "late", "-"}, cancelCaptureLog(t, false))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0: obeying the cancel is exactly what the spec asks for\n%s", code, stdout)
+	}
+
+	// And it reads properly in the JUnit report.
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	_, stdout, _ = executeCheck(t, []string{"--format", "junit", "--fail-on", "late", "-"}, cancelCaptureLog(t, true))
+	for _, want := range []string{`name="s1/late"`, `type="mcpsnoop.check.late"`, "1 result after a cancel"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("junit stdout missing %q\n%s", want, stdout)
+		}
+	}
+}
+
+// TestCheckMaxDurationIgnoresAnUnansweredCancel. Settling the call makes it
+// Done(), and its stored end is when the cancel landed, so without the skip a
+// capture that used to be exempt as pending would start failing the budget on a
+// number that is not a latency. A cancelled call that did get an answer is still
+// judged: that duration is a real server latency.
+func TestCheckMaxDurationIgnoresAnUnansweredCancel(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	code, stdout, _ := executeCheck(t, []string{"--max-duration", "100ms", "-"}, cancelCaptureLog(t, false))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0: a cancel timestamp is not a latency\n%s", code, stdout)
+	}
+
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	code, stdout, _ = executeCheck(t, []string{"--max-duration", "100ms", "-"}, cancelCaptureLog(t, true))
+	if code != 1 || !strings.Contains(stdout, "assertion failed:") {
+		t.Fatalf("exit = %d, want the real 610ms round trip still judged\n%s", code, stdout)
 	}
 }
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -130,9 +130,14 @@ type CallExport struct {
 	StartedAt  time.Time       `json:"started_at"`
 	EndedAt    *time.Time      `json:"ended_at,omitempty"`
 	DurationMS *float64        `json:"duration_ms,omitempty"`
-	Params     json.RawMessage `json:"params,omitempty"`
-	Result     json.RawMessage `json:"result,omitempty"`
-	Error      *proxy.RPCError `json:"error,omitempty"`
+	// CancelledAt is when a notifications/cancelled naming this call was observed,
+	// and CancelReason the host's own words for why. Present only on a cancelled
+	// call, so a reader can see the host had already walked away.
+	CancelledAt  *time.Time      `json:"cancelled_at,omitempty"`
+	CancelReason string          `json:"cancel_reason,omitempty"`
+	Params       json.RawMessage `json:"params,omitempty"`
+	Result       json.RawMessage `json:"result,omitempty"`
+	Error        *proxy.RPCError `json:"error,omitempty"`
 	// ErrorName is the specification's name for Error.Code, absent when the code
 	// is one the spec leaves to implementations. A sibling rather than a field
 	// inside Error, so the error object stays the wire shape.
@@ -159,6 +164,7 @@ type EventExport struct {
 	CacheTTLMs        *int            `json:"cache_ttl_ms,omitempty"`
 	CacheScope        string          `json:"cache_scope,omitempty"`
 	CacheStaleRefetch string          `json:"cache_stale_refetch,omitempty"`
+	LateResult        string          `json:"late_result,omitempty"`
 	CallIndex         *int            `json:"call_index,omitempty"`
 	Raw               json.RawMessage `json:"raw,omitempty"`
 	Text              string          `json:"text,omitempty"`
@@ -519,8 +525,10 @@ func WriteOTLP(w io.Writer, data SessionExport) error {
 			attrs = append(attrs, otlpDouble("mcpsnoop.call.duration_ms", *call.DurationMS))
 		}
 		status := "STATUS_CODE_OK"
-		if call.State == "pending" || call.State == "superseded" {
-			status = "STATUS_CODE_UNSET" // no definitive outcome, never answered
+		if call.State == "pending" || call.State == "superseded" || call.Status == "cancelled_request" {
+			// No definitive outcome, never answered. A cancelled call that did get a
+			// late result is left OK: it was answered, just too late to be wanted.
+			status = "STATUS_CODE_UNSET"
 		}
 		if call.IsError {
 			status = "STATUS_CODE_ERROR"
@@ -758,6 +766,12 @@ func exportCall(index int, c store.CallView) CallExport {
 		status = "streaming"
 	case c.State == store.Superseded:
 		status = "superseded"
+	case c.State == store.Cancelled:
+		// Ahead of the task branch below and deliberately not sharing its label. The
+		// Tasks feature already owns the bare "cancelled" status for a task that ended
+		// cancelled; a wire cancel of a request id is a different fact, and collapsing
+		// the two would make the export unable to say which one happened.
+		status = c.CancelStatus()
 	case c.TaskStatus == "cancelled":
 		// Terminal and without a result, so not ok, but the user stopped the work on
 		// purpose rather than hitting an error. Its own status ahead of Failed(),
@@ -786,12 +800,20 @@ func exportCall(index int, c store.CallView) CallExport {
 		ErrorName:  errorName(c.Err),
 	}
 	// A superseded call was never answered; its stored end is the moment the id was
-	// reused, not a latency, so omit the duration the way a pending call does.
-	if c.Done() && c.State != store.Superseded {
+	// reused, not a latency, so omit the duration the way a pending call does. A
+	// cancel with no answer is the same shape: its end is when the cancel landed.
+	// A cancelled call that did get a late answer keeps its duration, which is a
+	// real server latency and the whole point of reporting it.
+	if c.Done() && c.State != store.Superseded && !(c.State == store.Cancelled && !c.LateResult) {
 		end := c.End
 		dur := float64(c.End.Sub(c.Start)) / float64(time.Millisecond)
 		out.EndedAt = &end
 		out.DurationMS = &dur
+	}
+	if !c.CancelledAt.IsZero() {
+		cancelledAt := c.CancelledAt
+		out.CancelledAt = &cancelledAt
+		out.CancelReason = c.CancelReason
 	}
 	return out
 }
@@ -813,6 +835,7 @@ func exportEvent(ev store.EventView, callIndex map[string]int) EventExport {
 		CacheTTLMs:        cacheTTLExport(ev.CacheHint),
 		CacheScope:        ev.CacheHint.Scope,
 		CacheStaleRefetch: ev.CacheStaleRefetch,
+		LateResult:        ev.LateResult,
 		Raw:               ev.Raw,
 		Text:              ev.Text,
 	}
@@ -853,6 +876,11 @@ func writeText(w io.Writer, data SessionExport) error {
 		}
 		if ev.CacheStaleRefetch != "" {
 			title += " cache_stale_refetch"
+		}
+		// Spelled out rather than reduced to a marker word, because the note carries
+		// the ordering and the gap, which is the whole of what it reports.
+		if ev.LateResult != "" {
+			title += " late_result=" + ev.LateResult
 		}
 		if ev.CacheTTLMs != nil || ev.CacheScope != "" {
 			title += " cache"

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -163,6 +163,137 @@ func TestBuildExportsSupersededCallNotAsOk(t *testing.T) {
 	}
 }
 
+// TestBuildExportsAWireCancelUnderItsOwnStatus covers both shapes a
+// notifications/cancelled leaves behind, and guards the naming trap: the Tasks
+// feature already owns the bare "cancelled" status, so a cancelled request id
+// must not answer to the same label (see the sibling test below).
+func TestBuildExportsAWireCancelUnderItsOwnStatus(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name       string
+		late       bool
+		wantStatus string
+	}{
+		{"never answered", false, "cancelled_request"},
+		{"answered too late", true, "cancelled_late_result"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "cancel.jsonl")
+			writeEnv(t, path, proxy.Envelope{
+				SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: t0,
+				Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"slow_job"}}`),
+			})
+			writeEnv(t, path, proxy.Envelope{
+				SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: t0.Add(160 * time.Millisecond),
+				Direction: proxy.ClientToServer,
+				Raw:       json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":3,"reason":"Request timed out"}}`),
+			})
+			if tc.late {
+				writeEnv(t, path, proxy.Envelope{
+					SessionID: "s1", ServerLabel: "demo", Seq: 3, TS: t0.Add(610 * time.Millisecond),
+					Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`),
+				})
+			}
+
+			st, id, err := LoadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, err := Build(st, id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(out.Calls) != 1 {
+				t.Fatalf("want 1 call, got %d", len(out.Calls))
+			}
+			c := out.Calls[0]
+			if c.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", c.Status, tc.wantStatus)
+			}
+			if c.State != "cancelled" {
+				t.Fatalf("state = %q, want cancelled", c.State)
+			}
+			if c.IsError {
+				t.Fatal("a cancel is a decision, not an error, so is_error must stay false")
+			}
+			// The host's own words about what went wrong, which the spec asks both
+			// parties to log, plus when mcpsnoop saw the cancel.
+			if c.CancelReason != "Request timed out" {
+				t.Fatalf("cancel_reason = %q, want the host's reason", c.CancelReason)
+			}
+			if c.CancelledAt == nil || !c.CancelledAt.Equal(t0.Add(160*time.Millisecond)) {
+				t.Fatalf("cancelled_at = %v, want the cancel timestamp", c.CancelledAt)
+			}
+			if tc.late {
+				// A real round trip: the work finished, nobody was listening.
+				if c.DurationMS == nil || *c.DurationMS != 610 {
+					t.Fatalf("duration_ms = %v, want the real 610ms round trip", c.DurationMS)
+				}
+				if len(c.Result) == 0 {
+					t.Fatal("the late result bytes are the evidence and must be exported")
+				}
+			} else {
+				// The stored end is when the cancel landed, not a latency, so it is
+				// omitted the way a superseded call's is.
+				if c.DurationMS != nil || c.EndedAt != nil {
+					t.Fatalf("a cancel with no answer must omit the duration, got %v / %v", c.DurationMS, c.EndedAt)
+				}
+			}
+
+			// The response event carries the ordering and the gap, and does so
+			// structurally rather than as a warning: the spec's Timing Considerations
+			// bless the race, so a default check run must stay green.
+			var note, warning string
+			for _, ev := range out.Events {
+				if ev.LateResult != "" {
+					note = ev.LateResult
+				}
+				warning += ev.Warning
+			}
+			if tc.late && !strings.Contains(note, "450ms") {
+				t.Fatalf("late_result note = %q, want the observed gap", note)
+			}
+			if !tc.late && note != "" {
+				t.Fatalf("no response arrived, so there is no late_result note, got %q", note)
+			}
+			if warning != "" {
+				t.Fatalf("a cancel must raise no warning, got %q", warning)
+			}
+		})
+	}
+}
+
+// TestWireCancelDoesNotCollideWithTheTaskCancelledStatus. Two different facts,
+// two labels: this is the trap the issue calls out by name.
+func TestWireCancelDoesNotCollideWithTheTaskCancelledStatus(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task.jsonl")
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"slow"}}`),
+	})
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"resultType":"task","taskId":"t-1","status":"working"}}`),
+	})
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 3, TS: t0.Add(time.Second),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"t-1","status":"cancelled"}}`),
+	})
+
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := out.Calls[0].Status; got != "cancelled" {
+		t.Fatalf("cancelled task status = %q, want the unchanged cancelled label", got)
+	}
+}
+
 func TestBuildExportsCancelledTaskWithoutFlaggingAnError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cancel.jsonl")
 	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)

--- a/internal/exporter/har.go
+++ b/internal/exporter/har.go
@@ -204,10 +204,15 @@ func harStatus(status string) (int, string) {
 		return 200, "OK"
 	case "error":
 		return 500, "Error"
+	case "cancelled_late_result":
+		// The entry carries a body and a real round trip, so reporting it as "no
+		// response" would contradict the payload sitting right next to it. The text
+		// still says the call had been cancelled by the time it arrived.
+		return 200, "OK (cancelled)"
 	case "":
 		return 0, "No Response"
 	default:
-		return 0, status // pending or superseded, never answered
+		return 0, status // pending, superseded or cancelled_request, never answered
 	}
 }
 

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -37,6 +37,8 @@ main { padding:18px 24px 40px; max-width:1180px; margin:0 auto; }
 .status.error { color:var(--err); }
 .status.warn { color:var(--warn); }
 .status.superseded { color:var(--warn); }
+.status.cancelled_request { color:var(--warn); }
+.status.cancelled_late_result { color:var(--warn); }
 .status.pending { color:var(--pending); }
 .status.bad { color:var(--invalid); }
 /* Per-event tone by kind/status, matching the TUI stream colors. */
@@ -160,7 +162,10 @@ const toneOf = (ev, call) => {
     if (call && call.status === "error") return "error";
     // A cancelled task delivered no result but is not an error, so it reads as a
     // caution like the TUI row, reusing the warn tone rather than success green.
-    if (call && call.status === "cancelled") return "warn";
+    // A wire cancel of the request id is a separate fact with its own statuses,
+    // and reads the same way: answered too late, or never answered at all.
+    if (call && (call.status === "cancelled" || call.status === "cancelled_request" ||
+      call.status === "cancelled_late_result")) return "warn";
     return "resp";
   }
   return "resp";
@@ -175,6 +180,9 @@ const statusOf = (ev, call) => {
     if (call.status === "error") return "error";
     return call.status;
   }
+  // A wire cancel reads on the request row too: the call is settled, so an empty
+  // cell would leave it looking like an ordinary answered request.
+  if (call.status === "cancelled_request" || call.status === "cancelled_late_result") return call.status;
   return call.status === "pending" || call.status === "superseded" ? call.status : "";
 };
 const renderEvent = (ev) => {

--- a/internal/store/cancel_test.go
+++ b/internal/store/cancel_test.go
@@ -1,0 +1,268 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// cancelNotif is a notifications/cancelled naming a request id, in the shape a
+// host sends when it gives up: the id it issued plus the sentence it showed the
+// user.
+func cancelNotif(seq uint64, ts time.Time, dir proxy.Direction, requestID, reason string) proxy.Envelope {
+	params := `{"requestId":` + requestID
+	if reason != "" {
+		params += `,"reason":` + jsonString(reason)
+	}
+	params += `}`
+	return notif(seq, ts, dir, "notifications/cancelled", params)
+}
+
+func jsonString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// TestCancelSettlesAnUnansweredCall is the "server obeyed the cancel" half of
+// the bug: before this the call stayed Pending forever, so a conforming
+// cancellation was indistinguishable from a hang and --fail-on pending could
+// never be switched on.
+func TestCancelSettlesAnUnansweredCall(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, "3", "tools/call", `{"name":"slow_job"}`))
+	cancel := s.Ingest(cancelNotif(2, t0.Add(160*time.Millisecond), proxy.ClientToServer, "3", "Request timed out"))
+
+	events := s.Timeline("s1")
+	call := events[0].Call
+	if call == nil || call.State != Cancelled {
+		t.Fatalf("call state = %v, want cancelled", call)
+	}
+	if call.LateResult {
+		t.Fatal("no response arrived, so late_result must stay false")
+	}
+	if !call.Done() {
+		t.Fatal("a cancelled call is settled, so Done() must be true")
+	}
+	if got := call.CancelledAt; !got.Equal(t0.Add(160 * time.Millisecond)) {
+		t.Fatalf("cancelled_at = %v, want the cancel frame's timestamp", got)
+	}
+	if call.CancelReason != "Request timed out" {
+		t.Fatalf("cancel reason = %q, want the host's own words", call.CancelReason)
+	}
+	if got := call.CancelStatus(); got != "cancelled_request" {
+		t.Fatalf("cancel status = %q, want cancelled_request", got)
+	}
+	// The observation must not fail a default check run: the spec asks the server
+	// to do exactly this.
+	if cancel.Warning != "" {
+		t.Fatalf("the cancel frame must carry no warning, got %q", cancel.Warning)
+	}
+	header := s.Sessions()[0]
+	if header.Pending != 0 {
+		t.Fatalf("pending = %d, want 0 once the call is settled", header.Pending)
+	}
+	if header.Errors != 0 {
+		t.Fatalf("errors = %d, want 0: a cancel is a decision, not an error", header.Errors)
+	}
+}
+
+// TestCancelKeepsALateResultAsEvidence is the "server ignored the cancel" half:
+// the answer arrived and the host had already walked away, which used to read as
+// a clean success with no trace of the cancel anywhere.
+func TestCancelKeepsALateResultAsEvidence(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, "3", "tools/call", `{"name":"slow_job"}`))
+	s.Ingest(cancelNotif(2, t0.Add(160*time.Millisecond), proxy.ClientToServer, "3", "Request timed out"))
+	late := s.Ingest(resp(3, t0.Add(610*time.Millisecond), proxy.ServerToClient, "3", `"result":{"content":[{"type":"text","text":"done"}]}`))
+
+	call := late.Call
+	if call == nil || call.State != Cancelled {
+		t.Fatalf("call state = %v, want the call to stay cancelled", call)
+	}
+	if !call.LateResult {
+		t.Fatal("the late response must be recorded on the call")
+	}
+	if len(call.Result) == 0 {
+		t.Fatal("the result bytes are the evidence and must be kept")
+	}
+	if got := call.CancelStatus(); got != "cancelled_late_result" {
+		t.Fatalf("cancel status = %q, want cancelled_late_result", got)
+	}
+	// The note carries the ordering and the gap mcpsnoop observed, and nothing else.
+	if !strings.Contains(late.LateResult, "450ms") {
+		t.Fatalf("late-result note = %q, want the 450ms gap", late.LateResult)
+	}
+	// It must be an observation, not a protocol warning, or a default check run
+	// starts failing on a race the spec explicitly blesses.
+	if late.Warning != "" {
+		t.Fatalf("late result must not ride the warning field, got %q", late.Warning)
+	}
+	header := s.Sessions()[0]
+	if header.Pending != 0 || header.Errors != 0 {
+		t.Fatalf("pending/errors = %d/%d, want 0/0", header.Pending, header.Errors)
+	}
+}
+
+// TestLateErrorAfterACancelStaysAnError. A server acknowledging the cancel with
+// an error response is a common shape. The call still reads cancelled, because
+// that is what happened to it, but the error axis is untouched: an error frame on
+// the wire counted before this change and must count the same after it.
+func TestLateErrorAfterACancelStaysAnError(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, "3", "tools/call", `{"name":"slow_job"}`))
+	s.Ingest(cancelNotif(2, t0.Add(100*time.Millisecond), proxy.ClientToServer, "3", ""))
+	late := s.Ingest(resp(3, t0.Add(200*time.Millisecond), proxy.ServerToClient, "3",
+		`"error":{"code":-32800,"message":"request cancelled"}`))
+
+	if late.Call.State != Cancelled || !late.Call.LateResult {
+		t.Fatalf("call = state %v late %v, want cancelled with a late result", late.Call.State, late.Call.LateResult)
+	}
+	if !late.Call.Errored || !late.Call.Failed() {
+		t.Fatal("an error frame on the wire is still an error")
+	}
+	if late.Call.Err == nil || late.Call.Err.Code != -32800 {
+		t.Fatalf("the error object must be kept, got %+v", late.Call.Err)
+	}
+	if h := s.Sessions()[0]; h.Errors != 1 {
+		t.Fatalf("errors = %d, want 1, unchanged from before a cancel was settled", h.Errors)
+	}
+}
+
+// TestCancelIgnoresIdsItCannotClaim keeps the store from inventing anything on
+// evidence it does not have, the discipline serverCancelWarning is written to.
+func TestCancelIgnoresIdsItCannotClaim(t *testing.T) {
+	t.Run("never observed id", func(t *testing.T) {
+		s := New()
+		t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+		s.Ingest(req(1, t0, proxy.ClientToServer, "3", "tools/call", `{"name":"slow_job"}`))
+		s.Ingest(cancelNotif(2, t0.Add(time.Millisecond), proxy.ClientToServer, "404", ""))
+
+		if got := s.Timeline("s1")[0].Call.State; got != Pending {
+			t.Fatalf("state = %v, want the unrelated call left pending", got)
+		}
+		if h := s.Sessions()[0]; h.Pending != 1 {
+			t.Fatalf("pending = %d, want 1", h.Pending)
+		}
+	})
+
+	t.Run("already answered", func(t *testing.T) {
+		s := New()
+		t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+		s.Ingest(req(1, t0, proxy.ClientToServer, "3", "tools/call", `{"name":"fast"}`))
+		s.Ingest(resp(2, t0.Add(5*time.Millisecond), proxy.ServerToClient, "3", `"result":{"content":[]}`))
+		s.Ingest(cancelNotif(3, t0.Add(10*time.Millisecond), proxy.ClientToServer, "3", "too slow"))
+
+		call := s.Timeline("s1")[0].Call
+		if call.State != Completed {
+			t.Fatalf("state = %v, want the completed call untouched", call.State)
+		}
+		if call.CancelReason != "" || !call.CancelledAt.IsZero() {
+			t.Fatal("a cancel arriving after the answer must not rewrite the call")
+		}
+	})
+
+	t.Run("opposite direction", func(t *testing.T) {
+		s := New()
+		t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+		// A server-initiated request with id 1. JSON-RPC scopes id uniqueness per
+		// sender, so a client cancelling its own id 1 says nothing about this one.
+		s.Ingest(req(1, t0, proxy.ServerToClient, "1", "sampling/createMessage", `{}`))
+		s.Ingest(cancelNotif(2, t0.Add(time.Millisecond), proxy.ClientToServer, "1", "not mine"))
+
+		if got := s.Timeline("s1")[0].Call.State; got != Pending {
+			t.Fatalf("state = %v, want the server's own request untouched", got)
+		}
+	})
+}
+
+// TestCancelLeavesAStreamTeardownCompleted is the regression on the one shape
+// notifications/cancelled already had: a server tearing down a
+// subscriptions/listen stream ends that call Completed, not Cancelled.
+func TestCancelLeavesAStreamTeardownCompleted(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, "5", "subscriptions/listen", `{}`))
+	s.Ingest(cancelNotif(2, t0.Add(time.Second), proxy.ServerToClient, "5", "shutting down"))
+
+	call := s.Timeline("s1")[0].Call
+	if call.State != Completed {
+		t.Fatalf("state = %v, want completed", call.State)
+	}
+	if h := s.Sessions()[0]; h.Pending != 0 {
+		t.Fatalf("pending = %d, want 0", h.Pending)
+	}
+}
+
+// TestSecondResponseAfterALateResultStillWarns. The first answer after a cancel
+// is evidence; a second one for the same id is an ordinary duplicate again, and
+// neither may move the pending counter.
+func TestSecondResponseAfterALateResultStillWarns(t *testing.T) {
+	s := New()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s.Ingest(req(1, t0, proxy.ClientToServer, "3", "tools/call", `{"name":"slow_job"}`))
+	s.Ingest(cancelNotif(2, t0.Add(100*time.Millisecond), proxy.ClientToServer, "3", ""))
+	first := s.Ingest(resp(3, t0.Add(200*time.Millisecond), proxy.ServerToClient, "3", `"result":{"content":[]}`))
+	second := s.Ingest(resp(4, t0.Add(300*time.Millisecond), proxy.ServerToClient, "3", `"result":{"content":[]}`))
+
+	if strings.Contains(first.Warning, "duplicate response") {
+		t.Fatalf("the first late result is not a duplicate, got %q", first.Warning)
+	}
+	if !strings.Contains(second.Warning, "duplicate response for the same id") {
+		t.Fatalf("second response warning = %q, want the duplicate warning", second.Warning)
+	}
+	if h := s.Sessions()[0]; h.Pending != 0 {
+		t.Fatalf("pending = %d, want 0", h.Pending)
+	}
+}
+
+// TestToolSummarySkipsCancelledCallLatency mirrors the superseded case: the end
+// stored on a cancelled call is when the cancel landed, not a latency, so it must
+// not reach the percentiles. A cancelled call that did get a late answer still
+// feeds them, because that duration is a real server latency.
+func TestToolSummarySkipsCancelledCallLatency(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	s := New()
+	// One ordinary echo call at 25ms.
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"echo"}`))
+	s.Ingest(resp(2, t0.Add(25*time.Millisecond), proxy.ServerToClient, "1", `"result":{"content":[]}`))
+	// id 2 is cancelled a full second in and never answered.
+	s.Ingest(req(3, t0, proxy.ClientToServer, "2", "tools/call", `{"name":"echo"}`))
+	s.Ingest(cancelNotif(4, t0.Add(time.Second), proxy.ClientToServer, "2", "gave up"))
+
+	sum, ok := s.ToolSummary("s1")
+	if !ok || len(sum.Tools) != 1 {
+		t.Fatalf("ToolSummary = %+v ok %v", sum, ok)
+	}
+	echo := sum.Tools[0]
+	if echo.Calls != 2 || echo.Errors != 0 {
+		t.Fatalf("echo calls/errors = %d/%d, want 2/0", echo.Calls, echo.Errors)
+	}
+	if echo.P50 != 25*time.Millisecond || echo.P95 != 25*time.Millisecond {
+		t.Fatalf("echo percentiles = %s/%s, want 25ms from the answered call only", echo.P50, echo.P95)
+	}
+	for _, sc := range sum.Slowest {
+		if sc.Duration >= time.Second {
+			t.Fatalf("a cancel timestamp leaked into slowest as a latency: %+v", sc)
+		}
+	}
+
+	// The late-result shape is a real round trip, so it does feed the statistics.
+	withLate := New()
+	withLate.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"echo"}`))
+	withLate.Ingest(cancelNotif(2, t0.Add(160*time.Millisecond), proxy.ClientToServer, "1", ""))
+	withLate.Ingest(resp(3, t0.Add(610*time.Millisecond), proxy.ServerToClient, "1", `"result":{"content":[]}`))
+	lateSum, _ := withLate.ToolSummary("s1")
+	if lateSum.Tools[0].P50 != 610*time.Millisecond {
+		t.Fatalf("late-result p50 = %s, want the real 610ms round trip", lateSum.Tools[0].P50)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,6 +37,16 @@ const (
 	// Streaming means a long-lived stream request (subscriptions/listen) whose
 	// response arrives only when the stream ends. It is open but not pending.
 	Streaming
+	// Cancelled means the peer that issued the request sent notifications/cancelled
+	// for it, so it is settled and no longer pending: nobody is waiting for an
+	// answer any more. It is deliberately not Failed, because a cancel is a
+	// decision rather than an error, and the answer may still arrive (the spec's
+	// Timing Considerations bless that race), in which case the response is kept
+	// as evidence that the work actually completed.
+	//
+	// Appended rather than slotted next to Superseded so the existing iota values
+	// keep their numbers.
+	Cancelled
 )
 
 func (s CallState) String() string {
@@ -49,6 +59,8 @@ func (s CallState) String() string {
 		return "superseded"
 	case Streaming:
 		return "streaming"
+	case Cancelled:
+		return "cancelled"
 	default:
 		return "pending"
 	}
@@ -167,6 +179,16 @@ type call struct {
 	// remembered so completion can close it and a later notification under the
 	// same token is read as reuse rather than a violation.
 	progressToken string
+	// cancelledAt is when the notifications/cancelled frame was observed at
+	// mcpsnoop's own vantage point, which is the only ordering it can testify to.
+	cancelledAt time.Time
+	// cancelReason is the host's own words for why it gave up. The spec asks both
+	// parties to log cancellation reasons, and it is usually the sentence the user
+	// was shown ("Request timed out").
+	cancelReason string
+	// lateResult records that a response landed after the cancel: the work
+	// completed and the peer that asked for it was no longer listening.
+	lateResult bool
 }
 
 // event is the mutable internal timeline entry.
@@ -193,9 +215,15 @@ type event struct {
 	deprecated         string // a deprecated MCP feature was used (structured, not a protocol warning)
 	cacheHint          CacheHint
 	cacheStaleRefetch  string // client re-fetched inside a declared ttlMs window (structured, not a protocol warning)
-	call               *call  // set for request/response events
-	taskCall           *call  // originating call for a task lifecycle frame
-	taskID             string
+	// lateResult says a response arrived for a call that was already cancelled,
+	// with the ordering and the gap mcpsnoop observed. It rides its own field
+	// rather than warning because the spec's Timing Considerations bless the race,
+	// so a default check run must stay green on it (same discipline as truncated,
+	// deprecated and cacheStaleRefetch).
+	lateResult string
+	call       *call // set for request/response events
+	taskCall   *call // originating call for a task lifecycle frame
+	taskID     string
 	// mrtrRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised. Empty on an ordinary request.
 	mrtrRoot string
@@ -407,6 +435,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		if c != nil && c.state != Pending && c.state != Streaming {
 			sess.closeProgressToken(c.progressToken)
 		}
+		if matched && c != nil && c.state == Cancelled {
+			ev.lateResult = lateResultNote(c.cancelledAt, e.TS)
+		}
 		if state, ok := parseInputRequired(msg.Result); ok {
 			for _, note := range inputRequiredWarnings(state, c) {
 				ev.warning = appendWarning(ev.warning, note)
@@ -563,7 +594,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 				}]); note != "" {
 					ev.warning = appendWarning(ev.warning, note)
 				}
-				sess.closeStreamingCall(id, e.ConnID, e.TS)
+				// A stream teardown is its own shape (the call completes), so the
+				// ordinary settle runs only when that did not claim the id.
+				if !sess.closeStreamingCall(id, e.ConnID, e.TS) {
+					sess.cancelCall(e.Direction, id, e.ConnID, e.TS, cancelReason(msg.Params))
+				}
 			}
 		}
 		if msg.Method == "notifications/tasks" {
@@ -832,13 +867,22 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 	if c == nil {
 		return nil, false // unmatched response (request missed or before backfill)
 	}
-	if c.state != Pending && c.state != Streaming {
+	switch c.state {
+	case Pending, Streaming:
+	case Cancelled:
+		// The peer gave up, but the answer arrived anyway, which is the fact worth
+		// keeping: the work completed and nobody was listening. Record it once; a
+		// second response for the same id is a genuine duplicate again.
+		if c.lateResult {
+			return c, false
+		}
+	default:
 		return c, false // already answered, a duplicate or late response must not recount
 	}
 	if c.method == "tools/call" && c.taskID != "" {
 		return c, false // the task handle already continued this call
 	}
-	if state, ok := parseInputRequired(msg.Result); ok {
+	if state, ok := parseInputRequired(msg.Result); ok && c.state != Cancelled {
 		// The operation is not finished, it is waiting on the client. Keep it
 		// pending and open so its duration ends up spanning the whole exchange,
 		// including the time the user spends answering.
@@ -849,7 +893,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		sess.park(c)
 		return c, true
 	}
-	if c.method == "tools/call" {
+	if c.method == "tools/call" && c.state != Cancelled {
 		if state, ok := parseTaskState(msg.Result); ok && state.ResultType == "task" {
 			c.result = msg.Result
 			c.taskID = state.TaskID
@@ -862,18 +906,27 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 	c.result = msg.Result
 	c.err = msg.Error
 	wasPending := c.state == Pending
+	next := Completed
 	switch {
 	case msg.Error != nil:
-		c.state = Failed // JSON-RPC / protocol error
+		next = Failed // JSON-RPC / protocol error
 		c.errored = true
 	case isToolError(msg.Result):
-		c.state = Failed // tool-level error, a 200-OK response with result.isError=true
+		next = Failed // tool-level error, a 200-OK response with result.isError=true
 		c.toolErr = true
 		c.errored = true
-	default:
-		c.state = Completed
+	}
+	if c.state == Cancelled {
+		// A cancelled call stays cancelled: that is what the reader needs to know
+		// about it. The result, error and end above are still recorded, because the
+		// bytes are the evidence that the work finished.
+		c.lateResult = true
+	} else {
+		c.state = next
 	}
 	if wasPending {
+		// The slot was already released at cancel time, so wasPending is false there
+		// and the counter is not double-decremented.
 		sess.pending--
 	}
 	switch c.method {
@@ -1451,16 +1504,76 @@ func cancelledRequestID(params json.RawMessage) string {
 	return string(bytes.TrimSpace(p.RequestID))
 }
 
-func (sess *session) closeStreamingCall(id, conn string, ts time.Time) {
+// cancelReason is the host's own words for why it cancelled. Unlike the id this
+// is prose rather than a call key, so it is decoded into a Go string. Empty when
+// the notification carried none or the params do not parse.
+func cancelReason(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var p struct {
+		Reason string `json:"reason"`
+	}
+	if json.Unmarshal(params, &p) != nil {
+		return ""
+	}
+	return p.Reason
+}
+
+// closeStreamingCall ends a subscriptions/listen stream the notification tore
+// down. The bool reports whether it actually claimed a Streaming call, so the
+// caller can settle an ordinary request only when this did not.
+func (sess *session) closeStreamingCall(id, conn string, ts time.Time) bool {
 	for _, dir := range []proxy.Direction{proxy.ClientToServer, proxy.ServerToClient} {
 		key := callKey{dir: dir, id: id, conn: conn}
 		c := sess.calls[key]
 		if c != nil && c.state == Streaming {
 			c.end = ts
 			c.state = Completed
-			return
+			return true
 		}
 	}
+	return false
+}
+
+// cancelCall settles the request a notifications/cancelled names. Caller holds
+// the lock.
+//
+// It looks only in the direction the notification travelled, because the spec
+// scopes the notification to a request "previously issued in the same
+// direction". JSON-RPC scopes id uniqueness per sender, so scanning the opposite
+// direction too would let a client's cancel of id 1 settle an unrelated
+// server-initiated request that also happens to be id 1.
+//
+// Only a Pending call is settled: the spec likewise limits the notification to
+// requests "believed to still be in progress". An id mcpsnoop never observed, an
+// already-answered call, a superseded one, and a stream are therefore all
+// no-ops, which is the same discipline serverCancelWarning is written to.
+func (sess *session) cancelCall(dir proxy.Direction, id, conn string, ts time.Time, reason string) {
+	c := sess.calls[callKey{dir: dir, id: id, conn: conn}]
+	if c == nil || c.state != Pending {
+		return
+	}
+	c.state = Cancelled
+	// end is set so Done() is true and the TUI stops running a live spinner on a
+	// call nobody is waiting for. The exporter still omits the duration, because
+	// this timestamp is a cancel rather than a latency.
+	c.end = ts
+	c.cancelledAt = ts
+	c.cancelReason = reason
+	sess.pending--
+	sess.unpark(c) // a parked multi round-trip operation is settled too
+}
+
+// lateResultNote describes a response that landed after its call was cancelled.
+// The ordering and the gap at mcpsnoop's vantage point are all it claims: it
+// says nothing about which peer cancelled, and nothing about whether the server
+// was at fault, because the spec blesses the race and mcpsnoop cannot see inside
+// the server. max clamps a non-monotonic capture rather than printing "-2ms".
+func lateResultNote(cancelledAt, ts time.Time) string {
+	gap := max(ts.Sub(cancelledAt), 0).Round(time.Millisecond)
+	return "result arrived " + gap.String() +
+		" after the call was cancelled, and 2026-07-28 says the client should ignore it"
 }
 
 func operationName(msg proxy.RPCMessage) string {

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -31,6 +31,14 @@ type CallView struct {
 	State      CallState
 	TaskID     string
 	TaskStatus string
+	// CancelledAt is when mcpsnoop observed the notifications/cancelled naming this
+	// call, and CancelReason the host's own words for why. Both zero unless State
+	// is Cancelled.
+	CancelledAt  time.Time
+	CancelReason string
+	// LateResult is true when a response arrived after the cancel, so the work
+	// completed and the peer that asked for it had already stopped listening.
+	LateResult bool
 }
 
 // Failed reports a protocol error, a tool-level error (result.isError), or any
@@ -44,6 +52,25 @@ func (c CallView) Failed() bool { return c.Err != nil || c.ToolErr || c.State ==
 
 // Done reports whether a response has arrived.
 func (c CallView) Done() bool { return c.State != Pending && c.State != Streaming }
+
+// CancelStatus is the label a cancelled call reads under, separating the two
+// shapes a wire cancel produces: one nobody ever answered, and one the server
+// answered after the host had stopped listening. Empty for any other state.
+//
+// It lives beside the state so the export and the TUI row can never disagree,
+// and it deliberately avoids the bare "cancelled" the Tasks feature already uses
+// for a task that ended cancelled. That is a different fact from a cancel of a
+// request id on the wire, and one label could not tell them apart.
+func (c CallView) CancelStatus() string {
+	switch {
+	case c.State != Cancelled:
+		return ""
+	case c.LateResult:
+		return "cancelled_late_result"
+	default:
+		return "cancelled_request"
+	}
+}
 
 // Duration is the request→response latency, or elapsed-so-far while the call is
 // still open, which covers both a pending request and a live stream.
@@ -99,9 +126,13 @@ type EventView struct {
 	// CacheStaleRefetch is set when a client re-fetches inside a declared ttlMs
 	// window. Structured like Deprecated and never fails check.
 	CacheStaleRefetch string
-	Call              *CallView // set for request/response events
-	TaskCall          *CallView // originating call for a tasks/* lifecycle frame
-	TaskID            string
+	// LateResult is set on a response that arrived after its call was cancelled,
+	// carrying the ordering and the gap. Structured like Deprecated: an
+	// observation the spec's Timing Considerations allow, so it never fails check.
+	LateResult string
+	Call       *CallView // set for request/response events
+	TaskCall   *CallView // originating call for a tasks/* lifecycle frame
+	TaskID     string
 	// MRTRRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
 	MRTRRoot string
@@ -372,6 +403,7 @@ func (e *event) view(_ *session) EventView {
 		Deprecated:         e.deprecated,
 		CacheHint:          e.cacheHint,
 		CacheStaleRefetch:  e.cacheStaleRefetch,
+		LateResult:         e.lateResult,
 		TaskID:             e.taskID,
 		MRTRRoot:           e.mrtrRoot,
 		MRTRStateIssue:     e.mrtrStateIssue,
@@ -389,21 +421,24 @@ func (e *event) view(_ *session) EventView {
 
 func (c *call) view() CallView {
 	return CallView{
-		ID:         c.id,
-		Method:     c.method,
-		ReqDir:     c.reqDir,
-		IsTool:     c.isTool,
-		ToolName:   c.toolName,
-		Params:     c.params,
-		Result:     c.result,
-		Err:        c.err,
-		ToolErr:    c.toolErr,
-		Errored:    c.errored,
-		Start:      c.start,
-		End:        c.end,
-		State:      c.state,
-		TaskID:     c.taskID,
-		TaskStatus: c.taskStatus,
+		ID:           c.id,
+		Method:       c.method,
+		ReqDir:       c.reqDir,
+		IsTool:       c.isTool,
+		ToolName:     c.toolName,
+		Params:       c.params,
+		Result:       c.result,
+		Err:          c.err,
+		ToolErr:      c.toolErr,
+		Errored:      c.errored,
+		Start:        c.start,
+		End:          c.end,
+		State:        c.state,
+		TaskID:       c.taskID,
+		TaskStatus:   c.taskStatus,
+		CancelledAt:  c.cancelledAt,
+		CancelReason: c.cancelReason,
+		LateResult:   c.lateResult,
 	}
 }
 
@@ -713,6 +748,12 @@ func (s *Store) ToolSummary(sessionID string) (SessionToolSummary, bool) {
 		if c.state == Superseded {
 			// Its id was reused, so it was never answered. It still counts as a call
 			// (like a pending one), but has no real latency to feed the percentiles.
+			continue
+		}
+		if c.state == Cancelled && !c.lateResult {
+			// Cancelled and never answered. Its stored end is when the cancel landed,
+			// not a latency, so it counts as a call but feeds no percentile. One that
+			// did get a late answer still does: that duration is a real server latency.
 			continue
 		}
 		if c.errored {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1204,7 +1204,10 @@ func (m *Model) matchStatus(e store.EventView, v string) bool {
 		return e.Call.Errored
 	case "cancelled", "canceled":
 		// The row already labels a cancelled task "cancelled"; find it the same way.
-		return e.Call.TaskStatus == "cancelled"
+		// A cancelled request id keeps its own row and export labels, because they
+		// are different facts, but a search is not a label: one obvious query should
+		// find both rather than making the reader know which kind of cancel it was.
+		return e.Call.TaskStatus == "cancelled" || e.Call.State == store.Cancelled
 	case "pending", "pend", "inflight":
 		return e.Call.State == store.Pending
 	case "ok", "success":

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -201,6 +201,75 @@ func TestStreamRowShowsSupersededStatusInWarnStyle(t *testing.T) {
 	}
 }
 
+// TestStreamRowShowsCancelledCallWithoutASpinner. A cancelled call is settled,
+// so the row must stop offering the "possibly hung" affordance (spinner plus a
+// live clock) on a call nobody is waiting for, and must not read "ok" when the
+// answer arrives after the host has already walked away.
+func TestStreamRowShowsCancelledCallWithoutASpinner(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		late       bool
+		wantStatus string
+	}{
+		{"never answered", false, "cancelled_request"},
+		{"answered too late", true, "cancelled_late_result"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t0 := time.Now().Add(-time.Second)
+			st := store.New()
+			st.Ingest(envAt(1, proxy.ClientToServer, t0, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"slow_job"}}`))
+			st.Ingest(envAt(2, proxy.ClientToServer, t0.Add(160*time.Millisecond),
+				`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":3,"reason":"Request timed out"}}`))
+			if tc.late {
+				st.Ingest(envAt(3, proxy.ServerToClient, t0.Add(610*time.Millisecond),
+					`{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`))
+			}
+
+			m := ready(t, st)
+			m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // into the stream
+
+			request := m.full[0]
+			if request.Call == nil || request.Call.State != store.Cancelled {
+				t.Fatalf("first frame should be a cancelled call, got %+v", request.Call)
+			}
+			cells := m.streamCells(request)
+			if cells.status != tc.wantStatus {
+				t.Fatalf("request row status = %q, want %q", cells.status, tc.wantStatus)
+			}
+			if cells.dur != "" {
+				t.Fatalf("a settled call must not run a live timer, got dur %q", cells.dur)
+			}
+			if !strings.Contains(cells.detail, `cancelled: "Request timed out"`) {
+				t.Fatalf("the row should carry the host's reason, got %q", cells.detail)
+			}
+			// Warn, not the success green: never answered, or answered too late.
+			fg := m.statusStyle(request).GetForeground()
+			if fg != m.styles.warn.GetForeground() {
+				t.Fatal("a cancelled call should use the warn style")
+			}
+			if fg == m.styles.resp.GetForeground() {
+				t.Fatal("a cancelled call must not use the success style")
+			}
+
+			if !tc.late {
+				return
+			}
+			response := m.full[len(m.full)-1]
+			respCells := m.streamCells(response)
+			if respCells.status != "cancelled_late_result" {
+				t.Fatalf("response row status = %q, want cancelled_late_result", respCells.status)
+			}
+			if !strings.Contains(respCells.detail, "450ms") {
+				t.Fatalf("the response row should say how late the result was, got %q", respCells.detail)
+			}
+			// status:cancelled is one obvious query, and it finds a wire cancel too.
+			if !m.matchStatus(response, "cancelled") {
+				t.Fatal("status:cancelled should find a cancelled request id")
+			}
+		})
+	}
+}
+
 func TestRefreshClampsInspectWhenTimelineShrinks(t *testing.T) {
 	st := store.New()
 	seed(st)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -660,6 +661,20 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			} else if e.Call.State == store.Superseded {
 				// Its id was reused while in flight, so it will never be answered.
 				c.status = "superseded"
+			} else if e.Call.State == store.Cancelled {
+				// The peer gave up on it, so it is settled, not hung: no spinner and no
+				// pending label on a call nobody is waiting for.
+				c.status = e.Call.CancelStatus()
+				if e.Call.CancelReason != "" {
+					// Quoted like the other wire text this row shows, since a reason can
+					// carry newlines or control characters and this is a terminal cell.
+					reason := "cancelled: " + strconv.Quote(e.Call.CancelReason)
+					if c.detail == "" {
+						c.detail = reason
+					} else {
+						c.detail = reason + " · " + c.detail
+					}
+				}
 			}
 		}
 	case store.EventResponse:
@@ -668,6 +683,20 @@ func (m Model) streamCells(e store.EventView) streamCell {
 		if e.Call != nil {
 			c.dur = e.Call.Duration().Round(time.Millisecond).String()
 			switch {
+			case e.Call.State == store.Cancelled:
+				// The answer arrived, but the call had already been cancelled, so the
+				// row must not read "ok" as though someone were still waiting for it.
+				// The detail still says what arrived, since a server acknowledging the
+				// cancel with an error is a shape worth reading.
+				c.status = e.Call.CancelStatus()
+				switch {
+				case e.Call.Err != nil:
+					c.detail = rpcErrorText(*e.Call.Err)
+				case e.Call.ToolErr:
+					c.detail = toolErrorText(e.Call.Result)
+				default:
+					c.detail = compactJSON(e.Call.Result)
+				}
 			case e.Call.TaskID != "" && e.Call.State == store.Pending:
 				c.status = e.Call.TaskStatus
 				c.detail = compactJSON(e.Call.Result)
@@ -750,6 +779,15 @@ func (m Model) streamCells(e store.EventView) streamCell {
 			c.detail = e.CacheStaleRefetch
 		} else {
 			c.detail = e.CacheStaleRefetch + " · " + c.detail
+		}
+	}
+	// An observation, not a warning: the spec blesses the race, and the call state
+	// already supplies the row status, so this only adds the ordering and the gap.
+	if e.LateResult != "" {
+		if c.detail == "" {
+			c.detail = e.LateResult
+		} else {
+			c.detail = e.LateResult + " · " + c.detail
 		}
 	}
 	if !e.CacheHint.Empty() {
@@ -910,6 +948,11 @@ func (m Model) statusStyle(e store.EventView) lipgloss.Style {
 			return m.styles.follow
 		case e.Call.State == store.Superseded:
 			return m.styles.warn // never answered, not a success
+		case e.Call.State == store.Cancelled:
+			// Never answered, or answered after the peer stopped listening. Neither is
+			// a plain success, and neither is an error either, so it reads as a caution
+			// on the superseded precedent.
+			return m.styles.warn
 		case e.Call.Failed():
 			return m.styles.respErr
 		default:


### PR DESCRIPTION
## What and why

Closes #198.

A cancelled call read as a clean success. `notifications/cancelled` only closed a streaming call, and a late response could still overwrite the outcome as completed or failed.

Adds a `Cancelled` call state, with a reason and timestamp, that:

- settles the call the notification names, unless `closeStreamingCall` already claimed it
- releases the pending slot the way `Superseded` does
- survives a late response instead of being overwritten by it
- shows up in exports, the TUI row status, and the `check` summary

Uses `cancelled_request` / `cancelled_late_result`, since plain `cancelled` is already taken by the Tasks feature. A default `check` run stays green — the late-result case is opt-in via `--fail-on`. An id that was never observed stays a no-op.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
