### PR TITLE
feat(check): emit SARIF 2.1.0 so findings land in the Security tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ leave the capture incomplete, tool-definition drift, or use of deprecated
 protocol features.
 
 ```bash
-mcpsnoop check [--format text|junit] [--fail-on error,invalid,warn,mismatch,pending,drift,deprecated,incomplete] [session-id|log.jsonl|-]
+mcpsnoop check [--format text|junit|sarif] [--fail-on error,invalid,warn,mismatch,pending,drift,deprecated,incomplete] [session-id|log.jsonl|-]
 ```
 
 The three default signals (error, invalid, warn) fail the check. Add `pending`
@@ -393,6 +393,15 @@ definition remain observational only. Existing key- and value-based redaction
 also applies to captured parameter-header values before they reach a sink.
 Use `--format junit` to write one JUnit `<testcase>` per signal and session;
 failures follow the same `--fail-on` selection as the text output.
+Use `--format sarif` to write a SARIF 2.1.0 log instead. Where junit reports one
+aggregate per signal, SARIF reports one result per finding, carrying the session,
+the frame `Seq` and the frame's own warning or drift text, and pointing at the
+line of the log the frame was decoded from. A signal named in `--fail-on` is
+reported at level `error` and one outside it at level `note`, so the report and
+the gate never disagree. Alerts render only when the session log sits inside the
+checkout, since code scanning resolves a result's path against the repository
+root; the `artifacts/session.jsonl` recipe below already satisfies that, while a
+log read from the state directory or from stdin does not.
 
 ```bash
 mcpsnoop check build-agent
@@ -425,6 +434,23 @@ mcpsnoop check --expect-tool search --forbid-tool delete --max-duration 2s run.j
   with:
     name: mcpsnoop-junit
     path: test-results/mcpsnoop.xml
+```
+
+To put the findings in the Security tab instead, hand the SARIF log to
+`upload-sarif`. `check` exits non-zero on a finding, so the check step needs
+`continue-on-error` and the upload needs `if: always()`, or the report never
+reaches the tab on the runs that have something to report.
+
+```yaml
+- name: Check captured MCP session
+  continue-on-error: true
+  run: mcpsnoop check --format sarif artifacts/session.jsonl > mcpsnoop.sarif
+- name: Upload mcpsnoop SARIF report
+  if: always()
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: mcpsnoop.sarif
+    category: mcpsnoop
 ```
 
 ### Detect tool definition drift

--- a/README.md
+++ b/README.md
@@ -402,10 +402,19 @@ aggregate per signal, SARIF reports one result per finding, carrying the session
 the frame `Seq` and the frame's own warning or drift text, and pointing at the
 line of the log the frame was decoded from. A signal named in `--fail-on` is
 reported at level `error` and one outside it at level `note`, so the report and
-the gate never disagree. Alerts render only when the session log sits inside the
-checkout, since code scanning resolves a result's path against the repository
-root; the `artifacts/session.jsonl` recipe below already satisfies that, while a
-log read from the state directory or from stdin does not.
+the gate never disagree. Code scanning rejects a file whose run holds more than
+25,000 results and displays only the top 5,000 of what it accepts, so the report
+is capped at 5,000: the findings the gate failed on first, then a
+`mcpsnoop/report-truncated` result saying how many were left out. The text and
+junit formats stay complete.
+
+A result points at the log with a path relative to the working directory, which
+code scanning then resolves against the repository root. The alert renders with
+its surrounding lines only when that path is a file in the analysed commit, so a
+capture the workflow generated into `artifacts/` opens an alert carrying the
+message, the rule and the line number but no source view. Committing a capture
+you want rendered in full is the only way to get one. A log read from the state
+directory or from stdin gets no path at all.
 
 ```bash
 mcpsnoop check build-agent
@@ -441,17 +450,28 @@ mcpsnoop check --expect-tool search --forbid-tool delete --max-duration 2s run.j
 ```
 
 To put the findings in the Security tab instead, hand the SARIF log to
-`upload-sarif`. `check` exits non-zero on a finding, so the check step needs
-`continue-on-error` and the upload needs `if: always()`, or the report never
-reaches the tab on the runs that have something to report.
+`upload-sarif`. The job needs `security-events: write`, or the upload answers
+403. `check` exits non-zero on a finding, so the upload step needs `if: always()`
+to run at all on the runs that have something to report; `continue-on-error`
+hands the verdict to the code scanning check, which fails on an `error`-level
+alert and can be made a required check. Drop it if you would rather the check
+step itself be what turns the job red.
 
 ```yaml
+permissions:
+  # required for all workflows
+  security-events: write
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
+steps:
 - name: Check captured MCP session
   continue-on-error: true
   run: mcpsnoop check --format sarif artifacts/session.jsonl > mcpsnoop.sarif
 - name: Upload mcpsnoop SARIF report
   if: always()
-  uses: github/codeql-action/upload-sarif@v3
+  uses: github/codeql-action/upload-sarif@v4
   with:
     sarif_file: mcpsnoop.sarif
     category: mcpsnoop

--- a/cmd/mcpsnoop/baseline.go
+++ b/cmd/mcpsnoop/baseline.go
@@ -39,11 +39,12 @@ func newBaselineCmd() *cobra.Command {
 			if len(args) == 1 {
 				arg = args[0]
 			}
-			st, sessionID, err := loadCheckSession(cmd, arg)
+			sessionLog, err := loadCheckSession(cmd, arg)
 			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop baseline:", err)
 				return exitCode(1)
 			}
+			st, sessionID := sessionLog.store, sessionLog.sessionID
 			manager := toolbaseline.New(resolveBaselineDir(baselineDir))
 			switch {
 			case accept:

--- a/cmd/mcpsnoop/baseline.go
+++ b/cmd/mcpsnoop/baseline.go
@@ -39,7 +39,8 @@ func newBaselineCmd() *cobra.Command {
 			if len(args) == 1 {
 				arg = args[0]
 			}
-			sessionLog, err := loadCheckSession(cmd, arg)
+			// baseline reports tools, never lines, so it never pays for the index.
+			sessionLog, err := loadCheckSession(cmd, arg, false)
 			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop baseline:", err)
 				return exitCode(1)

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -75,7 +75,7 @@ func newCheckCmd() *cobra.Command {
 			if len(args) == 1 {
 				arg = args[0]
 			}
-			sessionLog, err := loadCheckSession(cmd, arg)
+			sessionLog, err := loadCheckSession(cmd, arg, format.needsLineIndex())
 			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
 				return exitCode(1)
@@ -252,6 +252,12 @@ func parseCheckOutputFormat(value string) (checkOutputFormat, error) {
 	}
 }
 
+// needsLineIndex reports whether a format points a reader at one line of the
+// log, which is the only thing the per-frame index is for. It costs a map entry
+// per captured frame held for the whole run, so a format that reports per
+// session rather than per frame must not pay for it.
+func (f checkOutputFormat) needsLineIndex() bool { return f == checkFormatSARIF }
+
 // checkLog is a loaded session log plus where it came from. A SARIF result has
 // to point at a file and a line, which neither the text nor the junit format
 // ever needed, so the path and the per-frame line index travel beside the store.
@@ -263,7 +269,10 @@ type checkLog struct {
 	lines     exporter.FrameLines
 }
 
-func loadCheckSession(cmd *cobra.Command, arg string) (checkLog, error) {
+// loadCheckSession reads the log a check or baseline run judges. withLines asks
+// for the per-frame line index, which only a caller that has to name a line
+// needs and which retains one map entry per captured frame until the run ends.
+func loadCheckSession(cmd *cobra.Command, arg string, withLines bool) (checkLog, error) {
 	if arg == "-" {
 		st, sessionID, err := exporter.Load(cmd.InOrStdin(), "stdin")
 		if err != nil {
@@ -274,6 +283,13 @@ func loadCheckSession(cmd *cobra.Command, arg string) (checkLog, error) {
 	path, err := exporter.ResolveSessionPath(arg)
 	if err != nil {
 		return checkLog{}, err
+	}
+	if !withLines {
+		st, sessionID, err := exporter.LoadFile(path)
+		if err != nil {
+			return checkLog{}, err
+		}
+		return checkLog{store: st, sessionID: sessionID, path: path}, nil
 	}
 	st, sessionID, lines, err := exporter.LoadFileLines(path)
 	if err != nil {

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -32,6 +32,7 @@ type checkOutputFormat string
 const (
 	checkFormatText  checkOutputFormat = "text"
 	checkFormatJUnit checkOutputFormat = "junit"
+	checkFormatSARIF checkOutputFormat = "sarif"
 )
 
 type checkSummary struct {
@@ -72,11 +73,12 @@ func newCheckCmd() *cobra.Command {
 			if len(args) == 1 {
 				arg = args[0]
 			}
-			st, _, err := loadCheckSession(cmd, arg)
+			sessionLog, err := loadCheckSession(cmd, arg)
 			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
 				return exitCode(1)
 			}
+			st := sessionLog.store
 
 			summaries := summarizeCheck(st, toolbaseline.New(resolveBaselineDir(baselineDir)))
 			anyFailed := false
@@ -92,7 +94,8 @@ func newCheckCmd() *cobra.Command {
 				}
 			}
 
-			if format == checkFormatJUnit {
+			switch format {
+			case checkFormatJUnit:
 				if err := writeCheckJUnit(cmd.OutOrStdout(), summaries, signals, assertionFailures); err != nil {
 					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
 					return exitCode(1)
@@ -100,7 +103,15 @@ func newCheckCmd() *cobra.Command {
 				if checkFailed(summaries, signals) {
 					anyFailed = true
 				}
-			} else {
+			case checkFormatSARIF:
+				if err := writeCheckSARIF(cmd.OutOrStdout(), sessionLog, summaries, signals, assertionFailures); err != nil {
+					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
+					return exitCode(1)
+				}
+				if checkFailed(summaries, signals) {
+					anyFailed = true
+				}
+			default:
 				for i, summary := range summaries {
 					fmt.Fprintf(cmd.OutOrStdout(), "session %s: errors=%d invalid=%d warnings=%d mismatches=%d pending=%d deprecated=%d missing_frames=%d\n",
 						summary.sessionID, summary.errors, summary.invalid, summary.warnings, summary.mismatches, summary.pending, summary.deprecated, summary.missingFrames)
@@ -139,7 +150,7 @@ func newCheckCmd() *cobra.Command {
 	}
 	cmd.Flags().SortFlags = false
 	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, drift, deprecated, incomplete")
-	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text or junit")
+	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text, junit, or sarif")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
 	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
 	cmd.Flags().StringArrayVar(&assertions.expectTools, "expect-tool", nil, "fail if this tool was never called, repeatable")
@@ -234,20 +245,41 @@ func parseCheckOutputFormat(value string) (checkOutputFormat, error) {
 		return checkFormatText, nil
 	case checkFormatJUnit:
 		return checkFormatJUnit, nil
+	case checkFormatSARIF:
+		return checkFormatSARIF, nil
 	default:
-		return "", fmt.Errorf("--format must be text or junit, got %q", value)
+		return "", fmt.Errorf("--format must be text, junit, or sarif, got %q", value)
 	}
 }
 
-func loadCheckSession(cmd *cobra.Command, arg string) (*store.Store, string, error) {
+// checkLog is a loaded session log plus where it came from. A SARIF result has
+// to point at a file and a line, which neither the text nor the junit format
+// ever needed, so the path and the per-frame line index travel beside the store.
+// Both are empty for a stdin run, which has no artifact to point at.
+type checkLog struct {
+	store     *store.Store
+	sessionID string
+	path      string
+	lines     exporter.FrameLines
+}
+
+func loadCheckSession(cmd *cobra.Command, arg string) (checkLog, error) {
 	if arg == "-" {
-		return exporter.Load(cmd.InOrStdin(), "stdin")
+		st, sessionID, err := exporter.Load(cmd.InOrStdin(), "stdin")
+		if err != nil {
+			return checkLog{}, err
+		}
+		return checkLog{store: st, sessionID: sessionID}, nil
 	}
 	path, err := exporter.ResolveSessionPath(arg)
 	if err != nil {
-		return nil, "", err
+		return checkLog{}, err
 	}
-	return exporter.LoadFile(path)
+	st, sessionID, lines, err := exporter.LoadFileLines(path)
+	if err != nil {
+		return checkLog{}, err
+	}
+	return checkLog{store: st, sessionID: sessionID, path: path, lines: lines}, nil
 }
 
 // summarizeCheck counts each signal for every session in the store, so a

--- a/cmd/mcpsnoop/check_sarif.go
+++ b/cmd/mcpsnoop/check_sarif.go
@@ -17,7 +17,10 @@ import (
 )
 
 const (
-	sarifSchema  = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+	// sarifSchema is the URI code scanning documents for a 2.1.0 log. The OASIS
+	// repository's own copy has moved twice and the path most producers still
+	// emit is a 404, which leaves a schema-aware reader with nothing to resolve.
+	sarifSchema  = "https://json.schemastore.org/sarif-2.1.0.json"
 	sarifVersion = "2.1.0"
 	// sarifDriverName and sarifInformationURI name the tool a code-scanning alert
 	// is attributed to, so both stay fixed regardless of how the binary was built.
@@ -26,13 +29,27 @@ const (
 	// sarifAssertionRuleID covers the --max-duration, --expect-tool and
 	// --forbid-tool failures, which are not signals and so have no signal name.
 	sarifAssertionRuleID = "mcpsnoop/assertion"
+	// sarifTruncationRuleID reports the report's own limit having been reached.
+	// It is not a signal either, and it describes this file rather than the
+	// traffic, but a reader who is not told the list was cut reads it as the
+	// whole story.
+	sarifTruncationRuleID = "mcpsnoop/report-truncated"
 	// sarifFingerprintKey is versioned, so a later change to how a finding is
 	// identified starts a fresh alert rather than silently rewriting the history
 	// of the alerts raised under the old scheme.
 	sarifFingerprintKey = "mcpsnoopFinding/v1"
 
-	sarifLevelError = "error"
-	sarifLevelNote  = "note"
+	sarifLevelError   = "error"
+	sarifLevelWarning = "warning"
+	sarifLevelNote    = "note"
+
+	// sarifMaxResults caps the results one run emits. Code scanning rejects a
+	// file outright above 25,000 results in a run and displays only the top 5,000
+	// of what it does accept, so an unbounded report either never reaches the
+	// Security tab or arrives silently cut. A capture can pass both thresholds
+	// without being pathological: one systematically misconfigured gateway yields
+	// two findings per request.
+	sarifMaxResults = 5000
 )
 
 type sarifLog struct {
@@ -57,11 +74,15 @@ type sarifDriver struct {
 	Rules          []sarifRule `json:"rules"`
 }
 
+// sarifRule carries help as well as the two descriptions, because code scanning
+// marks help.text required and renders it as the alert's "how to fix" panel. A
+// rule without one leaves that panel empty on every alert mcpsnoop raises.
 type sarifRule struct {
 	ID               string       `json:"id"`
 	Name             string       `json:"name"`
 	ShortDescription sarifMessage `json:"shortDescription"`
 	FullDescription  sarifMessage `json:"fullDescription"`
+	Help             sarifMessage `json:"help"`
 }
 
 type sarifMessage struct {
@@ -74,8 +95,11 @@ type sarifResult struct {
 	Level     string          `json:"level"`
 	Message   sarifMessage    `json:"message"`
 	Locations []sarifLocation `json:"locations,omitempty"`
-	// PartialFingerprints is what lets a consumer recognise a finding it has seen
-	// before across runs, so an unchanged one is not reported twice.
+	// PartialFingerprints identifies the finding rather than where it landed, so
+	// a consumer that reads the key can recognise the same finding in a later
+	// report over the same capture. Code scanning is not that consumer: it
+	// computes its own primaryLocationLineHash and ignores tool-defined keys, so
+	// this is written for everything else that reads SARIF.
 	PartialFingerprints map[string]string `json:"partialFingerprints"`
 }
 
@@ -138,8 +162,20 @@ func buildCheckSARIF(log checkLog, summaries []checkSummary, selected map[checkS
 			// run outright, so it is never a note. It also has no frame: it judges the
 			// session as a whole.
 			b.add(summary.sessionID, sarifAssertionRuleID, sarifLevelError,
-				fmt.Sprintf("session %s: %s", summary.sessionID, msg), msg, 0, false)
+				fmt.Sprintf("session %s: %s", summary.sessionID, msg), msg, 0)
 		}
+	}
+	if found := len(b.results); found > sarifMaxResults {
+		dropped := b.truncate()
+		// A warning, not an error: the gate has already decided whether this run
+		// passes, and a report that turned a green run red on its own would be the
+		// reporter overruling it. A note would be ranked below every finding if code
+		// scanning ever had to cut the list further, which is exactly when it must
+		// survive.
+		b.add("", sarifTruncationRuleID, sarifLevelWarning,
+			fmt.Sprintf("the capture holds %d findings, more than a code-scanning upload accepts in one run, so %d of them were left out of this report; the text and junit formats report all of them",
+				found, dropped),
+			"report-truncated", 0)
 	}
 	return sarifLog{
 		Schema:  sarifSchema,
@@ -176,24 +212,24 @@ func (b *sarifBuilder) session(st *store.Store, summary checkSummary) {
 		// and a log carrying no result at all would read as though it had.
 		b.add(sessionID, sarifRuleID(checkDrift), sarifLevelNote,
 			fmt.Sprintf("session %s: recorded first-seen tool baseline (trusted, not verified)", sessionID),
-			"baseline-recorded", 0, false)
+			"baseline-recorded", 0)
 	}
 
 	var toolListSeq uint64
-	var toolListSeen bool
 	pending := make(map[string]bool)
 	for _, event := range st.Timeline(sessionID) {
 		if event.Kind == store.EventResponse && event.Call != nil && event.Call.Method == "tools/list" {
 			// The last page, not the first: a paginated listing is only complete after
 			// it, and drift compares the complete list.
-			toolListSeq, toolListSeen = event.Seq, true
+			toolListSeq = event.Seq
 		}
 		if event.Errored {
-			// Keyed off the frame the store counted the error on, so the results are
-			// one per counted error. Deriving them from Call.Errored instead reported
-			// neither a transport failure nor an unmatched error response, both of
-			// which carry no call, and anchored an async task failure at the call's
-			// first response rather than at the frame that failed it.
+			// Keyed off the frames the store counted the errors on, so the report
+			// names them rather than re-deriving the conditions and drifting from the
+			// gate. Deriving them from Call.Errored instead reported neither a
+			// transport failure nor an unmatched error response, both of which carry
+			// no call, and anchored an async task failure at the call's first response
+			// rather than at the frame that failed it.
 			b.frame(sessionID, checkError, sarifErrorMessage(sessionID, event), event.Seq)
 		}
 		if event.Kind == store.EventInvalid {
@@ -215,6 +251,12 @@ func (b *sarifBuilder) session(st *store.Store, summary checkSummary) {
 			b.frame(sessionID, checkDeprecated,
 				fmt.Sprintf("session %s frame %d: %s", sessionID, event.Seq, event.Deprecated), event.Seq)
 		}
+		if event.LateResult {
+			// Keyed off the frame the store counted it on, like the error axis above.
+			// Call.LateResult is true from the request frame onwards once the answer
+			// lands, so reading it here would report the same finding twice.
+			b.frame(sessionID, checkLateResult, sarifLateResultMessage(sessionID, event), event.Seq)
+		}
 		if event.Kind == store.EventRequest && event.Call != nil && event.Call.State == store.Pending {
 			// A multi round-trip retry continues the same call, so keying on the call
 			// reports one hung operation rather than one per round trip.
@@ -234,7 +276,7 @@ func (b *sarifBuilder) session(st *store.Store, summary checkSummary) {
 		// sends the reader after something that never happened.
 		b.add(sessionID, sarifRuleID(checkDrift), driftLevel,
 			fmt.Sprintf("session %s: tool baseline error: %s", sessionID, summary.drift.BaselineError),
-			"baseline-error", toolListSeq, toolListSeen)
+			"baseline-error", toolListSeq)
 	}
 	// Looped over store.ToolDriftKinds so a kind the gate counts cannot go
 	// unreported here, leaving a failing run with no result to act on.
@@ -242,7 +284,7 @@ func (b *sarifBuilder) session(st *store.Store, summary checkSummary) {
 		for _, name := range summary.drift.Names(kind) {
 			b.add(sessionID, sarifRuleID(checkDrift), driftLevel,
 				fmt.Sprintf("session %s: tool %q %s", sessionID, name, driftLabel(kind)),
-				string(kind)+"/"+name, toolListSeq, toolListSeen)
+				string(kind)+"/"+name, toolListSeq)
 		}
 	}
 
@@ -250,20 +292,21 @@ func (b *sarifBuilder) session(st *store.Store, summary checkSummary) {
 		// The dropped frames never reached the log, so there is no line to point at.
 		b.add(sessionID, sarifRuleID(checkIncomplete), b.level(checkIncomplete),
 			checkSignalFailureReason(sessionID, checkIncomplete, int(summary.missingFrames)),
-			"missing-frames", 0, false)
+			"missing-frames", 0)
 	}
 }
 
 // frame appends a finding anchored at one captured frame.
 func (b *sarifBuilder) frame(sessionID string, signal checkSignal, message string, seq uint64) {
-	b.add(sessionID, sarifRuleID(signal), b.level(signal), message, strconv.FormatUint(seq, 10), seq, true)
+	b.add(sessionID, sarifRuleID(signal), b.level(signal), message, strconv.FormatUint(seq, 10), seq)
 }
 
 // add appends one result. anchor identifies the finding for its fingerprint and
 // is deliberately never the line number: a line moves whenever anything above it
 // changes, and a fingerprint that moved with it would close the alert and reopen
-// the same finding as a new one.
-func (b *sarifBuilder) add(sessionID, ruleID, level, message, anchor string, seq uint64, framed bool) {
+// the same finding as a new one. A seq of zero means the finding has no frame,
+// which both transports leave free by numbering from one.
+func (b *sarifBuilder) add(sessionID, ruleID, level, message, anchor string, seq uint64) {
 	result := sarifResult{
 		RuleID:    ruleID,
 		RuleIndex: b.ruleIndex[ruleID],
@@ -275,7 +318,7 @@ func (b *sarifBuilder) add(sessionID, ruleID, level, message, anchor string, seq
 	}
 	if b.uri != "" {
 		physical := sarifPhysicalLocation{ArtifactLocation: sarifArtifactLocation{URI: b.uri}}
-		if framed {
+		if seq != 0 {
 			if line, ok := b.lines.Line(sessionID, seq); ok {
 				physical.Region = &sarifRegion{StartLine: line}
 			}
@@ -283,6 +326,30 @@ func (b *sarifBuilder) add(sessionID, ruleID, level, message, anchor string, seq
 		result.Locations = []sarifLocation{{PhysicalLocation: physical}}
 	}
 	b.results = append(b.results, result)
+}
+
+// truncate cuts the report down to what a code-scanning upload will carry and
+// returns how many results were left out. The findings the gate failed on go
+// first, since a note dropped in favour of an error costs a reader nothing they
+// were going to act on, and one slot is held back for the result that says the
+// list was cut.
+func (b *sarifBuilder) truncate() int {
+	kept := make([]sarifResult, 0, sarifMaxResults)
+	// Two ordered passes rather than a sort, so results keep the order they were
+	// found in within a level and two runs over one log stay byte-identical.
+	for _, level := range []string{sarifLevelError, sarifLevelWarning, sarifLevelNote} {
+		for _, result := range b.results {
+			if len(kept) == sarifMaxResults-1 {
+				break
+			}
+			if result.Level == level {
+				kept = append(kept, result)
+			}
+		}
+	}
+	dropped := len(b.results) - len(kept)
+	b.results = kept
+	return dropped
 }
 
 // level ties the report to the gate: a signal named in --fail-on is an error,
@@ -303,14 +370,15 @@ func sarifRuleID(signal checkSignal) string { return "mcpsnoop/" + string(signal
 // sees the rule again without its result, so a rule that vanished from a green
 // run would leave its fixed finding open forever.
 func checkSARIFRules() []sarifRule {
-	rules := make([]sarifRule, 0, len(checkSignalOrder)+1)
+	rules := make([]sarifRule, 0, len(checkSignalOrder)+2)
 	for _, signal := range checkSignalOrder {
-		name, short, full := checkSARIFSignalRule(signal)
+		name, short, full, help := checkSARIFSignalRule(signal)
 		rules = append(rules, sarifRule{
 			ID:               sarifRuleID(signal),
 			Name:             name,
 			ShortDescription: sarifMessage{Text: short},
 			FullDescription:  sarifMessage{Text: full},
+			Help:             sarifMessage{Text: help},
 		})
 	}
 	return append(rules, sarifRule{
@@ -318,37 +386,59 @@ func checkSARIFRules() []sarifRule {
 		Name:             "AssertionFailure",
 		ShortDescription: sarifMessage{Text: "The session violates an asserted contract"},
 		FullDescription:  sarifMessage{Text: "A --max-duration, --expect-tool or --forbid-tool assertion failed: a completed tool call exceeded the latency budget, a tool that had to be called never was, or a forbidden tool was."},
+		Help:             sarifMessage{Text: "The result names which assertion failed and what the run actually did. Either the run stopped meeting the contract, or the contract has moved on and the flag on the check step needs updating."},
+	}, sarifRule{
+		ID:               sarifTruncationRuleID,
+		Name:             "ReportTruncated",
+		ShortDescription: sarifMessage{Text: "The capture held more findings than this report carries"},
+		FullDescription:  sarifMessage{Text: "Code scanning refuses a run holding more than 25,000 results and displays only the top 5,000 of what it accepts, so mcpsnoop caps the report and says how many findings it left out. The findings the gate failed on are kept first."},
+		Help:             sarifMessage{Text: "Run mcpsnoop check over the same capture with the default text format, or with --format junit, to see every finding. A capture this large usually means one systematic fault repeating, so fixing the first few findings tends to clear most of the rest."},
 	})
 }
 
-func checkSARIFSignalRule(signal checkSignal) (name, short, full string) {
+func checkSARIFSignalRule(signal checkSignal) (name, short, full, help string) {
 	switch signal {
 	case checkError:
 		return "CallError", "A call ended in an error",
-			"A request was answered with a JSON-RPC error, or with a result marked isError, or its task ended in a failure. It is the same axis the session error count and the CI gate read."
+			"A request was answered with a JSON-RPC error, or with a result marked isError, or its task ended in a failure. It is the same axis the session error count and the CI gate read.",
+			"Open the frame the result points at and read what the server actually said, which the message carries verbatim. A run that exercises failure paths on purpose can drop error from --fail-on, or capture only the traffic under test."
 	case checkInvalid:
 		return "InvalidFrame", "A frame is not valid JSON-RPC",
-			"A frame on the protocol channel could not be parsed as JSON-RPC, which usually means something wrote to the transport that is not part of the protocol, or the stream is corrupted."
+			"A frame on the protocol channel could not be parsed as JSON-RPC, which usually means something wrote to the transport that is not part of the protocol, or the stream is corrupted.",
+			"On stdio this is almost always a server logging to stdout, which the transport reserves for the protocol. Send that output to stderr instead. If the frame is JSON-RPC that mcpsnoop could not parse, the line the result points at is the whole evidence."
 	case checkWarn:
 		return "ProtocolWarning", "A frame violates a protocol expectation",
-			"A frame breaks an expectation the MCP or JSON-RPC specification sets, such as reusing an id already in flight, answering one id twice, or replying with neither result nor error."
+			"A frame breaks an expectation the MCP or JSON-RPC specification sets, such as reusing an id already in flight, answering one id twice, or replying with neither result nor error.",
+			"The message names the expectation and the frame that broke it. Fix the side that emitted the frame; mcpsnoop only observes, so nothing on the proxy changes this. A warning fails the gate by default, so a warning you accept has to leave --fail-on explicitly."
 	case checkMismatch:
 		return "RoutingMismatch", "A routing header disagrees with the body",
-			"An Mcp-Method, Mcp-Name, Mcp-Param-* or MCP-Protocol-Version header disagrees with the request body, rides a batch, or is missing where the negotiated revision requires it. A server's own -32020 rejection counts as the same condition."
+			"An Mcp-Method, Mcp-Name, Mcp-Param-* or MCP-Protocol-Version header disagrees with the request body, rides a batch, or is missing where the negotiated revision requires it. A server's own -32020 rejection counts as the same condition.",
+			"A gateway routing on the headers and a server reading the body are now looking at two different requests, so this is worth treating as a routing fault rather than cosmetics. The message names which header disagrees and with what."
 	case checkPending:
 		return "PendingCall", "A call never got a response",
-			"A request was captured with no response before the capture ended, so the caller was left waiting. Only a request that was still open at the end of the session counts."
+			"A request was captured with no response before the capture ended, so the caller was left waiting. Only a request that was still open at the end of the session counts.",
+			"Either the server never answered, or the capture stopped first. Check the end of the log before treating it as a hang, since a capture cut short leaves every in-flight call pending."
+	case checkLateResult:
+		return "LateResult", "A response arrived after its request was cancelled",
+			"The client cancelled a request and the server answered it anyway. The spec says a server receiving a cancellation SHOULD not send a response for it and that a client SHOULD ignore one that arrives, so this is wasted work on both sides rather than a protocol violation, which is why it is not in the default gate.",
+			"The message carries how long after the cancellation the answer arrived. A short delay is the race the specification allows for, since a cancellation can reach a server that has already replied. A long one means the server carried on working after being told to stop."
 	case checkDrift:
 		return "ToolDefinitionDrift", "An advertised tool definition changed after approval",
-			"An advertised tool differs from the trusted first-seen baseline for its server label in its description, title, input or output schema, annotations or icons, or a tool was added or removed. A baseline that could not be read is reported here too, since drift could not be verified."
+			"An advertised tool differs from the trusted first-seen baseline for its server label in its description, title, input or output schema, annotations or icons, or a tool was added or removed. A baseline that could not be read is reported here too, since drift could not be verified.",
+			"Read the change before accepting it: a description is a prompt an agent obeys, so rewriting one silently is how a trusted tool is repurposed. If the change is intended, re-record the baseline with mcpsnoop baseline. If the baseline could not be read at all, nothing was verified this run."
 	case checkDeprecated:
 		return "DeprecatedFeature", "A frame uses a deprecated protocol feature",
-			"A frame uses a feature the MCP specification has deprecated. Nothing is broken today, but the feature is on its way out and the traffic will need changing."
+			"A frame uses a feature the MCP specification has deprecated. Nothing is broken today, but the feature is on its way out and the traffic will need changing.",
+			"The message names the feature and what replaced it. Nothing fails until the feature is removed, so this is a note unless deprecated is named in --fail-on."
 	case checkIncomplete:
 		return "IncompleteCapture", "Frames were dropped, so the capture understates the session",
-			"Envelopes were dropped upstream, inferred from gaps in the per-session sequence numbers. Every other signal is then a floor rather than a total, because the dropped frames were never judged."
+			"Envelopes were dropped upstream, inferred from gaps in the per-session sequence numbers. Every other signal is then a floor rather than a total, because the dropped frames were never judged.",
+			"Every other count in this report is a floor, not a total, so a green run over an incomplete capture proves less than it looks. Frames are dropped when a sink cannot keep up, so a slow or blocked sink is the first place to look."
 	}
-	return string(signal), "An mcpsnoop check signal", "A signal reported by mcpsnoop check."
+	// Deliberately generic, and deliberately covered by a test that walks
+	// checkSignalOrder, because a signal reaching a code-scanning alert under a
+	// placeholder description is worse than one that never reaches it at all.
+	return string(signal), "An mcpsnoop check signal", "A signal reported by mcpsnoop check.", "See the mcpsnoop documentation."
 }
 
 // sarifErrorMessage names what went wrong on the frame the error was counted on,
@@ -392,6 +482,23 @@ func sarifErrorDetail(call store.CallView) string {
 	return "the call failed"
 }
 
+// sarifLateResultMessage names the call that was answered after its cancellation
+// and how late the answer was, since the delay is what separates the race the
+// spec allows for from a server that kept working after being told to stop. The
+// store writes that sentence as the frame's observation, so the two formats read
+// alike rather than paraphrasing each other.
+func sarifLateResultMessage(sessionID string, event store.EventView) string {
+	subject := "a cancelled call"
+	if event.Call != nil {
+		subject = sarifCallSubject(*event.Call)
+	}
+	if event.Observation == "" {
+		return fmt.Sprintf("session %s frame %d: %s was answered after it was cancelled", sessionID, event.Seq, subject)
+	}
+	return fmt.Sprintf("session %s frame %d: %s was answered after it was cancelled: %s",
+		sessionID, event.Seq, subject, event.Observation)
+}
+
 func sarifPendingMessage(sessionID string, seq uint64, call store.CallView) string {
 	return fmt.Sprintf("session %s frame %d: %s never got a response", sessionID, seq, sarifCallSubject(call))
 }
@@ -426,8 +533,9 @@ func sarifCallKey(call store.CallView) string {
 	return string(call.ReqDir) + "\x00" + call.ID + "\x00" + strconv.FormatInt(call.Start.UnixNano(), 10)
 }
 
-// sarifFingerprint is what lets a consumer recognise a finding across runs. It
-// is built from what the finding is, never from where it landed in the file.
+// sarifFingerprint identifies a finding by what it is, never by where it landed
+// in the file, so re-running check over a capture whose lines have moved
+// produces the same value.
 func sarifFingerprint(sessionID, ruleID, anchor string) string {
 	sum := sha256.Sum256([]byte(sessionID + "\x00" + ruleID + "\x00" + anchor))
 	return hex.EncodeToString(sum[:8])
@@ -435,10 +543,12 @@ func sarifFingerprint(sessionID, ruleID, anchor string) string {
 
 // sarifArtifactURI turns the session log path into the URI a result points at.
 // Code scanning resolves a relative URI against the root of the repository it
-// analysed and refuses a result whose artifact it cannot locate, so a log under
-// the working directory is reported relative to it. A log outside cannot
-// honestly be given a relative path, so it gets an absolute file: URI, which
-// will not render as an alert but also will not point at the wrong file.
+// analysed, so a log under the working directory is reported relative to it,
+// which is right whenever check runs at the root of the checkout as a workflow
+// step does by default. A log outside cannot honestly be given a relative path,
+// so it gets an absolute file: URI; code scanning converts that back against the
+// checkout when it can and otherwise leaves the alert without source context
+// rather than dropping it.
 func sarifArtifactURI(path string) string {
 	if path == "" {
 		return ""

--- a/cmd/mcpsnoop/check_sarif.go
+++ b/cmd/mcpsnoop/check_sarif.go
@@ -1,0 +1,471 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+const (
+	sarifSchema  = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+	sarifVersion = "2.1.0"
+	// sarifDriverName and sarifInformationURI name the tool a code-scanning alert
+	// is attributed to, so both stay fixed regardless of how the binary was built.
+	sarifDriverName     = "mcpsnoop"
+	sarifInformationURI = "https://github.com/kerlenton/mcpsnoop"
+	// sarifAssertionRuleID covers the --max-duration, --expect-tool and
+	// --forbid-tool failures, which are not signals and so have no signal name.
+	sarifAssertionRuleID = "mcpsnoop/assertion"
+	// sarifFingerprintKey is versioned, so a later change to how a finding is
+	// identified starts a fresh alert rather than silently rewriting the history
+	// of the alerts raised under the old scheme.
+	sarifFingerprintKey = "mcpsnoopFinding/v1"
+
+	sarifLevelError = "error"
+	sarifLevelNote  = "note"
+)
+
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	Version        string      `json:"version"`
+	InformationURI string      `json:"informationUri"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID               string       `json:"id"`
+	Name             string       `json:"name"`
+	ShortDescription sarifMessage `json:"shortDescription"`
+	FullDescription  sarifMessage `json:"fullDescription"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifResult struct {
+	RuleID    string          `json:"ruleId"`
+	RuleIndex int             `json:"ruleIndex"`
+	Level     string          `json:"level"`
+	Message   sarifMessage    `json:"message"`
+	Locations []sarifLocation `json:"locations,omitempty"`
+	// PartialFingerprints is what lets a consumer recognise a finding it has seen
+	// before across runs, so an unchanged one is not reported twice.
+	PartialFingerprints map[string]string `json:"partialFingerprints"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
+}
+
+func writeCheckSARIF(w io.Writer, log checkLog, summaries []checkSummary, selected map[checkSignal]bool, assertionFailures [][]string) error {
+	payload := buildCheckSARIF(log, summaries, selected, assertionFailures, appVersion())
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, "\n")
+	return err
+}
+
+// buildCheckSARIF renders every finding of the run as one result. It emits a
+// single run for the whole file rather than one per session: code scanning caps
+// a SARIF file at 20 runs and a concatenated capture can hold more sessions than
+// that, so the session id rides on each result instead.
+func buildCheckSARIF(log checkLog, summaries []checkSummary, selected map[checkSignal]bool, assertionFailures [][]string, version string) sarifLog {
+	rules := checkSARIFRules()
+	ruleIndex := make(map[string]int, len(rules))
+	for i, rule := range rules {
+		ruleIndex[rule.ID] = i
+	}
+	b := &sarifBuilder{
+		uri:       sarifArtifactURI(log.path),
+		lines:     log.lines,
+		selected:  selected,
+		ruleIndex: ruleIndex,
+		// Non-nil, so a clean run marshals "results": [] and not null. The empty
+		// array is what tells code scanning that the alerts it still holds are fixed.
+		results: []sarifResult{},
+	}
+	for i, summary := range summaries {
+		b.session(log.store, summary)
+		if i >= len(assertionFailures) {
+			continue
+		}
+		for _, msg := range assertionFailures[i] {
+			// An assertion runs only because the user asked for it and it fails the
+			// run outright, so it is never a note. It also has no frame: it judges the
+			// session as a whole.
+			b.add(summary.sessionID, sarifAssertionRuleID, sarifLevelError,
+				fmt.Sprintf("session %s: %s", summary.sessionID, msg), msg, 0, false)
+		}
+	}
+	return sarifLog{
+		Schema:  sarifSchema,
+		Version: sarifVersion,
+		Runs: []sarifRun{{
+			Tool: sarifTool{Driver: sarifDriver{
+				Name:           sarifDriverName,
+				Version:        version,
+				InformationURI: sarifInformationURI,
+				Rules:          rules,
+			}},
+			Results: b.results,
+		}},
+	}
+}
+
+// sarifBuilder accumulates the results of one run.
+type sarifBuilder struct {
+	uri       string
+	lines     exporter.FrameLines
+	selected  map[checkSignal]bool
+	ruleIndex map[string]int
+	results   []sarifResult
+}
+
+// session appends every finding of one session, in a fixed order so two runs
+// over the same log produce byte-identical output.
+func (b *sarifBuilder) session(st *store.Store, summary checkSummary) {
+	sessionID := summary.sessionID
+	if summary.baselineCreated {
+		// A first-seen baseline is recorded, not verified, which the text and junit
+		// formats both say out loud. SARIF has no equivalent of junit's <skipped>,
+		// so it is a note: the run is not failing, but it verified nothing either,
+		// and a log carrying no result at all would read as though it had.
+		b.add(sessionID, sarifRuleID(checkDrift), sarifLevelNote,
+			fmt.Sprintf("session %s: recorded first-seen tool baseline (trusted, not verified)", sessionID),
+			"baseline-recorded", 0, false)
+	}
+
+	var toolListSeq uint64
+	var toolListSeen bool
+	pending := make(map[string]bool)
+	for _, event := range st.Timeline(sessionID) {
+		if event.Kind == store.EventResponse && event.Call != nil && event.Call.Method == "tools/list" {
+			// The last page, not the first: a paginated listing is only complete after
+			// it, and drift compares the complete list.
+			toolListSeq, toolListSeen = event.Seq, true
+		}
+		if event.Errored {
+			// Keyed off the frame the store counted the error on, so the results are
+			// one per counted error. Deriving them from Call.Errored instead reported
+			// neither a transport failure nor an unmatched error response, both of
+			// which carry no call, and anchored an async task failure at the call's
+			// first response rather than at the frame that failed it.
+			b.frame(sessionID, checkError, sarifErrorMessage(sessionID, event), event.Seq)
+		}
+		if event.Kind == store.EventInvalid {
+			b.frame(sessionID, checkInvalid,
+				fmt.Sprintf("session %s frame %d: frame on the protocol channel is not valid JSON-RPC", sessionID, event.Seq), event.Seq)
+		}
+		if event.Warning != "" {
+			b.frame(sessionID, checkWarn,
+				fmt.Sprintf("session %s frame %d: %s", sessionID, event.Seq, event.Warning), event.Seq)
+		}
+		if event.RoutingMismatch {
+			// A mismatched frame usually carries the warning naming it, and then it is
+			// two findings under two rules, exactly as the gate counts it under two
+			// signals. Reporting fewer results than the gate counts would leave a
+			// failing run with nothing to open.
+			b.frame(sessionID, checkMismatch, sarifMismatchMessage(sessionID, event.Seq, event.Warning), event.Seq)
+		}
+		if event.Deprecated != "" {
+			b.frame(sessionID, checkDeprecated,
+				fmt.Sprintf("session %s frame %d: %s", sessionID, event.Seq, event.Deprecated), event.Seq)
+		}
+		if event.Kind == store.EventRequest && event.Call != nil && event.Call.State == store.Pending {
+			// A multi round-trip retry continues the same call, so keying on the call
+			// reports one hung operation rather than one per round trip.
+			if key := sarifCallKey(*event.Call); !pending[key] {
+				pending[key] = true
+				b.frame(sessionID, checkPending, sarifPendingMessage(sessionID, event.Seq, *event.Call), event.Seq)
+			}
+		}
+	}
+
+	// Drift and a baseline error both concern the advertised tool list, so both
+	// anchor at the response that carried it. A stdin run, or one whose log holds
+	// no tools/list response, simply gets no region.
+	driftLevel := b.level(checkDrift)
+	if summary.drift.BaselineError != "" {
+		// A baseline that could not be read is not a tool change. Saying otherwise
+		// sends the reader after something that never happened.
+		b.add(sessionID, sarifRuleID(checkDrift), driftLevel,
+			fmt.Sprintf("session %s: tool baseline error: %s", sessionID, summary.drift.BaselineError),
+			"baseline-error", toolListSeq, toolListSeen)
+	}
+	// Looped over store.ToolDriftKinds so a kind the gate counts cannot go
+	// unreported here, leaving a failing run with no result to act on.
+	for _, kind := range store.ToolDriftKinds {
+		for _, name := range summary.drift.Names(kind) {
+			b.add(sessionID, sarifRuleID(checkDrift), driftLevel,
+				fmt.Sprintf("session %s: tool %q %s", sessionID, name, driftLabel(kind)),
+				string(kind)+"/"+name, toolListSeq, toolListSeen)
+		}
+	}
+
+	if summary.missingFrames > 0 {
+		// The dropped frames never reached the log, so there is no line to point at.
+		b.add(sessionID, sarifRuleID(checkIncomplete), b.level(checkIncomplete),
+			checkSignalFailureReason(sessionID, checkIncomplete, int(summary.missingFrames)),
+			"missing-frames", 0, false)
+	}
+}
+
+// frame appends a finding anchored at one captured frame.
+func (b *sarifBuilder) frame(sessionID string, signal checkSignal, message string, seq uint64) {
+	b.add(sessionID, sarifRuleID(signal), b.level(signal), message, strconv.FormatUint(seq, 10), seq, true)
+}
+
+// add appends one result. anchor identifies the finding for its fingerprint and
+// is deliberately never the line number: a line moves whenever anything above it
+// changes, and a fingerprint that moved with it would close the alert and reopen
+// the same finding as a new one.
+func (b *sarifBuilder) add(sessionID, ruleID, level, message, anchor string, seq uint64, framed bool) {
+	result := sarifResult{
+		RuleID:    ruleID,
+		RuleIndex: b.ruleIndex[ruleID],
+		Level:     level,
+		Message:   sarifMessage{Text: message},
+		PartialFingerprints: map[string]string{
+			sarifFingerprintKey: sarifFingerprint(sessionID, ruleID, anchor),
+		},
+	}
+	if b.uri != "" {
+		physical := sarifPhysicalLocation{ArtifactLocation: sarifArtifactLocation{URI: b.uri}}
+		if framed {
+			if line, ok := b.lines.Line(sessionID, seq); ok {
+				physical.Region = &sarifRegion{StartLine: line}
+			}
+		}
+		result.Locations = []sarifLocation{{PhysicalLocation: physical}}
+	}
+	b.results = append(b.results, result)
+}
+
+// level ties the report to the gate: a signal named in --fail-on is an error,
+// one outside it a note, which surfaces the observation without asserting that
+// anyone must act on it.
+func (b *sarifBuilder) level(signal checkSignal) string {
+	if b.selected[signal] {
+		return sarifLevelError
+	}
+	return sarifLevelNote
+}
+
+func sarifRuleID(signal checkSignal) string { return "mcpsnoop/" + string(signal) }
+
+// checkSARIFRules is one rule per signal in checkSignalOrder plus one for the
+// assertions, so a signal added to that list reaches the report. Every rule is
+// declared on every run, clean or not: a consumer closes an alert only when it
+// sees the rule again without its result, so a rule that vanished from a green
+// run would leave its fixed finding open forever.
+func checkSARIFRules() []sarifRule {
+	rules := make([]sarifRule, 0, len(checkSignalOrder)+1)
+	for _, signal := range checkSignalOrder {
+		name, short, full := checkSARIFSignalRule(signal)
+		rules = append(rules, sarifRule{
+			ID:               sarifRuleID(signal),
+			Name:             name,
+			ShortDescription: sarifMessage{Text: short},
+			FullDescription:  sarifMessage{Text: full},
+		})
+	}
+	return append(rules, sarifRule{
+		ID:               sarifAssertionRuleID,
+		Name:             "AssertionFailure",
+		ShortDescription: sarifMessage{Text: "The session violates an asserted contract"},
+		FullDescription:  sarifMessage{Text: "A --max-duration, --expect-tool or --forbid-tool assertion failed: a completed tool call exceeded the latency budget, a tool that had to be called never was, or a forbidden tool was."},
+	})
+}
+
+func checkSARIFSignalRule(signal checkSignal) (name, short, full string) {
+	switch signal {
+	case checkError:
+		return "CallError", "A call ended in an error",
+			"A request was answered with a JSON-RPC error, or with a result marked isError, or its task ended in a failure. It is the same axis the session error count and the CI gate read."
+	case checkInvalid:
+		return "InvalidFrame", "A frame is not valid JSON-RPC",
+			"A frame on the protocol channel could not be parsed as JSON-RPC, which usually means something wrote to the transport that is not part of the protocol, or the stream is corrupted."
+	case checkWarn:
+		return "ProtocolWarning", "A frame violates a protocol expectation",
+			"A frame breaks an expectation the MCP or JSON-RPC specification sets, such as reusing an id already in flight, answering one id twice, or replying with neither result nor error."
+	case checkMismatch:
+		return "RoutingMismatch", "A routing header disagrees with the body",
+			"An Mcp-Method, Mcp-Name, Mcp-Param-* or MCP-Protocol-Version header disagrees with the request body, rides a batch, or is missing where the negotiated revision requires it. A server's own -32020 rejection counts as the same condition."
+	case checkPending:
+		return "PendingCall", "A call never got a response",
+			"A request was captured with no response before the capture ended, so the caller was left waiting. Only a request that was still open at the end of the session counts."
+	case checkDrift:
+		return "ToolDefinitionDrift", "An advertised tool definition changed after approval",
+			"An advertised tool differs from the trusted first-seen baseline for its server label in its description, title, input or output schema, annotations or icons, or a tool was added or removed. A baseline that could not be read is reported here too, since drift could not be verified."
+	case checkDeprecated:
+		return "DeprecatedFeature", "A frame uses a deprecated protocol feature",
+			"A frame uses a feature the MCP specification has deprecated. Nothing is broken today, but the feature is on its way out and the traffic will need changing."
+	case checkIncomplete:
+		return "IncompleteCapture", "Frames were dropped, so the capture understates the session",
+			"Envelopes were dropped upstream, inferred from gaps in the per-session sequence numbers. Every other signal is then a floor rather than a total, because the dropped frames were never judged."
+	}
+	return string(signal), "An mcpsnoop check signal", "A signal reported by mcpsnoop check."
+}
+
+// sarifErrorMessage names what went wrong on the frame the error was counted on,
+// rather than leaving a reader with a count and a frame number. The store counts
+// an error on four kinds of frame, and each one reads differently: a settled
+// call, a task that ended in a failed state, an HTTP failure carrying no
+// JSON-RPC body, and an error response matching no request it could name.
+func sarifErrorMessage(sessionID string, event store.EventView) string {
+	switch {
+	// The failed call is read before the task it was polling: a tasks/get that
+	// errored is the poll failing, not the task, and a task lifecycle frame
+	// carries both calls either way.
+	case event.Kind == store.EventResponse && event.Call != nil && event.Call.Errored:
+		return fmt.Sprintf("session %s frame %d: %s ended in an error: %s",
+			sessionID, event.Seq, sarifCallSubject(*event.Call), sarifErrorDetail(*event.Call))
+	case event.TaskCall != nil:
+		return fmt.Sprintf("session %s frame %d: %s failed as task %s: %s",
+			sessionID, event.Seq, sarifCallSubject(*event.TaskCall), event.TaskID, sarifErrorDetail(*event.TaskCall))
+	case event.Kind == store.EventTransport:
+		return fmt.Sprintf("session %s frame %d: the transport failed with HTTP %d",
+			sessionID, event.Seq, event.HTTPStatus)
+	}
+	// An error response whose id matches no request the capture saw. There is no
+	// call to name, so the frame and its own warning are all a reader gets.
+	if event.Warning != "" {
+		return fmt.Sprintf("session %s frame %d: error response could not be matched to a call: %s",
+			sessionID, event.Seq, event.Warning)
+	}
+	return fmt.Sprintf("session %s frame %d: error response could not be matched to a call", sessionID, event.Seq)
+}
+
+// sarifErrorDetail says why a call is counted as failed, preferring the server's
+// own words to a restatement of the flag.
+func sarifErrorDetail(call store.CallView) string {
+	switch {
+	case call.Err != nil:
+		return fmt.Sprintf("%s (code %d)", call.Err.Message, call.Err.Code)
+	case call.ToolErr:
+		return "the result is marked isError"
+	}
+	return "the call failed"
+}
+
+func sarifPendingMessage(sessionID string, seq uint64, call store.CallView) string {
+	return fmt.Sprintf("session %s frame %d: %s never got a response", sessionID, seq, sarifCallSubject(call))
+}
+
+func sarifMismatchMessage(sessionID string, seq uint64, warning string) string {
+	if warning == "" {
+		return fmt.Sprintf("session %s frame %d: a routing header disagrees with the body", sessionID, seq)
+	}
+	return fmt.Sprintf("session %s frame %d: routing header mismatch: %s", sessionID, seq, warning)
+}
+
+// sarifCallSubject names a call the way the reader saw it on the wire, tool name
+// included when there is one, since "tools/call" alone identifies nothing.
+func sarifCallSubject(call store.CallView) string {
+	method := call.Method
+	if method == "" {
+		method = "call"
+	}
+	if call.IsTool && call.ToolName != "" {
+		method = fmt.Sprintf("%s %s", method, call.ToolName)
+	}
+	if call.ID == "" {
+		return method
+	}
+	return fmt.Sprintf("%s (id %s)", method, call.ID)
+}
+
+// sarifCallKey identifies one correlated call. The id alone would not: a client
+// may reuse an id once the earlier call is settled, and the two are separate
+// findings.
+func sarifCallKey(call store.CallView) string {
+	return string(call.ReqDir) + "\x00" + call.ID + "\x00" + strconv.FormatInt(call.Start.UnixNano(), 10)
+}
+
+// sarifFingerprint is what lets a consumer recognise a finding across runs. It
+// is built from what the finding is, never from where it landed in the file.
+func sarifFingerprint(sessionID, ruleID, anchor string) string {
+	sum := sha256.Sum256([]byte(sessionID + "\x00" + ruleID + "\x00" + anchor))
+	return hex.EncodeToString(sum[:8])
+}
+
+// sarifArtifactURI turns the session log path into the URI a result points at.
+// Code scanning resolves a relative URI against the root of the repository it
+// analysed and refuses a result whose artifact it cannot locate, so a log under
+// the working directory is reported relative to it. A log outside cannot
+// honestly be given a relative path, so it gets an absolute file: URI, which
+// will not render as an alert but also will not point at the wrong file.
+func sarifArtifactURI(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	if wd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(wd, abs); err == nil && !sarifEscapes(rel) {
+			// Through net/url so a space or a '#' in a directory name is escaped
+			// rather than silently truncating the URI.
+			return (&url.URL{Path: filepath.ToSlash(rel)}).String()
+		}
+	}
+	slash := filepath.ToSlash(abs)
+	if !strings.HasPrefix(slash, "/") {
+		// A Windows path (C:/logs/session.jsonl) needs the leading slash that makes
+		// it file:///C:/logs/session.jsonl.
+		slash = "/" + slash
+	}
+	return (&url.URL{Scheme: "file", Path: slash}).String()
+}
+
+// sarifEscapes reports whether a relative path climbs out of the directory it
+// was computed against. Matching on a ".." prefix alone would also catch a
+// legitimate "..data" directory.
+func sarifEscapes(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/cmd/mcpsnoop/check_sarif_test.go
+++ b/cmd/mcpsnoop/check_sarif_test.go
@@ -1,0 +1,646 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func TestCheckSARIFCleanSessionDeclaresEveryRuleAndNoResults(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"ping"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{}}`),
+	)
+
+	code, stdout, stderr := executeCheck(t, []string{"--format", "sarif", "-"}, log)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", code, stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	// An empty array rather than null: that is what tells a consumer the alerts it
+	// still holds are fixed, where null would read as "nothing was analysed".
+	if !strings.Contains(stdout, `"results": []`) {
+		t.Fatalf("a clean run must emit an empty results array:\n%s", stdout)
+	}
+
+	report := decodeCheckSARIF(t, stdout)
+	if report.Schema == "" || report.Version != sarifVersion {
+		t.Fatalf("$schema = %q, version = %q", report.Schema, report.Version)
+	}
+	if len(report.Runs) != 1 {
+		t.Fatalf("runs = %d, want exactly one for the whole file", len(report.Runs))
+	}
+	driver := report.Runs[0].Tool.Driver
+	if driver.Name != "mcpsnoop" || driver.Version == "" || driver.InformationURI == "" {
+		t.Fatalf("driver = %+v", driver)
+	}
+	// Every rule on every run, clean or not, or a fixed finding's alert never
+	// closes.
+	want := []string{
+		"mcpsnoop/error", "mcpsnoop/invalid", "mcpsnoop/warn", "mcpsnoop/mismatch",
+		"mcpsnoop/pending", "mcpsnoop/drift", "mcpsnoop/deprecated", "mcpsnoop/incomplete",
+		"mcpsnoop/assertion",
+	}
+	if len(driver.Rules) != len(want) {
+		t.Fatalf("rules = %d, want %d", len(driver.Rules), len(want))
+	}
+	for i, id := range want {
+		rule := driver.Rules[i]
+		if rule.ID != id {
+			t.Fatalf("rule %d = %q, want %q", i, rule.ID, id)
+		}
+		if rule.Name == "" || rule.ShortDescription.Text == "" || rule.FullDescription.Text == "" {
+			t.Fatalf("rule %q is missing a name or a description: %+v", id, rule)
+		}
+	}
+}
+
+// TestCheckSARIFReportsOneResultPerFinding. The junit report collapses every
+// finding of a kind into one count, which is the whole reason for this format:
+// three warnings have to arrive as three results a reader can open.
+func TestCheckSARIFReportsOneResultPerFinding(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t, checkSignalEnvelopes()...)
+
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	report := decodeCheckSARIF(t, stdout)
+
+	// The counts the text format prints for this fixture, one result each.
+	for ruleID, want := range map[string]int{
+		"mcpsnoop/error":   2,
+		"mcpsnoop/invalid": 1,
+		"mcpsnoop/warn":    1,
+		"mcpsnoop/pending": 1,
+	} {
+		if got := len(sarifResultsFor(report, ruleID)); got != want {
+			t.Fatalf("%s results = %d, want %d\n%s", ruleID, got, want, stdout)
+		}
+	}
+
+	// The two errors are two distinct findings on two distinct frames, not one
+	// message saying "2 errors".
+	messages := sarifMessagesFor(report, "mcpsnoop/error")
+	if messages[0] == messages[1] {
+		t.Fatalf("the two errors must not share a message: %q", messages[0])
+	}
+	for _, message := range messages {
+		if !strings.Contains(message, "session s1 frame ") {
+			t.Fatalf("a result must name its session and frame: %q", message)
+		}
+		if strings.Contains(message, "has 2 errors") {
+			t.Fatalf("a result must be a finding, not a per-session count: %q", message)
+		}
+	}
+	if got := sarifMessagesFor(report, "mcpsnoop/error")[0]; !strings.Contains(got, "-32601") {
+		t.Fatalf("the error result must carry what the server actually said: %q", got)
+	}
+
+	// Every result names a rule that was declared, and points at the right one.
+	rules := report.Runs[0].Tool.Driver.Rules
+	for _, result := range report.Runs[0].Results {
+		if result.RuleIndex < 0 || result.RuleIndex >= len(rules) {
+			t.Fatalf("ruleIndex %d is out of range", result.RuleIndex)
+		}
+		if rules[result.RuleIndex].ID != result.RuleID {
+			t.Fatalf("ruleIndex %d points at %q, not %q", result.RuleIndex, rules[result.RuleIndex].ID, result.RuleID)
+		}
+		if result.PartialFingerprints[sarifFingerprintKey] == "" {
+			t.Fatalf("result %q has no fingerprint", result.Message.Text)
+		}
+	}
+}
+
+// TestCheckSARIFLevelFollowsFailOn. The report follows the gate, never the other
+// way round, so flipping the selection moves the levels and nothing else.
+func TestCheckSARIFLevelFollowsFailOn(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t, checkSignalEnvelopes()...)
+
+	_, defaults, _ := executeCheck(t, []string{"--format", "sarif", "-"}, log)
+	_, flipped, _ := executeCheck(t, []string{"--format", "sarif", "--fail-on", "pending", "-"}, log)
+
+	byDefault := decodeCheckSARIF(t, defaults)
+	byPending := decodeCheckSARIF(t, flipped)
+
+	for _, tc := range []struct {
+		ruleID              string
+		underDefault, under string
+	}{
+		{"mcpsnoop/error", "error", "note"},
+		{"mcpsnoop/warn", "error", "note"},
+		{"mcpsnoop/pending", "note", "error"},
+	} {
+		for _, result := range sarifResultsFor(byDefault, tc.ruleID) {
+			if result.Level != tc.underDefault {
+				t.Fatalf("%s level = %q under the default selection, want %q", tc.ruleID, result.Level, tc.underDefault)
+			}
+		}
+		for _, result := range sarifResultsFor(byPending, tc.ruleID) {
+			if result.Level != tc.under {
+				t.Fatalf("%s level = %q under --fail-on pending, want %q", tc.ruleID, result.Level, tc.under)
+			}
+		}
+	}
+
+	// Only the levels move. The findings themselves are what the capture holds,
+	// which the selection has no say over.
+	if got, want := sarifAllMessages(byPending), sarifAllMessages(byDefault); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("the selection changed which findings were reported:\n%v\n%v", want, got)
+	}
+}
+
+// TestCheckSARIFRegionIsTheTrueLine. Seq is per session and skips dropped
+// frames, so writing it into startLine would send a reader to the wrong frame,
+// which is worse than sending them nowhere.
+func TestCheckSARIFRegionIsTheTrueLine(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeCheckLog(t, filepath.Join(dir, "two.jsonl"), gapEnvelopes()...)
+
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--fail-on", "warn,pending,incomplete", "two.jsonl"}, "")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1\n%s", code, stdout)
+	}
+	report := decodeCheckSARIF(t, stdout)
+
+	// alpha's warning rides Seq 5 on line 3, beta's Seq 1 on line 4: in both the
+	// line and the Seq are different numbers.
+	lines := map[string]int{}
+	for _, result := range sarifResultsFor(report, "mcpsnoop/warn") {
+		region := sarifRegionOf(t, result)
+		lines[sarifSessionOf(t, result.Message.Text)] = region.StartLine
+	}
+	if lines["alpha"] != 3 {
+		t.Fatalf("alpha's warning is on line %d, want 3", lines["alpha"])
+	}
+	if lines["beta"] != 4 {
+		t.Fatalf("beta's warning is on line %d, want 4", lines["beta"])
+	}
+
+	// beta's hung tools/call is Seq 2 on line 5.
+	var hung sarifResult
+	for _, result := range sarifResultsFor(report, "mcpsnoop/pending") {
+		if strings.Contains(result.Message.Text, "tools/call y") {
+			hung = result
+		}
+	}
+	if hung.RuleID == "" {
+		t.Fatalf("no pending result for the hung call:\n%s", stdout)
+	}
+	if got := sarifRegionOf(t, hung).StartLine; got != 5 {
+		t.Fatalf("beta's pending call is on line %d, want 5", got)
+	}
+
+	// A log inside the working directory is pointed at relatively, since code
+	// scanning resolves the URI against the repository root.
+	if uri := sarifURIOf(t, hung); uri != "two.jsonl" {
+		t.Fatalf("artifact uri = %q, want the relative path", uri)
+	}
+}
+
+// TestCheckSARIFIncompleteHasNoRegion. The dropped frames never reached the log,
+// so there is no line to send a reader to.
+func TestCheckSARIFIncompleteHasNoRegion(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeCheckLog(t, filepath.Join(dir, "two.jsonl"), gapEnvelopes()...)
+
+	_, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--fail-on", "incomplete", "two.jsonl"}, "")
+	report := decodeCheckSARIF(t, stdout)
+
+	results := sarifResultsFor(report, "mcpsnoop/incomplete")
+	if len(results) != 1 {
+		t.Fatalf("incomplete results = %d, want one for the only affected session\n%s", len(results), stdout)
+	}
+	if !strings.Contains(results[0].Message.Text, "alpha") {
+		t.Fatalf("the incomplete result must name its session: %q", results[0].Message.Text)
+	}
+	if len(results[0].Locations) != 1 {
+		t.Fatalf("the incomplete result must still point at the log: %+v", results[0].Locations)
+	}
+	if region := results[0].Locations[0].PhysicalLocation.Region; region != nil {
+		t.Fatalf("a dropped frame has no line, got startLine %d", region.StartLine)
+	}
+}
+
+// TestCheckSARIFFingerprintsSurviveTheLinesMoving. A fingerprint derived from
+// the line would close every alert and reopen it as new whenever anything above
+// it changed.
+func TestCheckSARIFFingerprintsSurviveTheLinesMoving(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	path := filepath.Join(dir, "run.jsonl")
+	writeCheckLog(t, path, checkSignalEnvelopes()...)
+
+	_, first, _ := executeCheck(t, []string{"--format", "sarif", "run.jsonl"}, "")
+	_, again, _ := executeCheck(t, []string{"--format", "sarif", "run.jsonl"}, "")
+	if first != again {
+		t.Fatalf("two runs over the same log disagree:\n%s\n%s", first, again)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every envelope moves down one line, and no finding changes.
+	if err := os.WriteFile(path, append([]byte("\n"), body...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, shifted, _ := executeCheck(t, []string{"--format", "sarif", "run.jsonl"}, "")
+
+	before, after := decodeCheckSARIF(t, first), decodeCheckSARIF(t, shifted)
+	if len(before.Runs[0].Results) != len(after.Runs[0].Results) {
+		t.Fatalf("shifting the lines changed the findings")
+	}
+	movedALine := false
+	for i, result := range before.Runs[0].Results {
+		moved := after.Runs[0].Results[i]
+		if got, want := moved.PartialFingerprints[sarifFingerprintKey], result.PartialFingerprints[sarifFingerprintKey]; got != want {
+			t.Fatalf("fingerprint for %q changed from %q to %q when the lines moved", result.Message.Text, want, got)
+		}
+		if a, b := sarifRegionOf(t, result), sarifRegionOf(t, moved); b.StartLine == a.StartLine+1 {
+			movedALine = true
+		}
+	}
+	if !movedALine {
+		t.Fatal("the fixture must actually move the lines, or the test proves nothing")
+	}
+}
+
+func TestCheckSARIFStdinEmitsNoLocation(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t, checkSignalEnvelopes()...)
+
+	_, stdout, _ := executeCheck(t, []string{"--format", "sarif", "-"}, log)
+	report := decodeCheckSARIF(t, stdout)
+	if len(report.Runs[0].Results) == 0 {
+		t.Fatalf("the fixture must produce findings:\n%s", stdout)
+	}
+	for _, result := range report.Runs[0].Results {
+		// stdin has no artifact, and inventing a path would have code scanning
+		// refuse the whole upload.
+		if len(result.Locations) != 0 {
+			t.Fatalf("a stdin run must not invent a location: %+v", result.Locations)
+		}
+	}
+}
+
+func TestCheckSARIFReportsAssertionFailures(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t, checkErrorEnvelopes()...)
+
+	code, stdout, _ := executeCheck(t, []string{
+		"--format", "sarif", "--fail-on", "invalid",
+		"--max-duration", "1ms", "--expect-tool", "absent", "--forbid-tool", "missing", "-",
+	}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	report := decodeCheckSARIF(t, stdout)
+
+	results := sarifResultsFor(report, "mcpsnoop/assertion")
+	if len(results) != 3 {
+		t.Fatalf("assertion results = %d, want one per failed assertion\n%s", len(results), stdout)
+	}
+	joined := strings.Join(sarifMessagesFor(report, "mcpsnoop/assertion"), "\n")
+	for _, want := range []string{"budget", `expected tool "absent"`, `forbidden tool "missing"`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("assertion results missing %q:\n%s", want, joined)
+		}
+	}
+	for _, result := range results {
+		// An assertion only runs because the user asked for it, and it fails the run
+		// outright, so it is never a note.
+		if result.Level != "error" {
+			t.Fatalf("assertion level = %q, want error", result.Level)
+		}
+	}
+}
+
+// TestCheckSARIFMarksTheFirstSeenBaseline. A run that recorded a baseline
+// verified nothing, and a log with no result at all would read as though it had.
+func TestCheckSARIFMarksTheFirstSeenBaseline(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","inputSchema":{"type":"object"}}]}}`),
+	)
+
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--baseline", dir, "-"}, log)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0: recording a baseline is not a failure", code)
+	}
+	results := sarifResultsFor(decodeCheckSARIF(t, stdout), "mcpsnoop/drift")
+	if len(results) != 1 {
+		t.Fatalf("drift results = %d, want the baseline note\n%s", len(results), stdout)
+	}
+	if !strings.Contains(results[0].Message.Text, "recorded first-seen tool baseline (trusted, not verified)") {
+		t.Fatalf("the baseline note must say what junit's <skipped> says: %q", results[0].Message.Text)
+	}
+	// A first-seen baseline is not drift, so its level never follows the gate.
+	if results[0].Level != "note" {
+		t.Fatalf("baseline level = %q, want note", results[0].Level)
+	}
+}
+
+func TestCheckSARIFReportsDriftPerTool(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	before := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"find","inputSchema":{"type":"object"}}]}}`),
+	)
+	if code, _, stderr := executeCheck(t, []string{"--format", "sarif", "--baseline", dir, "-"}, before); code != 0 {
+		t.Fatalf("recording the baseline failed: %d %s", code, stderr)
+	}
+
+	after := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"find and delete","inputSchema":{"type":"object"}}]}}`),
+	)
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--fail-on", "drift", "--baseline", dir, "-"}, after)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	results := sarifResultsFor(decodeCheckSARIF(t, stdout), "mcpsnoop/drift")
+	if len(results) != 1 {
+		t.Fatalf("drift results = %d, want one per changed tool\n%s", len(results), stdout)
+	}
+	if !strings.Contains(results[0].Message.Text, `tool "search" description changed`) {
+		t.Fatalf("the drift result must name the tool and what changed: %q", results[0].Message.Text)
+	}
+	if results[0].Level != "error" {
+		t.Fatalf("drift level = %q, want error when drift is selected", results[0].Level)
+	}
+}
+
+func TestCheckSARIFRejectsAnUnknownFormat(t *testing.T) {
+	code, stdout, stderr := executeCheck(t, []string{"--format", "sarif-2", "-"}, "{}\n")
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "--format must be text, junit, or sarif") {
+		t.Fatalf("stderr = %q, want all three formats named", stderr)
+	}
+}
+
+// TestCheckSARIFArtifactURIStaysAbsoluteOutsideTheCheckout. A log the workflow
+// never committed cannot honestly be given a path relative to the repository.
+func TestCheckSARIFArtifactURIStaysAbsoluteOutsideTheCheckout(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	logDir := t.TempDir()
+	t.Chdir(t.TempDir())
+	path := filepath.Join(logDir, "run.jsonl")
+	writeCheckLog(t, path, checkErrorEnvelopes()...)
+
+	_, stdout, _ := executeCheck(t, []string{"--format", "sarif", path}, "")
+	report := decodeCheckSARIF(t, stdout)
+	results := sarifResultsFor(report, "mcpsnoop/error")
+	if len(results) == 0 {
+		t.Fatalf("the fixture must produce findings:\n%s", stdout)
+	}
+	if uri := sarifURIOf(t, results[0]); !strings.HasPrefix(uri, "file:///") {
+		t.Fatalf("artifact uri = %q, want an absolute file: URI", uri)
+	}
+}
+
+// gapEnvelopes is a two-session log in which the line and the Seq differ for
+// every frame after the first session's gap.
+func gapEnvelopes() []proxy.Envelope {
+	env := func(session string, seq uint64, dir proxy.Direction, raw string) proxy.Envelope {
+		return proxy.Envelope{
+			SessionID: session, ServerLabel: "srv", Seq: seq,
+			TS: time.Unix(int64(seq), 0), Direction: dir, Raw: json.RawMessage(raw),
+		}
+	}
+	return []proxy.Envelope{
+		// line 1 and 2
+		env("alpha", 1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x"}}`),
+		env("alpha", 2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`),
+		// line 3, Seq 5: two frames were dropped upstream
+		env("alpha", 5, proxy.ClientToServer, `{"id":3,"method":"tools/list"}`),
+		// line 4, Seq 1 of a different session
+		env("beta", 1, proxy.ClientToServer, `{"id":9,"method":"tools/list"}`),
+		// line 5, a call that never gets an answer
+		env("beta", 2, proxy.ClientToServer, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"y"}}`),
+	}
+}
+
+func decodeCheckSARIF(t *testing.T, stdout string) sarifLog {
+	t.Helper()
+	var report sarifLog
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, stdout)
+	}
+	if len(report.Runs) != 1 {
+		t.Fatalf("runs = %d, want exactly one", len(report.Runs))
+	}
+	return report
+}
+
+func sarifResultsFor(report sarifLog, ruleID string) []sarifResult {
+	var out []sarifResult
+	for _, result := range report.Runs[0].Results {
+		if result.RuleID == ruleID {
+			out = append(out, result)
+		}
+	}
+	return out
+}
+
+func sarifMessagesFor(report sarifLog, ruleID string) []string {
+	var out []string
+	for _, result := range sarifResultsFor(report, ruleID) {
+		out = append(out, result.Message.Text)
+	}
+	return out
+}
+
+func sarifAllMessages(report sarifLog) []string {
+	out := make([]string, 0, len(report.Runs[0].Results))
+	for _, result := range report.Runs[0].Results {
+		out = append(out, result.Message.Text)
+	}
+	return out
+}
+
+func sarifRegionOf(t *testing.T, result sarifResult) sarifRegion {
+	t.Helper()
+	if len(result.Locations) != 1 || result.Locations[0].PhysicalLocation.Region == nil {
+		t.Fatalf("result %q has no region: %+v", result.Message.Text, result.Locations)
+	}
+	return *result.Locations[0].PhysicalLocation.Region
+}
+
+func sarifURIOf(t *testing.T, result sarifResult) string {
+	t.Helper()
+	if len(result.Locations) != 1 {
+		t.Fatalf("result %q has no location", result.Message.Text)
+	}
+	return result.Locations[0].PhysicalLocation.ArtifactLocation.URI
+}
+
+// sarifSessionOf pulls the session id back out of a message, so a test can group
+// results the way a reader would.
+func sarifSessionOf(t *testing.T, message string) string {
+	t.Helper()
+	rest, ok := strings.CutPrefix(message, "session ")
+	if !ok {
+		t.Fatalf("message does not name a session: %q", message)
+	}
+	id, _, ok := strings.Cut(rest, " ")
+	if !ok {
+		t.Fatalf("message does not name a session: %q", message)
+	}
+	return id
+}
+
+// TestCheckSARIFReportsErrorsThatCarryNoCall. `error` is one of the three
+// default --fail-on signals, and the store counts it on frames that have no
+// correlated call at all: an HTTP failure with no JSON-RPC body, and an error
+// response whose id matches no request. Deriving the results from a call's
+// Errored flag left both uncounted, so the run failed with an empty results
+// array — a red build with nothing for the reader to open.
+func TestCheckSARIFReportsErrorsThatCarryNoCall(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		// A bare transport failure: a status, no body of its own.
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: time.Unix(1, 0),
+			Direction: proxy.ServerToClient, Status: 503,
+		},
+		// An error response answering a request this capture never saw.
+		checkEnvelope(2, proxy.ServerToClient,
+			`{"jsonrpc":"2.0","id":99,"error":{"code":-32601,"message":"no such method"}}`),
+	)
+
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1: neither error is a call, but both fail the gate", code)
+	}
+	results := sarifResultsFor(decodeCheckSARIF(t, stdout), "mcpsnoop/error")
+	if len(results) != 2 {
+		t.Fatalf("mcpsnoop/error results = %d, want 2 (one per counted error):\n%s", len(results), stdout)
+	}
+	// Named, not just counted: "frame 1" alone does not tell a reader that the
+	// transport answered 503 rather than that a call returned an error.
+	if !strings.Contains(results[0].Message.Text, "the transport failed with HTTP 503") {
+		t.Fatalf("transport failure is not named: %q", results[0].Message.Text)
+	}
+	if !strings.Contains(results[1].Message.Text, "could not be matched to a call") {
+		t.Fatalf("unmatched error response is not named: %q", results[1].Message.Text)
+	}
+}
+
+// TestCheckSARIFAnchorsATaskFailureAtItsTerminalFrame. A task's terminal failure
+// mutates the originating call in place, so reading Errored off that call marked
+// its *first* response — the "still working" acknowledgement — and sent a Code
+// Scanning reviewer to a frame where nothing went wrong.
+func TestCheckSARIFAnchorsATaskFailureAtItsTerminalFrame(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	// A file rather than stdin, since the region is the point of the test and a
+	// piped log has no artifact to point into.
+	writeCheckLog(t, filepath.Join(dir, "task.jsonl"),
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"slow"}}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"task","taskId":"t-1","status":"working"}}`),
+		checkEnvelope(3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"taskId":"t-1"}}`),
+		checkEnvelope(4, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"taskId":"t-1","status":"failed"}}`),
+	)
+
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "task.jsonl"}, "")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	results := sarifResultsFor(decodeCheckSARIF(t, stdout), "mcpsnoop/error")
+	if len(results) != 1 {
+		t.Fatalf("mcpsnoop/error results = %d, want 1:\n%s", len(results), stdout)
+	}
+	if !strings.Contains(results[0].Message.Text, "frame 4") {
+		t.Fatalf("a task failure must anchor at the frame that failed it, not at the acknowledgement: %q",
+			results[0].Message.Text)
+	}
+	// The region follows the same frame, so the alert opens on the line the
+	// failure actually arrived on.
+	if got := sarifRegionOf(t, results[0]).StartLine; got != 4 {
+		t.Fatalf("region startLine = %d, want 4", got)
+	}
+}
+
+// TestCheckSARIFErrorResultsMatchTheGateCount. The two bugs above were both the
+// same shape: the gate counted an error the report never named. This pins the
+// invariant itself over a fixture mixing all four counted kinds, so a new error
+// source cannot be added to the store without the report following it.
+func TestCheckSARIFErrorResultsMatchTheGateCount(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		// A settled call that failed.
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search"}}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}`),
+		// A task that ended failed.
+		checkEnvelope(3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"slow"}}`),
+		checkEnvelope(4, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"task","taskId":"t-1","status":"working"}}`),
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 5, TS: time.Unix(5, 0), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"t-1","status":"failed"}}`),
+		},
+		// A transport failure and an unmatched error response.
+		proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 6, TS: time.Unix(6, 0),
+			Direction: proxy.ServerToClient, Status: 500,
+		},
+		checkEnvelope(7, proxy.ServerToClient,
+			`{"jsonrpc":"2.0","id":99,"error":{"code":-32601,"message":"no such method"}}`),
+	)
+
+	_, textOut, _ := executeCheck(t, []string{"-"}, log)
+	want := checkTextSignalCount(t, textOut, "errors")
+	if want != 4 {
+		t.Fatalf("fixture counted errors = %d, want 4 (one of each kind):\n%s", want, textOut)
+	}
+
+	_, sarifOut, _ := executeCheck(t, []string{"--format", "sarif", "-"}, log)
+	results := sarifResultsFor(decodeCheckSARIF(t, sarifOut), "mcpsnoop/error")
+	if len(results) != want {
+		t.Fatalf("sarif reported %d errors, the gate counted %d:\n%s", len(results), want, sarifOut)
+	}
+}
+
+// checkTextSignalCount reads one signal's count back out of the text report, so
+// a test can compare a format against the gate rather than against a constant.
+func checkTextSignalCount(t *testing.T, out, signal string) int {
+	t.Helper()
+	for field := range strings.FieldsSeq(out) {
+		value, ok := strings.CutPrefix(field, signal+"=")
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			t.Fatalf("%s= is not a number: %q", signal, value)
+		}
+		return n
+	}
+	t.Fatalf("text report names no %s count:\n%s", signal, out)
+	return 0
+}

--- a/cmd/mcpsnoop/check_sarif_test.go
+++ b/cmd/mcpsnoop/check_sarif_test.go
@@ -33,8 +33,14 @@ func TestCheckSARIFCleanSessionDeclaresEveryRuleAndNoResults(t *testing.T) {
 	}
 
 	report := decodeCheckSARIF(t, stdout)
-	if report.Schema == "" || report.Version != sarifVersion {
-		t.Fatalf("$schema = %q, version = %q", report.Schema, report.Version)
+	// Pinned as literals rather than compared against the constants that produced
+	// them, which would hold whatever typo the constants held. Code scanning names
+	// this exact $schema and accepts no version but 2.1.0.
+	if report.Schema != "https://json.schemastore.org/sarif-2.1.0.json" {
+		t.Fatalf("$schema = %q, want the URI code scanning documents", report.Schema)
+	}
+	if report.Version != "2.1.0" {
+		t.Fatalf("version = %q, want 2.1.0, the only version code scanning ingests", report.Version)
 	}
 	if len(report.Runs) != 1 {
 		t.Fatalf("runs = %d, want exactly one for the whole file", len(report.Runs))
@@ -47,8 +53,9 @@ func TestCheckSARIFCleanSessionDeclaresEveryRuleAndNoResults(t *testing.T) {
 	// closes.
 	want := []string{
 		"mcpsnoop/error", "mcpsnoop/invalid", "mcpsnoop/warn", "mcpsnoop/mismatch",
-		"mcpsnoop/pending", "mcpsnoop/drift", "mcpsnoop/deprecated", "mcpsnoop/incomplete",
-		"mcpsnoop/assertion",
+		"mcpsnoop/pending", "mcpsnoop/late-result", "mcpsnoop/drift", "mcpsnoop/deprecated",
+		"mcpsnoop/incomplete",
+		"mcpsnoop/assertion", "mcpsnoop/report-truncated",
 	}
 	if len(driver.Rules) != len(want) {
 		t.Fatalf("rules = %d, want %d", len(driver.Rules), len(want))
@@ -58,8 +65,10 @@ func TestCheckSARIFCleanSessionDeclaresEveryRuleAndNoResults(t *testing.T) {
 		if rule.ID != id {
 			t.Fatalf("rule %d = %q, want %q", i, rule.ID, id)
 		}
-		if rule.Name == "" || rule.ShortDescription.Text == "" || rule.FullDescription.Text == "" {
-			t.Fatalf("rule %q is missing a name or a description: %+v", id, rule)
+		// help.text as well: code scanning marks it required and renders it as the
+		// alert's "how to fix" panel, which is blank without one.
+		if rule.Name == "" || rule.ShortDescription.Text == "" || rule.FullDescription.Text == "" || rule.Help.Text == "" {
+			t.Fatalf("rule %q is missing a name, a description or its help: %+v", id, rule)
 		}
 	}
 }
@@ -643,4 +652,256 @@ func checkTextSignalCount(t *testing.T, out, signal string) int {
 	}
 	t.Fatalf("text report names no %s count:\n%s", signal, out)
 	return 0
+}
+
+// TestEverySignalHasItsOwnSARIFRule. checkSARIFRules walks checkSignalOrder, so a
+// signal added to that list reaches the report on its own. What it does not get
+// on its own is a description, and the fallback hands out a placeholder that
+// would land in a code-scanning alert as the whole explanation. Adding
+// late-result did exactly that and only the rule count caught it.
+func TestEverySignalHasItsOwnSARIFRule(t *testing.T) {
+	for _, signal := range checkSignalOrder {
+		name, short, full, help := checkSARIFSignalRule(signal)
+		if name == string(signal) {
+			t.Errorf("signal %q fell through to the placeholder rule name", signal)
+		}
+		if short == "An mcpsnoop check signal" || full == "A signal reported by mcpsnoop check." {
+			t.Errorf("signal %q has no description of its own", signal)
+		}
+		if help == "See the mcpsnoop documentation." {
+			t.Errorf("signal %q has no help of its own", signal)
+		}
+	}
+}
+
+// TestCheckSARIFReportsEverySignalTheGateCounts. A rule declared with nothing
+// that can ever emit it is worse than no rule: the run goes red, the Security
+// tab shows the rule, and there is no alert to open. late-result shipped exactly
+// that way, and the rule walk above did not catch it because a description is
+// not a result. This walks emission instead, comparing the report against the
+// counts the text format prints for the same capture.
+func TestCheckSARIFReportsEverySignalTheGateCounts(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t, everySignalEnvelopes()...)
+
+	_, textOut, _ := executeCheck(t, []string{"-"}, log)
+	_, sarifOut, _ := executeCheck(t, []string{"--format", "sarif", "-"}, log)
+	report := decodeCheckSARIF(t, sarifOut)
+
+	// drift needs a baseline and incomplete needs a dropped frame, neither of
+	// which belongs in one hand-written capture. Both are covered on their own.
+	skip := map[checkSignal]bool{checkDrift: true, checkIncomplete: true}
+	counted := 0
+	for _, signal := range checkSignalOrder {
+		if skip[signal] {
+			continue
+		}
+		want := checkTextSignalCount(t, textOut, checkTextCountField(signal))
+		if want == 0 {
+			t.Fatalf("the fixture must trigger %s, or this test proves nothing about it:\n%s", signal, textOut)
+		}
+		counted++
+		if got := len(sarifResultsFor(report, sarifRuleID(signal))); got != want {
+			t.Fatalf("sarif reported %d %s results, the gate counted %d:\n%s", got, signal, want, sarifOut)
+		}
+	}
+	if counted != len(checkSignalOrder)-len(skip) {
+		t.Fatalf("walked %d signals, want every one of checkSignalOrder bar the skipped", counted)
+	}
+}
+
+// checkTextCountField maps a signal to the field the text report prints it
+// under, so the walk above compares against the gate rather than a constant.
+func checkTextCountField(signal checkSignal) string {
+	switch signal {
+	case checkWarn:
+		return "warnings"
+	case checkMismatch:
+		return "mismatches"
+	case checkLateResult:
+		return "late_results"
+	case checkIncomplete:
+		return "missing_frames"
+	case checkError:
+		return "errors"
+	}
+	return string(signal)
+}
+
+// everySignalEnvelopes is one session triggering every signal a single capture
+// can carry, so a walk over checkSignalOrder has something to measure.
+func everySignalEnvelopes() []proxy.Envelope {
+	return []proxy.Envelope{
+		// error: a call answered with a JSON-RPC error.
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search"}}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}`),
+		// invalid: a frame that is not JSON-RPC at all.
+		checkEnvelope(3, proxy.ServerToClient, `{"hello":"world"}`),
+		// warn: a response carrying neither result nor error.
+		checkEnvelope(4, proxy.ClientToServer, `{"jsonrpc":"2.0","id":2,"method":"ping"}`),
+		checkEnvelope(5, proxy.ServerToClient, `{"jsonrpc":"2.0","id":2}`),
+		// mismatch: an Mcp-Method header naming a different method than the body.
+		{
+			SessionID: "s1", ServerLabel: "srv", Seq: 6, TS: time.Unix(6, 0),
+			Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+			MCPMethod: "resources/read",
+			Raw:       json.RawMessage(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search"}}`),
+		},
+		checkEnvelope(7, proxy.ServerToClient, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`),
+		// late-result: a cancelled call the server answered anyway.
+		checkEnvelope(8, proxy.ClientToServer, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"slow"}}`),
+		checkEnvelope(9, proxy.ClientToServer, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":4}}`),
+		checkEnvelope(10, proxy.ServerToClient, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`),
+		// deprecated: logging, which 2026-07-28 retired in favour of stderr.
+		checkEnvelope(11, proxy.ClientToServer, `{"jsonrpc":"2.0","id":5,"method":"logging/setLevel","params":{"level":"debug"}}`),
+		checkEnvelope(12, proxy.ServerToClient, `{"jsonrpc":"2.0","id":5,"result":{}}`),
+		// pending: a call still open when the capture ends.
+		checkEnvelope(13, proxy.ClientToServer, `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"hang"}}`),
+	}
+}
+
+// TestCheckOnlySARIFPaysForTheLineIndex. The index retains one map entry per
+// captured frame for the whole run, and only SARIF ever reads it, so building it
+// for text, junit and baseline was a cost the default format paid for nothing.
+func TestCheckOnlySARIFPaysForTheLineIndex(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	dir := t.TempDir()
+	path := filepath.Join(dir, "run.jsonl")
+	writeCheckLog(t, path, checkSignalEnvelopes()...)
+
+	// Only sarif names a line, so only sarif asks for the index.
+	for _, format := range []checkOutputFormat{checkFormatText, checkFormatJUnit} {
+		if format.needsLineIndex() {
+			t.Errorf("%s reports per session, so it must not build a per-frame index", format)
+		}
+	}
+	if !checkFormatSARIF.needsLineIndex() {
+		t.Error("sarif anchors its results at a line, so it must build the index")
+	}
+
+	cmd := newCheckCmd()
+	withLines, err := loadCheckSession(cmd, path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(withLines.lines) == 0 {
+		t.Fatal("a sarif run must get the index, or its results carry no region")
+	}
+	without, err := loadCheckSession(cmd, path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if without.lines != nil {
+		t.Fatalf("a run that never names a line built %d index entries", len(without.lines))
+	}
+	// The store itself is unchanged either way, so nothing but the index moves.
+	if len(without.store.Timeline(without.sessionID)) != len(withLines.store.Timeline(withLines.sessionID)) {
+		t.Fatal("skipping the index changed what was loaded")
+	}
+}
+
+// TestCheckSARIFNamesTheLateResultAndItsDelay. The delay is what separates the
+// race the specification allows for, a cancellation crossing a reply in flight,
+// from a server that carried on working after being told to stop, so a result
+// that only said "late" would leave the reader unable to tell them apart.
+func TestCheckSARIFNamesTheLateResultAndItsDelay(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeCheckLog(t, filepath.Join(dir, "late.jsonl"),
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"slow"}}`),
+		checkEnvelope(2, proxy.ClientToServer, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}`),
+		checkEnvelope(5, proxy.ServerToClient, `{"jsonrpc":"2.0","id":7,"result":{"content":[]}}`),
+	)
+
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--fail-on", "late-result", "late.jsonl"}, "")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1\n%s", code, stdout)
+	}
+	report := decodeCheckSARIF(t, stdout)
+	results := sarifResultsFor(report, "mcpsnoop/late-result")
+	if len(results) != 1 {
+		t.Fatalf("late-result results = %d, want one; a red build with nothing to open is the bug this pins\n%s",
+			len(results), stdout)
+	}
+	for _, want := range []string{"tools/call slow (id 7)", "after cancellation"} {
+		if !strings.Contains(results[0].Message.Text, want) {
+			t.Fatalf("the late-result message must carry %q: %q", want, results[0].Message.Text)
+		}
+	}
+	if results[0].Level != "error" {
+		t.Fatalf("late-result level = %q, want error when the gate selected it", results[0].Level)
+	}
+	// The frame the answer arrived on, which is line 3 while its Seq is 5.
+	if got := sarifRegionOf(t, results[0]).StartLine; got != 3 {
+		t.Fatalf("region startLine = %d, want 3, the line the late answer arrived on", got)
+	}
+}
+
+// TestCheckSARIFCapsTheResultsAndSaysSo. Code scanning refuses a run holding
+// more than 25,000 results, so an unbounded report on a large capture never
+// reaches the Security tab at all, and silently keeps only the top 5,000 below
+// that. A capped report that says what it left out beats both.
+func TestCheckSARIFCapsTheResultsAndSaysSo(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	var envelopes []proxy.Envelope
+	// Two findings per round trip, an error and a warning, enough of them to
+	// overflow the cap and few enough errors that the cut has a real preference
+	// to express rather than simply running out of room.
+	for i := uint64(0); i < sarifMaxResults/2+100; i++ {
+		envelopes = append(envelopes,
+			checkEnvelope(2*i+1, proxy.ClientToServer,
+				`{"jsonrpc":"2.0","id":`+strconv.FormatUint(i+1, 10)+`,"method":"tools/call","params":{"name":"search"}}`),
+			checkEnvelope(2*i+2, proxy.ServerToClient,
+				`{"jsonrpc":"2.0","id":`+strconv.FormatUint(i+1, 10)+`,"error":{"code":-32000,"message":"boom"},"result":{}}`))
+	}
+	log := encodeCheckLog(t, envelopes...)
+
+	_, textOut, _ := executeCheck(t, []string{"-"}, log)
+	errors := checkTextSignalCount(t, textOut, "errors")
+	warnings := checkTextSignalCount(t, textOut, "warnings")
+	found := errors + warnings
+	if found <= sarifMaxResults || errors >= sarifMaxResults {
+		t.Fatalf("the fixture must overflow the cap with room for the gate to choose, got %d errors and %d warnings",
+			errors, warnings)
+	}
+
+	// Gated on error alone, so the warnings are notes and the cut has a real
+	// preference to express rather than two rules at one level.
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--fail-on", "error", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	report := decodeCheckSARIF(t, stdout)
+	if got := len(report.Runs[0].Results); got != sarifMaxResults {
+		t.Fatalf("results = %d, want exactly the cap of %d", got, sarifMaxResults)
+	}
+
+	notice := sarifResultsFor(report, "mcpsnoop/report-truncated")
+	if len(notice) != 1 {
+		t.Fatalf("a truncated report must say so, got %d notices", len(notice))
+	}
+	if !strings.Contains(notice[0].Message.Text, strconv.Itoa(found-sarifMaxResults+1)) {
+		t.Fatalf("the notice must name how many findings were left out: %q", notice[0].Message.Text)
+	}
+	// A warning, not an error: the gate decides whether the run passes, and the
+	// reporter must not fail a green one on its own.
+	if notice[0].Level != "warning" {
+		t.Fatalf("truncation level = %q, want warning", notice[0].Level)
+	}
+	// Every finding the gate failed on survives and the notes give way, since the
+	// other order would cut the alerts a reader has to act on. What room is left
+	// is still filled, so nothing is dropped that the report could have carried.
+	if got := len(sarifResultsFor(report, "mcpsnoop/error")); got != errors {
+		t.Fatalf("kept %d of %d errors, want all of them before any note", got, errors)
+	}
+	notes := 0
+	for _, result := range report.Runs[0].Results {
+		if result.Level == "note" {
+			notes++
+		}
+	}
+	if want := sarifMaxResults - 1 - errors; notes != want {
+		t.Fatalf("kept %d notes, want %d: the errors first, then the cap filled", notes, want)
+	}
 }

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -149,7 +149,7 @@ func TestCheckRejectsUnknownFormat(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
 	}
-	if !strings.Contains(stderr, "mcpsnoop check: --format must be text or junit") {
+	if !strings.Contains(stderr, "mcpsnoop check: --format must be text, junit, or sarif") {
 		t.Fatalf("stderr = %q, want --format error", stderr)
 	}
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -258,15 +258,60 @@ func LoadFile(path string) (*store.Store, string, error) {
 	return Load(f, path)
 }
 
-// Load reads a JSONL envelope stream into a store and returns its first session.
-func Load(r io.Reader, source string) (*store.Store, string, error) {
-	return load(r, source, proxy.RedactConfig{})
+// LoadFileLines is LoadFile plus the log line every envelope was decoded from,
+// for a caller that has to point a reader at one specific frame of the file.
+func LoadFileLines(path string) (*store.Store, string, FrameLines, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	defer f.Close()
+	lines := make(FrameLines)
+	st, sessionID, err := load(f, path, proxy.RedactConfig{}, lines)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return st, sessionID, lines, nil
 }
 
-func load(r io.Reader, source string, redaction proxy.RedactConfig) (*store.Store, string, error) {
+// FrameRef identifies one captured envelope inside a log. Seq alone would not:
+// it restarts per session, and a concatenated capture holds several.
+type FrameRef struct {
+	SessionID string
+	Seq       uint64
+}
+
+// FrameLines maps a captured envelope to the 1-based line of the log it was
+// decoded from. Seq cannot stand in for that line, because it is scoped per
+// session and skips the frames dropped upstream, so the two diverge in exactly
+// the captures worth pointing a reader at.
+type FrameLines map[FrameRef]int
+
+// Line returns the 1-based log line a frame was decoded from. ok is false for a
+// frame this index never saw, and for every frame of a stream that was not
+// loaded through LoadFileLines.
+func (f FrameLines) Line(sessionID string, seq uint64) (int, bool) {
+	line, ok := f[FrameRef{SessionID: sessionID, Seq: seq}]
+	return line, ok
+}
+
+// Load reads a JSONL envelope stream into a store and returns its first session.
+func Load(r io.Reader, source string) (*store.Store, string, error) {
+	return load(r, source, proxy.RedactConfig{}, nil)
+}
+
+// load folds a JSONL envelope stream into a store. When lines is non-nil it is
+// filled with the log line each envelope came from, which costs a wrapping
+// reader, so the callers that do not need it pass nil.
+func load(r io.Reader, source string, redaction proxy.RedactConfig, lines FrameLines) (*store.Store, string, error) {
 	st := store.New()
 	redactor := proxy.NewRedactor(redaction)
 	var firstSession string
+	var counter *newlineCounter
+	if lines != nil {
+		counter = &newlineCounter{r: r}
+		r = counter
+	}
 	dec := json.NewDecoder(r)
 	for {
 		var env proxy.Envelope
@@ -279,12 +324,60 @@ func load(r io.Reader, source string, redaction proxy.RedactConfig) (*store.Stor
 		if firstSession == "" {
 			firstSession = env.SessionID
 		}
+		if counter != nil {
+			// InputOffset lands just past the envelope's closing brace, so it names
+			// the line the value ended on. The proxy writes one compact envelope per
+			// line, so that is also the line it started on.
+			lines[FrameRef{SessionID: env.SessionID, Seq: env.Seq}] = counter.lineAt(dec.InputOffset())
+		}
 		st.Ingest(redactor.RedactEnvelope(env))
 	}
 	if firstSession == "" {
 		return nil, "", fmt.Errorf("%s: no envelopes found", source)
 	}
 	return st, firstSession, nil
+}
+
+// newlineCounter records where every newline fell in the stream, so a decoded
+// value's byte offset can be turned back into a line number. A running count
+// kept alongside Decode would be wrong: json.Decoder buffers ahead of the value
+// it hands back, so by the time Decode returns the reader has usually already
+// consumed the lines that follow.
+type newlineCounter struct {
+	r    io.Reader
+	read int64 // bytes pulled from r so far
+	// offsets holds the newlines not yet walked past, next indexes the first of
+	// them, and passed counts the ones already behind us.
+	offsets []int64
+	next    int
+	passed  int
+}
+
+func (c *newlineCounter) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	for i, b := range p[:n] {
+		if b == '\n' {
+			c.offsets = append(c.offsets, c.read+int64(i))
+		}
+	}
+	c.read += int64(n)
+	return n, err
+}
+
+// lineAt returns the 1-based line containing the byte before offset, which is
+// where a decoded value ends. Offsets must arrive in non-decreasing order, which
+// a single forward pass over the stream guarantees. The buffer is reused once
+// drained so a long capture does not retain one entry per line.
+func (c *newlineCounter) lineAt(offset int64) int {
+	for c.next < len(c.offsets) && c.offsets[c.next] < offset {
+		c.next++
+		c.passed++
+	}
+	if c.next == len(c.offsets) {
+		c.offsets = c.offsets[:0]
+		c.next = 0
+	}
+	return c.passed + 1
 }
 
 func Build(st *store.Store, sessionID string) (SessionExport, error) {
@@ -738,7 +831,7 @@ func ExportFile(inputPath string, w io.Writer, opts Options) error {
 // Export renders the session read from r, a JSONL envelope stream, to w. It is
 // the reader form of ExportFile, so a piped log ("-") exports like a file.
 func Export(r io.Reader, source string, w io.Writer, opts Options) error {
-	st, sessionID, err := load(r, source, opts.Redaction)
+	st, sessionID, err := load(r, source, opts.Redaction, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -371,15 +371,19 @@ func (c *newlineCounter) Read(p []byte) (int, error) {
 
 // lineAt returns the 1-based line containing the byte before offset, which is
 // where a decoded value ends. Offsets must arrive in non-decreasing order, which
-// a single forward pass over the stream guarantees. The buffer is reused once
-// drained so a long capture does not retain one entry per line.
+// a single forward pass over the stream guarantees.
 func (c *newlineCounter) lineAt(offset int64) int {
 	for c.next < len(c.offsets) && c.offsets[c.next] < offset {
 		c.next++
 		c.passed++
 	}
-	if c.next == len(c.offsets) {
-		c.offsets = c.offsets[:0]
+	// The offsets already walked past are dropped on every call rather than only
+	// when the buffer happens to drain, which a json.Decoder reading ahead of the
+	// value it returns almost never leaves true: a long capture kept one entry per
+	// line for the whole load. What remains is bounded by the decoder's read-ahead,
+	// so the copy is over a handful of entries.
+	if c.next > 0 {
+		c.offsets = c.offsets[:copy(c.offsets, c.offsets[c.next:])]
 		c.next = 0
 	}
 	return c.passed + 1

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1386,5 +1387,35 @@ func TestLoadFileLinesCountsBlankLines(t *testing.T) {
 		if !ok || got != want {
 			t.Fatalf("seq %d is on line %d (ok=%v), want %d", seq, got, ok, want)
 		}
+	}
+}
+
+// TestNewlineCounterDropsOffsetsItHasWalkedPast. json.Decoder reads ahead of the
+// value it hands back, so the buffer is essentially never empty when lineAt runs
+// and a "reuse it once drained" rule never fires. That kept one int64 per line of
+// the capture alive for the whole load, on the format that never asked for a line
+// index at all.
+func TestNewlineCounterDropsOffsetsItHasWalkedPast(t *testing.T) {
+	const lines = 20000
+	body := strings.Repeat("x\n", lines)
+	// A reader that hands over the whole stream at once, which is the worst case:
+	// every newline is recorded before the first lineAt call walks past any.
+	counter := &newlineCounter{r: strings.NewReader(body)}
+	buf := make([]byte, len(body))
+	if _, err := io.ReadFull(counter, buf); err != nil {
+		t.Fatal(err)
+	}
+
+	for line := 1; line <= lines; line++ {
+		// Two bytes per line, so a value on line n ends just past offset 2n-1, one
+		// short of that line's own newline. Stopping there rather than walking past
+		// it is the point: it is the state a forward pass is always in, and the state
+		// the old "reuse it once drained" rule never recognised.
+		if got := counter.lineAt(int64(2*line - 1)); got != line {
+			t.Fatalf("lineAt(%d) = %d, want %d", 2*line-1, got, line)
+		}
+	}
+	if got := len(counter.offsets); got > 1 {
+		t.Fatalf("offsets = %d after walking %d lines, want only what is still ahead", got, lines)
 	}
 }

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1181,3 +1181,97 @@ func TestResolveSessionPathSkipsAnEmptyLog(t *testing.T) {
 		t.Fatalf("resolved %q, want the last real capture %q", got, real)
 	}
 }
+
+// TestLoadFileLinesTracksTrueLineNumbers. Seq is scoped per session and skips
+// frames dropped upstream, so a result pointed at Seq would send a reader to the
+// wrong frame in exactly the captures worth pointing them at: this log has a
+// gap in one session and a second session that restarts numbering at 1.
+func TestLoadFileLinesTracksTrueLineNumbers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "two.jsonl")
+	t0 := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		session string
+		seq     uint64
+	}{
+		{"alpha", 1},
+		{"alpha", 2},
+		{"alpha", 5}, // Seq 3 and 4 were dropped upstream.
+		{"beta", 1},
+		{"beta", 2},
+	}
+	for i, frame := range frames {
+		writeEnv(t, path, proxy.Envelope{
+			SessionID: frame.session, ServerLabel: "demo", Seq: frame.seq,
+			TS: t0.Add(time.Duration(i) * time.Millisecond), Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		})
+	}
+
+	st, first, lines, err := LoadFileLines(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st == nil || first != "alpha" {
+		t.Fatalf("first session = %q, want alpha", first)
+	}
+	for i, frame := range frames {
+		want := i + 1
+		got, ok := lines.Line(frame.session, frame.seq)
+		if !ok {
+			t.Fatalf("no line recorded for %s seq %d", frame.session, frame.seq)
+		}
+		if got != want {
+			t.Fatalf("%s seq %d is on line %d, want %d", frame.session, frame.seq, got, want)
+		}
+	}
+	// The point of the index: after the gap, and in the second session, the line
+	// and the Seq are different numbers.
+	if line, _ := lines.Line("alpha", 5); line == 5 {
+		t.Fatal("alpha seq 5 must not be reported on line 5")
+	}
+	if line, _ := lines.Line("beta", 1); line == 1 {
+		t.Fatal("beta seq 1 must not be reported on line 1")
+	}
+	if _, ok := lines.Line("alpha", 3); ok {
+		t.Fatal("a frame that never reached the log must have no line")
+	}
+	// A stream loaded without the index answers the same way as a missing frame,
+	// so a caller cannot mistake "not tracked" for line zero.
+	if _, ok := FrameLines(nil).Line("alpha", 1); ok {
+		t.Fatal("an absent index must report no line")
+	}
+}
+
+// TestLoadFileLinesCountsBlankLines. json.Decoder buffers past the value it
+// returns, so a newline count kept alongside Decode would run ahead of it, and
+// whitespace between envelopes would shift every line after it.
+func TestLoadFileLinesCountsBlankLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "padded.jsonl")
+	envelope := func(seq uint64) string {
+		b, err := json.Marshal(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "demo", Seq: seq,
+			TS: time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC), Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	// Envelopes on lines 1, 2, 4 and 5, with line 3 blank.
+	body := envelope(1) + "\n" + envelope(2) + "\n\n" + envelope(3) + "\n" + envelope(4) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, lines, err := LoadFileLines(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for seq, want := range map[uint64]int{1: 1, 2: 2, 3: 4, 4: 5} {
+		got, ok := lines.Line("s1", seq)
+		if !ok || got != want {
+			t.Fatalf("seq %d is on line %d (ok=%v), want %d", seq, got, ok, want)
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -196,6 +196,13 @@ type event struct {
 	call               *call  // set for request/response events
 	taskCall           *call  // originating call for a task lifecycle frame
 	taskID             string
+	// errored marks the frame this session counted an error on. It is set at
+	// every site that increments sess.errors, so a reporter can name the frames
+	// behind the count instead of re-deriving the conditions and drifting from
+	// them. A transport failure and an unmatched error response carry no call at
+	// all, and a task failure is counted on its terminal frame rather than on the
+	// call's first response, so call.errored alone cannot stand in for this.
+	errored bool
 	// mrtrRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised. Empty on an ordinary request.
 	mrtrRoot string
@@ -372,6 +379,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.kind = EventTransport
 		if httpFailed(e.Status) {
 			sess.errors++
+			ev.errored = true
 		}
 		sess.events = append(sess.events, ev)
 		return ev.view(sess)
@@ -394,6 +402,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			// and on stdio, where there is no status, nothing changes.
 			ev.kind = EventTransport
 			sess.errors++
+			ev.errored = true
 		} else {
 			ev.kind = EventInvalid
 		}
@@ -458,6 +467,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 						ev.taskCall = parent
 						if failed {
 							sess.errors++
+							ev.errored = true
 						}
 					}
 				}
@@ -476,12 +486,14 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			}
 			if msg.Error != nil {
 				sess.errors++
+				ev.errored = true
 			}
 		case !matched:
 			ev.warning = appendWarning(ev.warning, "duplicate response for the same id")
 		default:
 			if c.errored {
 				sess.errors++
+				ev.errored = true
 			}
 		}
 	case msg.Method != "" && len(msg.ID) > 0:
@@ -573,6 +585,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 					ev.taskCall = parent
 					if failed {
 						sess.errors++
+						ev.errored = true
 					}
 				}
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -212,13 +212,18 @@ type event struct {
 	call               *call  // set for request/response events
 	taskCall           *call  // originating call for a task lifecycle frame
 	taskID             string
-	// errored marks the frame this session counted an error on. It is set at
-	// every site that increments sess.errors, so a reporter can name the frames
-	// behind the count instead of re-deriving the conditions and drifting from
-	// them. A transport failure and an unmatched error response carry no call at
-	// all, and a task failure is counted on its terminal frame rather than on the
-	// call's first response, so call.errored alone cannot stand in for this.
+	// errored marks a frame this session counted an error on. It is set at every
+	// site that increments sess.errors, so a reporter can name the frames behind
+	// the count instead of re-deriving the conditions and drifting from them. A
+	// transport failure and an unmatched error response carry no call at all, and
+	// a task failure is counted on its terminal frame rather than on the call's
+	// first response, so call.errored alone cannot stand in for this.
 	errored bool
+	// lateResult marks the frame this session counted a late result on, the same
+	// way errored marks a counted error. call.lateResult stays true for the rest
+	// of the capture and is visible from the request frame too, so it cannot
+	// stand in for this.
+	lateResult bool
 	// mrtrRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised. Empty on an ordinary request.
 	mrtrRoot string
@@ -430,6 +435,10 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		c, matched := sess.completeCall(ev.id, e.Direction, e.ConnID, e.TS, msg)
 		ev.call = c
 		if matched && c != nil && c.lateResult {
+			// One-for-one with sess.lateResults++: completeCall returns matched for the
+			// frame that incremented it and false for any further response to the same
+			// call, so this marks each counted late result exactly once.
+			ev.lateResult = true
 			ev.observation = "result arrived " + e.TS.Sub(c.cancelledAt).Round(time.Millisecond).String() + " after cancellation"
 		}
 		if c != nil && c.state != Pending && c.state != Streaming {

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -110,12 +110,19 @@ type EventView struct {
 	Call              *CallView // set for request/response events
 	TaskCall          *CallView // originating call for a tasks/* lifecycle frame
 	TaskID            string
-	// Errored is true on the frame this session counted an error on, matching
-	// the Errors total one for one. It is the frame to point a reader at: a
-	// transport failure and an unmatched error response have no Call, and a task
-	// failure lands on its terminal frame while Call.Errored, read off a live
-	// call, would retroactively mark that call's first response instead.
+	// Errored marks a frame this session counted an error on, so a reporter can
+	// name the frames the Errors total came from. It is the frame to point a
+	// reader at: a transport failure and an unmatched error response have no
+	// Call, and a task failure lands on its terminal frame while Call.Errored,
+	// read off a live call, would retroactively mark that call's first response
+	// instead. Every counted error marks a frame; one frame that raises the count
+	// twice still marks once, so the marked frames are where the count came from
+	// rather than a running tally of it.
 	Errored bool
+	// LateResult marks the frame this session counted a late result on, one per
+	// LateResults. Call.LateResult says the call ever got one, which stays true
+	// for the rest of the capture and is visible from the request frame too.
+	LateResult bool
 	// MRTRRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
 	MRTRRoot string
@@ -392,6 +399,7 @@ func (e *event) view(_ *session) EventView {
 		MRTRRoot:           e.mrtrRoot,
 		MRTRStateIssue:     e.mrtrStateIssue,
 		Errored:            e.errored,
+		LateResult:         e.lateResult,
 	}
 	if e.call != nil {
 		cv := e.call.view()

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -102,6 +102,12 @@ type EventView struct {
 	Call              *CallView // set for request/response events
 	TaskCall          *CallView // originating call for a tasks/* lifecycle frame
 	TaskID            string
+	// Errored is true on the frame this session counted an error on, matching
+	// the Errors total one for one. It is the frame to point a reader at: a
+	// transport failure and an unmatched error response have no Call, and a task
+	// failure lands on its terminal frame while Call.Errored, read off a live
+	// call, would retroactively mark that call's first response instead.
+	Errored bool
 	// MRTRRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
 	MRTRRoot string
@@ -375,6 +381,7 @@ func (e *event) view(_ *session) EventView {
 		TaskID:             e.taskID,
 		MRTRRoot:           e.mrtrRoot,
 		MRTRStateIssue:     e.mrtrStateIssue,
+		Errored:            e.errored,
 	}
 	if e.call != nil {
 		cv := e.call.view()


### PR DESCRIPTION
Closes #205.

`check` emitted text and JUnit but nothing code scanning could ingest, so findings could fail a build without ever becoming an alert. Adds `--format sarif` (SARIF 2.1.0).

- one run per file, not per session — code scanning caps a file at 20 runs, and a concatenated capture can hold more
- every rule declared on every run, so a fixed finding's alert closes
- level follows `--fail-on`; a clean run emits `"results": []`, not `null`
- results anchor at the true line, but fingerprints are built from what a finding *is*, so alerts survive lines moving

One design note worth a look: the `error` signal comes from a new `EventView.Errored`, set in the store wherever the session's error counter is incremented. Deriving it from `Call.Errored` instead was wrong — some counted errors carry no call at all (a bare HTTP failure, an error response matching no request), and a task's terminal failure mutates its call in place, which anchored the alert at the call's *first* response. Marking the frame where it's counted keeps the report and the gate in sync by construction.

README gains the `--format` synopsis and an `upload-sarif` snippet.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, where it makes sense
- [x] Updated the README / docs if user-facing behaviour changed
