### PR TITLE
fix(store): warn on null request ids and stop false id-reuse

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -937,7 +937,7 @@ func eventKind(k store.EventKind) string {
 }
 
 func callKey(c store.CallView) string {
-	return string(c.ReqDir) + "\x00" + c.ID
+	return string(c.ReqDir) + "\x00" + c.CorrID
 }
 
 func formatDuration(ms *float64) string {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1181,3 +1181,42 @@ func TestResolveSessionPathSkipsAnEmptyLog(t *testing.T) {
 		t.Fatalf("resolved %q, want the last real capture %q", got, real)
 	}
 }
+
+func TestNullRequestIDEventsMapToDistinctCalls(t *testing.T) {
+	st := store.New()
+	now := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	meta := `,"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}`
+	frames := []struct {
+		seq uint64
+		dir proxy.Direction
+		raw string
+	}{
+		{1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28"` + meta + `,"capabilities":{},"clientInfo":{"name":"demo","version":"1.0"}}}`},
+		{2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","protocolVersion":"2026-07-28","capabilities":{"tools":{}},"serverInfo":{"name":"files","version":"0.1"}}}`},
+		{3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/etc/hosts"}` + meta + `}}`},
+		{4, proxy.ClientToServer, `{"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"write_file","arguments":{"path":"/tmp/out"}` + meta + `}}`},
+	}
+	for _, f := range frames {
+		st.Ingest(proxy.Envelope{
+			SessionID: "n1", ServerLabel: "files", Seq: f.seq, TS: now.Add(time.Duration(f.seq) * time.Second),
+			Direction: f.dir, Raw: json.RawMessage(f.raw),
+		})
+	}
+	export, err := Build(st, "n1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if export.Calls[1].ToolName != "read_file" || export.Calls[2].ToolName != "write_file" {
+		t.Fatalf("export calls: %+v, %+v", export.Calls[1], export.Calls[2])
+	}
+	for _, ev := range export.Events {
+		if ev.Seq == 3 && ev.CallIndex != nil && export.Calls[*ev.CallIndex].ToolName != "read_file" {
+			t.Fatalf("frame #3 should map to read_file, got call index %d tool=%s",
+				*ev.CallIndex, export.Calls[*ev.CallIndex].ToolName)
+		}
+		if ev.Seq == 4 && ev.CallIndex != nil && export.Calls[*ev.CallIndex].ToolName != "write_file" {
+			t.Fatalf("frame #4 should map to write_file, got call index %d tool=%s",
+				*ev.CallIndex, export.Calls[*ev.CallIndex].ToolName)
+		}
+	}
+}

--- a/internal/store/request_id.go
+++ b/internal/store/request_id.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// isValidRequestID reports whether id is a legal MCP request id: a JSON string or
+// integer, never null, float, boolean, array, or object.
+func isValidRequestID(id json.RawMessage) bool {
+	if len(id) == 0 {
+		return false
+	}
+	if bytes.Equal(bytes.TrimSpace(id), []byte("null")) {
+		return false
+	}
+	var v any
+	if err := json.Unmarshal(id, &v); err != nil {
+		return false
+	}
+	switch x := v.(type) {
+	case string:
+		return true
+	case float64:
+		return x == math.Trunc(x)
+	default:
+		return false
+	}
+}
+
+// invalidRequestIDKind names what arrived on the wire for warning text.
+func invalidRequestIDKind(id json.RawMessage) string {
+	if bytes.Equal(bytes.TrimSpace(id), []byte("null")) {
+		return "null"
+	}
+	var v any
+	if err := json.Unmarshal(id, &v); err != nil {
+		return "malformed"
+	}
+	switch x := v.(type) {
+	case float64:
+		if x != math.Trunc(x) {
+			return "a floating-point number"
+		}
+		return fmt.Sprintf("%v", x)
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case []any:
+		return "an array"
+	case map[string]any:
+		return "an object"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}
+
+// requestIDWarning reports when a request carries an id MCP forbids.
+func requestIDWarning(msg proxy.RPCMessage) string {
+	if msg.Method == "" || len(msg.ID) == 0 {
+		return ""
+	}
+	if isValidRequestID(msg.ID) {
+		return ""
+	}
+	kind := invalidRequestIDKind(msg.ID)
+	if kind == "null" {
+		return "request id is null, and 2026-07-28 requires a string or integer id"
+	}
+	return fmt.Sprintf("request id is %s, and 2026-07-28 requires a string or integer id", kind)
+}
+
+// correlateID is the key used to match a request to its response. Wire ids that
+// are legal correlate normally; illegal ids identify nothing and each request
+// is keyed by its envelope sequence instead.
+func correlateID(wireID json.RawMessage, seq uint64) string {
+	if isValidRequestID(wireID) {
+		return string(wireID)
+	}
+	return fmt.Sprintf("@seq:%d", seq)
+}

--- a/internal/store/request_id_test.go
+++ b/internal/store/request_id_test.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func TestNullRequestIDWarnsAndDoesNotFalseReuse(t *testing.T) {
+	s := New()
+	now := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	meta := `,"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}`
+
+	frames := []struct {
+		seq uint64
+		dir proxy.Direction
+		raw string
+	}{
+		{1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28"` + meta + `,"capabilities":{},"clientInfo":{"name":"demo","version":"1.0"}}}`},
+		{2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","protocolVersion":"2026-07-28","capabilities":{"tools":{}},"serverInfo":{"name":"files","version":"0.1"}}}`},
+		{3, proxy.ClientToServer, `{"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/etc/hosts"}` + meta + `}}`},
+		{4, proxy.ClientToServer, `{"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"write_file","arguments":{"path":"/tmp/out"}` + meta + `}}`},
+	}
+
+	for _, f := range frames {
+		s.Ingest(proxy.Envelope{
+			SessionID: "n1", ServerLabel: "files", Seq: f.seq, TS: now.Add(time.Duration(f.seq) * time.Second),
+			Direction: f.dir, Raw: json.RawMessage(f.raw),
+		})
+	}
+
+	calls := s.Calls("n1")
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 calls, got %d", len(calls))
+	}
+	if calls[1].ToolName != "read_file" || calls[2].ToolName != "write_file" {
+		t.Fatalf("expected distinct tool calls, got %+v, %+v", calls[1], calls[2])
+	}
+	if calls[1].State != Pending || calls[2].State != Pending {
+		t.Fatalf("both null-id calls should stay pending, got %v and %v", calls[1].State, calls[2].State)
+	}
+
+	events := s.Timeline("n1")
+	var nullWarnings int
+	for _, ev := range events {
+		if ev.Kind == EventRequest && ev.ID == "null" {
+			if !strings.Contains(ev.Warning, "request id is null") {
+				t.Fatalf("expected null-id warning on seq %d, got %q", ev.Seq, ev.Warning)
+			}
+			if strings.Contains(ev.Warning, "reuses an id already in flight") {
+				t.Fatalf("seq %d should not report false id reuse, got %q", ev.Seq, ev.Warning)
+			}
+			nullWarnings++
+		}
+	}
+	if nullWarnings != 2 {
+		t.Fatalf("expected 2 null-id warnings, got %d", nullWarnings)
+	}
+
+	header := s.Sessions()[0]
+	if header.Pending != 2 {
+		t.Fatalf("expected 2 pending null-id calls, got %d", header.Pending)
+	}
+
+	if calls[1].CorrID == calls[2].CorrID {
+		t.Fatalf("null-id calls should have distinct correlation keys, both %q", calls[1].CorrID)
+	}
+}
+
+func TestInvalidRequestIDKindsWarn(t *testing.T) {
+	cases := []struct {
+		id       string
+		contains string
+	}{
+		{`1.5`, "floating-point"},
+		{`true`, "true"},
+		{`{"a":1}`, "object"},
+		{`[]`, "array"},
+	}
+	for _, tc := range cases {
+		msg := proxy.RPCMessage{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage(tc.id),
+			Method:  "ping",
+		}
+		w := requestIDWarning(msg)
+		if !strings.Contains(w, tc.contains) {
+			t.Fatalf("id %s: expected warning containing %q, got %q", tc.id, tc.contains, w)
+		}
+	}
+}
+
+func TestTitleCaseResourceNotFoundStillValidID(t *testing.T) {
+	if !isValidRequestID(json.RawMessage(`1`)) {
+		t.Fatal("integer id should be valid")
+	}
+	if !isValidRequestID(json.RawMessage(`"abc"`)) {
+		t.Fatal("string id should be valid")
+	}
+	if isValidRequestID(json.RawMessage(`null`)) {
+		t.Fatal("null id should be invalid")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -125,6 +125,7 @@ type callKey struct {
 // call is the mutable internal record for one request/response pair.
 type call struct {
 	id       string
+	corrID   string // correlation key; differs from id when the wire id is illegal
 	method   string
 	reqDir   proxy.Direction
 	params   json.RawMessage
@@ -488,7 +489,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.kind = EventRequest
 		ev.method = msg.Method
 		ev.id = string(msg.ID)
+		corrID := correlateID(msg.ID, e.Seq)
 		ev.warning = validationWarning(msg)
+		ev.warning = appendWarning(ev.warning, requestIDWarning(msg))
 		var reused bool
 		if root, stateIssue := sess.matchRetry(msg); root != nil {
 			// A continuation, not a new call. Mapping the retry id onto the same
@@ -515,7 +518,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			sess.requests++ // a request on the wire, even though not a new call
 			break
 		}
-		ev.call, reused = sess.openCall(ev.id, msg, e)
+		ev.call, reused = sess.openCall(corrID, msg, e)
 		ev.call.progressToken = sess.noteProgressToken(msg.Params)
 		if msg.Method == "subscriptions/listen" && e.Direction == proxy.ClientToServer {
 			sess.noteSubscription(ev.id, msg.Params)
@@ -780,8 +783,8 @@ func (s *Store) sessionFor(e proxy.Envelope) *session {
 // openCall records a new pending request. The bool reports whether it displaced
 // a still-pending call for the same id and direction, meaning the client reused
 // an id while its earlier request was in flight. Caller holds the write lock.
-func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope) (*call, bool) {
-	key := callKey{dir: e.Direction, id: id, conn: e.ConnID}
+func (sess *session) openCall(corrID string, msg proxy.RPCMessage, e proxy.Envelope) (*call, bool) {
+	key := callKey{dir: e.Direction, id: corrID, conn: e.ConnID}
 	prev, ok := sess.calls[key]
 	reused := ok && (prev.state == Pending || prev.state == Streaming)
 	if reused {
@@ -801,7 +804,8 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		prev.end = e.TS
 	}
 	c := &call{
-		id:     id,
+		id:     string(msg.ID),
+		corrID: corrID,
 		method: msg.Method,
 		reqDir: e.Direction,
 		params: msg.Params,

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -14,6 +14,7 @@ import (
 // CallView is an immutable snapshot of a correlated request/response pair.
 type CallView struct {
 	ID       string
+	CorrID   string
 	Method   string
 	ReqDir   proxy.Direction
 	IsTool   bool
@@ -390,6 +391,7 @@ func (e *event) view(_ *session) EventView {
 func (c *call) view() CallView {
 	return CallView{
 		ID:         c.id,
+		CorrID:     c.corrID,
 		Method:     c.method,
 		ReqDir:     c.reqDir,
 		IsTool:     c.isTool,


### PR DESCRIPTION
## Summary

Requests carrying JSON `null` (or other illegal) ids are now flagged as protocol warnings, and each such request gets its own correlation slot instead of colliding on the literal key `"null"`.

## Motivation

MCP 2026-07-28 requires request ids to be a string or integer, never `null`. mcpsnoop treated `"id": null` as a normal request, keyed every null-id call on the string `null`, and reported a false "request reuses an id already in flight" warning. The exporter then stamped the wrong tool name on earlier frames because both events shared one `call_index`.

Fixes #197

## Changes

- Add `requestIDWarning` for `null`, floats, booleans, arrays, and objects
- Introduce `correlateID`: legal wire ids correlate normally; illegal ids key by `@seq:N`
- Thread `CorrID` through `CallView` so the exporter indexes events with the same identity the store uses
- Regression tests for store ingest and exporter event→call mapping

## Tests

- `go test ./internal/store/... ./internal/exporter/... -run 'TestNullRequestID|TestInvalidRequestID'` — pass
- `go test ./internal/store/... ./internal/exporter/...` — pass
- Full `go test ./...` — store/exporter/cmd/proxy all green; two pre-existing TUI style test failures on `main` (`TestStreamRowShowsSupersededStatusInWarnStyle`, `TestStatusStyleWarnsOnTruncated`) unrelated to this change

## Notes

- Null-id requests remain pending forever (no response can correlate), which matches the broken-wire semantics
- OTLP sink still keys on wire id bytes; out of scope for #197