### PR TITLE
fix(store): report a tool inputSchema that is not an object schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,20 +545,27 @@ calling wrongly is often a tool whose schema asked for more than the client
 delivers.
 
 The tool summary, opened with `s`, has a SCHEMA column naming the most notable
-construct each advertised tool uses, with a trailing `+` when the schema uses
-more than one kind.
+thing about each advertised tool's schema, with a trailing `+` when there is more
+than one kind.
 
 | Shown | Means |
 |---|---|
+| `no root` | the `inputSchema` is absent, is not a JSON object, or has a root type other than `"object"` |
 | `ext ref` | a `$ref` pointing outside the document, which is also the case the spec warns implementers not to follow blindly |
 | `oneOf`, `anyOf`, `allOf`, `not` | a composition keyword, handled inconsistently across clients |
 | `ref` | a `$ref` pointing inside the same document |
 | `untyped` | a property that declares no type and no other way of saying what it accepts |
 
-This is an observation, not a verdict. A schema using `oneOf` is not wrong, only
-likely to be read differently by different clients, so the column carries the
-warning color and never the red of the ERR column. There is no `check` signal for
-it, and nothing about MCP traffic changes.
+All but the first are observations rather than verdicts. A schema using `oneOf`
+is not wrong, only likely to be read differently by different clients. `no root`
+is the exception: the `Tool` definition requires `inputSchema` and pins its root
+type to `"object"`, so a client validating a listing rejects that tool outright
+and it never becomes callable, with nothing on the wire to say why. `no root`
+leads the column for that reason, and a schema mcpsnoop's own redaction scrubbed
+is never reported, since an unreadable schema is not a wrong one.
+
+The column carries the warning color and never the red of the ERR column. There
+is no `check` signal for any of it yet, and nothing about MCP traffic changes.
 
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.

--- a/cmd/mcpsnoop/demo.go
+++ b/cmd/mcpsnoop/demo.go
@@ -139,7 +139,17 @@ func demoScript() []demoFrame {
 		{dir: proxy.ServerToClient, raw: `{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":true},"logging":{}},"serverInfo":{"name":"demo-server","version":"1.0.0"}}}`, pause: 400 * time.Millisecond},
 		{dir: proxy.ClientToServer, raw: `{"jsonrpc":"2.0","method":"notifications/initialized"}`, pause: 500 * time.Millisecond},
 		{dir: proxy.ClientToServer, raw: `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, pause: 400 * time.Millisecond},
-		{dir: proxy.ServerToClient, raw: `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo","description":"Echo back a message"},{"name":"get_sum","description":"Add two numbers"},{"name":"slow_search","description":"A search that takes a while"},{"name":"big_payload","description":"Return a large value"},{"name":"flaky","description":"Sometimes fails"}]}}`, pause: 600 * time.Millisecond},
+		// Each tool carries the inputSchema the spec requires of one, matching the
+		// arguments the calls below actually send. Advertising them bare left every
+		// row of the demo's own summary table reporting a missing root type, which
+		// is a real finding against a fixture nobody meant as a bad example.
+		{dir: proxy.ServerToClient, raw: `{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+			`{"name":"echo","description":"Echo back a message","inputSchema":{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}},` +
+			`{"name":"get_sum","description":"Add two numbers","inputSchema":{"type":"object","properties":{"a":{"type":"number"},"b":{"type":"number"}},"required":["a","b"]}},` +
+			`{"name":"slow_search","description":"A search that takes a while","inputSchema":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}},` +
+			`{"name":"big_payload","description":"Return a large value","inputSchema":{"type":"object","additionalProperties":false}},` +
+			`{"name":"flaky","description":"Sometimes fails","inputSchema":{"type":"object","additionalProperties":false}}` +
+			`]}}`, pause: 600 * time.Millisecond},
 		{dir: proxy.ClientToServer, raw: `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello from the demo"}}}`, pause: 400 * time.Millisecond},
 		{dir: proxy.ServerToClient, raw: `{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Echo: hello from the demo"}]}}`, pause: 500 * time.Millisecond},
 		{dir: proxy.ClientToServer, raw: `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_sum","arguments":{"a":40,"b":2}}}`, pause: 350 * time.Millisecond},

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 )
 
@@ -11,6 +12,10 @@ import (
 type SchemaFindingKind string
 
 const (
+	// FindingNonObjectRoot is the one kind here that is a violation rather than
+	// an observation. Every other finding says a schema may travel badly; this
+	// one says a conforming client rejects the tool outright.
+	FindingNonObjectRoot   SchemaFindingKind = "nonObjectRoot"
 	FindingOneOf           SchemaFindingKind = "oneOf"
 	FindingAnyOf           SchemaFindingKind = "anyOf"
 	FindingAllOf           SchemaFindingKind = "allOf"
@@ -33,19 +38,69 @@ type SchemaFinding struct {
 // them lets a caller treat "more than one finding" as "more than one kind of
 // problem", which is the question a reader actually has.
 func analyzeSchema(raw json.RawMessage) []SchemaFinding {
+	var findings []SchemaFinding
+	seen := make(map[SchemaFindingKind]bool, 8)
+
+	// First, so the violation leads the list the walk order would otherwise
+	// decide. A rootless schema still gets walked, because naming the construct
+	// it uses is worth having next to the reason a client refused it.
+	if schemaRootViolation(raw) != "" {
+		addFinding(&findings, seen, FindingNonObjectRoot)
+	}
+
 	if len(raw) == 0 {
-		return nil
+		return findings
 	}
 
 	var v any
 	if err := json.Unmarshal(raw, &v); err != nil {
-		return nil
+		return findings
 	}
 
-	var findings []SchemaFinding
-	seen := make(map[SchemaFindingKind]bool, 7)
 	walkSchema(v, &findings, seen)
 	return findings
+}
+
+// schemaRootViolation reports how a tool's inputSchema fails the root-object
+// rule, in words naming what was seen, or "" when it satisfies it. Nothing is
+// resolved and no dialect is interpreted: the verdict is decided by the bytes.
+//
+// $defs.Tool.inputSchema carries "required": ["type"] with "type" a const of
+// "object", and $defs.Tool.required is ["inputSchema", "name"], so an absent
+// inputSchema fails the same way a rootless one does. The identical constraint
+// appears in the 2026-07-28, 2025-11-25 and 2025-06-18 schema files, which is
+// why this needs no revision gate.
+//
+// The rule is an inputSchema rule only. outputSchema's entry has no "required"
+// and no const, and the Tools page shows an array-rooted outputSchema in its
+// list_users example, so this is never asked about one.
+func schemaRootViolation(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "no inputSchema"
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil || root == nil {
+		// Covers true, false, null, an array, a number, a string, and bytes that
+		// are not JSON at all. A boolean schema is valid JSON Schema in the
+		// abstract and still not a tool inputSchema, which must be an object.
+		return "an inputSchema that is not a JSON object"
+	}
+	switch t := root["type"].(type) {
+	case nil:
+		if _, present := root["type"]; present {
+			return "an inputSchema with a null root type"
+		}
+		return "an inputSchema with no root type"
+	case string:
+		if t == "object" {
+			return ""
+		}
+		return "an inputSchema with root type " + strconv.Quote(t)
+	default:
+		// A type union like ["object","null"] is not the const the schema demands,
+		// and a client validating against $defs.Tool rejects it the same way.
+		return `an inputSchema whose root type is not the string "object"`
+	}
 }
 
 func addFinding(findings *[]SchemaFinding, seen map[SchemaFindingKind]bool, kind SchemaFindingKind) {

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 )
 
-// SchemaFindingKind names a JSON Schema construct that clients handle
-// inconsistently. A finding is an observation, not a verdict: a schema using
-// oneOf is not wrong, only likely to be interpreted differently across clients.
+// SchemaFindingKind names something worth knowing about a tool's advertised
+// input schema. All but one are observations rather than verdicts: a schema
+// using oneOf is not wrong, only likely to be interpreted differently across
+// clients. FindingNonObjectRoot is the exception and says so on its own doc.
 type SchemaFindingKind string
 
 const (
@@ -25,6 +26,21 @@ const (
 	FindingUntypedProperty SchemaFindingKind = "untypedProperty"
 )
 
+// SchemaFindingKinds is every kind analyzeSchema can report, in the order the
+// constants declare them. Exported for the same reason ToolDriftKinds is: a
+// renderer that ranks or labels kinds from a hand-kept list of its own has no
+// way to notice a kind added here, and would show the raw enum name for it.
+var SchemaFindingKinds = []SchemaFindingKind{
+	FindingNonObjectRoot,
+	FindingOneOf,
+	FindingAnyOf,
+	FindingAllOf,
+	FindingNot,
+	FindingRef,
+	FindingExternalRef,
+	FindingUntypedProperty,
+}
+
 type SchemaFinding struct {
 	Kind SchemaFindingKind
 }
@@ -37,14 +53,14 @@ type SchemaFinding struct {
 // entries of the same kind are indistinguishable and add nothing; collapsing
 // them lets a caller treat "more than one finding" as "more than one kind of
 // problem", which is the question a reader actually has.
-func analyzeSchema(raw json.RawMessage) []SchemaFinding {
+func analyzeSchema(raw json.RawMessage, redacted bool) []SchemaFinding {
 	var findings []SchemaFinding
 	seen := make(map[SchemaFindingKind]bool, 8)
 
 	// First, so the violation leads the list the walk order would otherwise
 	// decide. A rootless schema still gets walked, because naming the construct
 	// it uses is worth having next to the reason a client refused it.
-	if schemaRootViolation(raw) != "" {
+	if schemaRootViolation(raw, redacted) != "" {
 		addFinding(&findings, seen, FindingNonObjectRoot)
 	}
 
@@ -62,8 +78,9 @@ func analyzeSchema(raw json.RawMessage) []SchemaFinding {
 }
 
 // schemaRootViolation reports how a tool's inputSchema fails the root-object
-// rule, in words naming what was seen, or "" when it satisfies it. Nothing is
-// resolved and no dialect is interpreted: the verdict is decided by the bytes.
+// rule, in words naming what was seen, or "" when it satisfies it or when
+// mcpsnoop cannot tell. Nothing is resolved and no dialect is interpreted: the
+// verdict is decided by the bytes.
 //
 // $defs.Tool.inputSchema carries "required": ["type"] with "type" a const of
 // "object", and $defs.Tool.required is ["inputSchema", "name"], so an absent
@@ -71,12 +88,27 @@ func analyzeSchema(raw json.RawMessage) []SchemaFinding {
 // appears in the 2026-07-28, 2025-11-25 and 2025-06-18 schema files, which is
 // why this needs no revision gate.
 //
-// The rule is an inputSchema rule only. outputSchema's entry has no "required"
-// and no const, and the Tools page shows an array-rooted outputSchema in its
-// list_users example, so this is never asked about one.
-func schemaRootViolation(raw json.RawMessage) string {
+// The rule is an inputSchema rule only. On 2026-07-28 outputSchema's entry has
+// no "required" and no const, and the Tools page shows an array-rooted
+// outputSchema in its list_users example, so this is never asked about one.
+// Extending it there would need the revision gate this does not, since
+// 2025-11-25 and 2025-06-18 do constrain an outputSchema root to "object".
+//
+// redacted says the frame passed through mcpsnoop's own redaction, which is what
+// makes the placeholder below trustworthy as a placeholder rather than a value
+// a peer chose to send.
+func schemaRootViolation(raw json.RawMessage, redacted bool) string {
 	if len(raw) == 0 {
 		return "no inputSchema"
+	}
+	// A schema the user asked mcpsnoop to scrub is unreadable, not wrong. Saying
+	// otherwise turns a privacy setting into an accusation against a server that
+	// was conforming, which is the answer the sibling x-mcp-header check already
+	// gives for the same input and the reason it gives it. --redact-path is the
+	// documented way to name something inside a schema, so this is a supported
+	// workflow rather than a misuse.
+	if unverifiableAfterRedaction(redacted, redactedSchemaRoot(raw)) {
+		return ""
 	}
 	var root map[string]any
 	if err := json.Unmarshal(raw, &root); err != nil || root == nil {
@@ -101,6 +133,22 @@ func schemaRootViolation(raw json.RawMessage) string {
 		// and a client validating against $defs.Tool rejects it the same way.
 		return `an inputSchema whose root type is not the string "object"`
 	}
+}
+
+// redactedSchemaRoot returns whichever of the two things a redaction rule can
+// replace decides the root verdict, the whole schema or just its type, so one
+// call covers both. Anything else it returns is a value that was never going to
+// match the placeholder anyway.
+func redactedSchemaRoot(raw json.RawMessage) string {
+	var whole string
+	if json.Unmarshal(raw, &whole) == nil {
+		return whole
+	}
+	var root struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(raw, &root)
+	return root.Type
 }
 
 func addFinding(findings *[]SchemaFinding, seen map[SchemaFindingKind]bool, kind SchemaFindingKind) {

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 )
@@ -25,6 +26,7 @@ func TestAnalyzeSchemaClean(t *testing.T) {
 
 func TestAnalyzeSchemaOneOf(t *testing.T) {
 	schema := json.RawMessage(`{
+		"type":"object",
 		"oneOf": [
 			{"type":"string"},
 			{"type":"integer"}
@@ -44,6 +46,7 @@ func TestAnalyzeSchemaOneOf(t *testing.T) {
 
 func TestAnalyzeSchemaAnyOf(t *testing.T) {
 	schema := json.RawMessage(`{
+		"type":"object",
 		"anyOf": [
 			{"type":"string"},
 			{"type":"integer"}
@@ -63,6 +66,7 @@ func TestAnalyzeSchemaAnyOf(t *testing.T) {
 
 func TestAnalyzeSchemaAllOf(t *testing.T) {
 	schema := json.RawMessage(`{
+		"type":"object",
 		"allOf": [
 			{"type":"string"},
 			{"type":"integer"}
@@ -82,6 +86,7 @@ func TestAnalyzeSchemaAllOf(t *testing.T) {
 
 func TestAnalyzeSchemaNot(t *testing.T) {
 	schema := json.RawMessage(`{
+		"type":"object",
 		"not": {
 			"type":"string"
 		}
@@ -100,6 +105,7 @@ func TestAnalyzeSchemaNot(t *testing.T) {
 
 func TestAnalyzeSchemaRef(t *testing.T) {
 	schema := json.RawMessage(`{
+		"type":"object",
 		"$ref": "#/$defs/Foo"
 	}`)
 
@@ -133,6 +139,7 @@ func TestAnalyzeSchemaPropertyNamedLikeKeyword(t *testing.T) {
 
 func TestAnalyzeSchemaExternalRef(t *testing.T) {
 	schema := json.RawMessage(`{
+		"type":"object",
 		"$ref": "https://example.com/schema.json"
 	}`)
 
@@ -305,8 +312,8 @@ func TestAnalyzeSchemaReachesEveryContainer(t *testing.T) {
 		{"if", `{"type":"object","if":{"oneOf":[{"type":"string"}]}}`, FindingOneOf},
 		{"then", `{"type":"object","then":{"$ref":"https://example.com/x.json"}}`, FindingExternalRef},
 		{"else", `{"type":"object","else":{"anyOf":[{"type":"string"}]}}`, FindingAnyOf},
-		{"contains", `{"type":"array","contains":{"allOf":[{"type":"string"}]}}`, FindingAllOf},
-		{"prefixItems", `{"type":"array","prefixItems":[{"oneOf":[{"type":"string"}]}]}`, FindingOneOf},
+		{"contains", `{"type":"object","properties":{"xs":{"type":"array","contains":{"allOf":[{"type":"string"}]}}}}`, FindingAllOf},
+		{"prefixItems", `{"type":"object","properties":{"xs":{"type":"array","prefixItems":[{"oneOf":[{"type":"string"}]}]}}}`, FindingOneOf},
 		{"patternProperties", `{"type":"object","patternProperties":{"^a":{"$ref":"#/$defs/A"}}}`, FindingRef},
 		{"$defs", `{"type":"object","$defs":{"X":{"oneOf":[{"type":"string"}]}}}`, FindingOneOf},
 		{"definitions", `{"type":"object","definitions":{"X":{"anyOf":[{"type":"string"}]}}}`, FindingAnyOf},
@@ -340,6 +347,80 @@ func TestAnalyzeSchemaClassifiesRefsByFormOnly(t *testing.T) {
 		got := analyzeSchema(schema)
 		if len(got) != 1 || got[0].Kind != want {
 			t.Fatalf("$ref %q: got %v, want [%s]", ref, got, want)
+		}
+	}
+}
+
+// A tool's inputSchema must be a JSON Schema object whose root type is "object".
+// The constraint is in $defs.Tool of every schema revision mcpsnoop can observe,
+// so none of these cases needs a revision gate.
+func TestAnalyzeSchemaNonObjectRoot(t *testing.T) {
+	cases := map[string]string{
+		"dialect marker only":  `{"$schema":"http://json-schema.org/draft-07/schema#"}`,
+		"empty object":         `{}`,
+		"array root":           `{"type":"array","items":{"type":"string"}}`,
+		"boolean schema":       `true`,
+		"null":                 `null`,
+		"string root":          `{"type":"string"}`,
+		"type is not a string": `{"type":["object","null"]}`,
+	}
+	for name, schema := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := analyzeSchema(json.RawMessage(schema))
+			if !slices.Contains(got, SchemaFinding{Kind: FindingNonObjectRoot}) {
+				t.Fatalf("got %v, want a %s finding", got, FindingNonObjectRoot)
+			}
+		})
+	}
+}
+
+// An absent inputSchema fails the same rule: $defs.Tool.required is
+// ["inputSchema", "name"], so there is nothing for a client to validate against.
+func TestAnalyzeSchemaAbsentInputSchemaIsANonObjectRoot(t *testing.T) {
+	got := analyzeSchema(nil)
+
+	want := []SchemaFinding{{Kind: FindingNonObjectRoot}}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// The two forms the Tools page names for a tool that takes no parameters. Both
+// are correct and must stay silent, or every parameterless tool reports.
+func TestAnalyzeSchemaObjectRootIsClean(t *testing.T) {
+	for _, schema := range []string{
+		`{"type":"object"}`,
+		`{"type":"object","additionalProperties":false}`,
+		`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object"}`,
+	} {
+		got := analyzeSchema(json.RawMessage(schema))
+		if slices.Contains(got, SchemaFinding{Kind: FindingNonObjectRoot}) {
+			t.Fatalf("schema %s: got %v, want no %s finding", schema, got, FindingNonObjectRoot)
+		}
+	}
+}
+
+// The reason travels into the warning, so it has to name what was actually on
+// the wire rather than just say the schema was wrong. Bisecting a listing is the
+// cost of a warning that does not.
+func TestSchemaRootViolationNamesWhatWasSeen(t *testing.T) {
+	cases := map[string]string{
+		``:                                "no inputSchema",
+		`{}`:                              "an inputSchema with no root type",
+		`{"type":null}`:                   "an inputSchema with a null root type",
+		`{"type":"array"}`:                `an inputSchema with root type "array"`,
+		`{"type":["object"]}`:             `an inputSchema whose root type is not the string "object"`,
+		`true`:                            "an inputSchema that is not a JSON object",
+		`null`:                            "an inputSchema that is not a JSON object",
+		`[{"type":"object"}]`:             "an inputSchema that is not a JSON object",
+		`{"not valid json`:                "an inputSchema that is not a JSON object",
+		`{"type":"object"}`:               "",
+		`{"$schema":"x","type":"object"}`: "",
+	}
+	for schema, want := range cases {
+		if got := schemaRootViolation(json.RawMessage(schema)); got != want {
+			t.Fatalf("schema %q: got %q, want %q", schema, got, want)
 		}
 	}
 }

--- a/internal/store/schema_test.go
+++ b/internal/store/schema_test.go
@@ -6,6 +6,9 @@ import (
 	"slices"
 	"strconv"
 	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
 )
 
 func TestAnalyzeSchemaClean(t *testing.T) {
@@ -17,7 +20,7 @@ func TestAnalyzeSchemaClean(t *testing.T) {
 		}
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	if len(got) != 0 {
 		t.Fatalf("got %v findings, want none", got)
@@ -33,7 +36,7 @@ func TestAnalyzeSchemaOneOf(t *testing.T) {
 		]
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingOneOf},
@@ -53,7 +56,7 @@ func TestAnalyzeSchemaAnyOf(t *testing.T) {
 		]
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingAnyOf},
@@ -73,7 +76,7 @@ func TestAnalyzeSchemaAllOf(t *testing.T) {
 		]
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingAllOf},
@@ -92,7 +95,7 @@ func TestAnalyzeSchemaNot(t *testing.T) {
 		}
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingNot},
@@ -109,7 +112,7 @@ func TestAnalyzeSchemaRef(t *testing.T) {
 		"$ref": "#/$defs/Foo"
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingRef},
@@ -130,7 +133,7 @@ func TestAnalyzeSchemaPropertyNamedLikeKeyword(t *testing.T) {
 		}
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	if len(got) != 0 {
 		t.Fatalf("got %v, want none", got)
@@ -143,7 +146,7 @@ func TestAnalyzeSchemaExternalRef(t *testing.T) {
 		"$ref": "https://example.com/schema.json"
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingExternalRef},
@@ -162,7 +165,7 @@ func TestAnalyzeSchemaUntypedProperty(t *testing.T) {
 		}
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingUntypedProperty},
@@ -188,7 +191,7 @@ func TestAnalyzeSchemaNestedUntypedProperty(t *testing.T) {
 		}
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	want := []SchemaFinding{
 		{Kind: FindingUntypedProperty},
@@ -217,7 +220,7 @@ func TestAnalyzeSchemaTopLevelWithoutTypeIsNotFlaggedAsUntypedProperty(t *testin
 		]
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 
 	for _, finding := range got {
 		if finding.Kind == FindingUntypedProperty {
@@ -259,7 +262,7 @@ func TestAnalyzeSchemaConstructOnAPropertyIsNotAlsoUntyped(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := analyzeSchema(json.RawMessage(tc.schema))
+			got := analyzeSchema(json.RawMessage(tc.schema), false)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}
@@ -274,7 +277,7 @@ func TestAnalyzeSchemaEnumAndConstAreNotUntyped(t *testing.T) {
 		`{"type":"object","properties":{"mode":{"enum":["fast","slow"]}}}`,
 		`{"type":"object","properties":{"version":{"const":2}}}`,
 	} {
-		if got := analyzeSchema(json.RawMessage(schema)); len(got) != 0 {
+		if got := analyzeSchema(json.RawMessage(schema), false); len(got) != 0 {
 			t.Fatalf("analyzeSchema(%s) = %v, want no findings", schema, got)
 		}
 	}
@@ -292,7 +295,7 @@ func TestAnalyzeSchemaDeduplicatesByKind(t *testing.T) {
 		}
 	}`)
 
-	got := analyzeSchema(schema)
+	got := analyzeSchema(schema, false)
 	want := []SchemaFinding{{Kind: FindingUntypedProperty}}
 
 	if !reflect.DeepEqual(got, want) {
@@ -322,7 +325,7 @@ func TestAnalyzeSchemaReachesEveryContainer(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := analyzeSchema(json.RawMessage(tc.schema))
+			got := analyzeSchema(json.RawMessage(tc.schema), false)
 			if len(got) != 1 || got[0].Kind != tc.want {
 				t.Fatalf("got %v, want exactly [%s]", got, tc.want)
 			}
@@ -344,7 +347,7 @@ func TestAnalyzeSchemaClassifiesRefsByFormOnly(t *testing.T) {
 	}
 	for ref, want := range cases {
 		schema := json.RawMessage(`{"type":"object","properties":{"u":{"$ref":` + strconv.Quote(ref) + `}}}`)
-		got := analyzeSchema(schema)
+		got := analyzeSchema(schema, false)
 		if len(got) != 1 || got[0].Kind != want {
 			t.Fatalf("$ref %q: got %v, want [%s]", ref, got, want)
 		}
@@ -366,7 +369,7 @@ func TestAnalyzeSchemaNonObjectRoot(t *testing.T) {
 	}
 	for name, schema := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := analyzeSchema(json.RawMessage(schema))
+			got := analyzeSchema(json.RawMessage(schema), false)
 			if !slices.Contains(got, SchemaFinding{Kind: FindingNonObjectRoot}) {
 				t.Fatalf("got %v, want a %s finding", got, FindingNonObjectRoot)
 			}
@@ -377,7 +380,7 @@ func TestAnalyzeSchemaNonObjectRoot(t *testing.T) {
 // An absent inputSchema fails the same rule: $defs.Tool.required is
 // ["inputSchema", "name"], so there is nothing for a client to validate against.
 func TestAnalyzeSchemaAbsentInputSchemaIsANonObjectRoot(t *testing.T) {
-	got := analyzeSchema(nil)
+	got := analyzeSchema(nil, false)
 
 	want := []SchemaFinding{{Kind: FindingNonObjectRoot}}
 
@@ -394,16 +397,17 @@ func TestAnalyzeSchemaObjectRootIsClean(t *testing.T) {
 		`{"type":"object","additionalProperties":false}`,
 		`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object"}`,
 	} {
-		got := analyzeSchema(json.RawMessage(schema))
+		got := analyzeSchema(json.RawMessage(schema), false)
 		if slices.Contains(got, SchemaFinding{Kind: FindingNonObjectRoot}) {
 			t.Fatalf("schema %s: got %v, want no %s finding", schema, got, FindingNonObjectRoot)
 		}
 	}
 }
 
-// The reason travels into the warning, so it has to name what was actually on
-// the wire rather than just say the schema was wrong. Bisecting a listing is the
-// cost of a warning that does not.
+// The reason is what a warning will carry, so it has to name what was actually
+// on the wire rather than just say the schema was wrong. Bisecting a listing is
+// the cost of a warning that does not. Pinned now so the wording is settled
+// before anything renders it.
 func TestSchemaRootViolationNamesWhatWasSeen(t *testing.T) {
 	cases := map[string]string{
 		``:                                "no inputSchema",
@@ -419,8 +423,82 @@ func TestSchemaRootViolationNamesWhatWasSeen(t *testing.T) {
 		`{"$schema":"x","type":"object"}`: "",
 	}
 	for schema, want := range cases {
-		if got := schemaRootViolation(json.RawMessage(schema)); got != want {
+		if got := schemaRootViolation(json.RawMessage(schema), false); got != want {
 			t.Fatalf("schema %q: got %q, want %q", schema, got, want)
 		}
+	}
+}
+
+// TestSchemaRootIsUnverifiableAfterRedaction. --redact-path is the documented
+// way to scrub something inside a schema, and it can replace the schema itself
+// or just its root type. Reading either placeholder as a missing root type
+// reports a conforming server for the user's own privacy setting, on the axis
+// the follow-up wires to a warning that fails a default check run. The sibling
+// x-mcp-header check answers the same input the same way and says why.
+func TestSchemaRootIsUnverifiableAfterRedaction(t *testing.T) {
+	for name, schema := range map[string]string{
+		"the whole schema":  `"[REDACTED]"`,
+		"the root type":     `{"type":"[REDACTED]","properties":{"q":{"type":"string"}}}`,
+		"type and the rest": `{"$schema":"[REDACTED]","type":"[REDACTED]"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := schemaRootViolation(json.RawMessage(schema), true); got != "" {
+				t.Fatalf("redacted schema reported %q, want silence", got)
+			}
+			// Only mcpsnoop's own rewriting earns that silence. The placeholder is a
+			// string either peer may send, so a check that stops at the bytes alone is
+			// a check the traffic can switch off.
+			if got := schemaRootViolation(json.RawMessage(schema), false); got == "" {
+				t.Fatal("an unredacted capture spelling the placeholder must still be judged")
+			}
+		})
+	}
+
+	// Redaction excuses the root verdict and nothing else. A scrubbed root does
+	// not hide what the rest of the document uses.
+	got := analyzeSchema(json.RawMessage(`{"type":"[REDACTED]","properties":{"a":{"oneOf":[{"type":"string"}]}}}`), true)
+	if slices.Contains(got, SchemaFinding{Kind: FindingNonObjectRoot}) {
+		t.Fatalf("got %v, want no %s finding on a redacted root", got, FindingNonObjectRoot)
+	}
+	if !slices.Contains(got, SchemaFinding{Kind: FindingOneOf}) {
+		t.Fatalf("got %v, want the oneOf the walk can still see", got)
+	}
+}
+
+// TestToolsListVerdictSurvivesRedaction drives the whole ingest path, since the
+// flag has to travel from the envelope through completeCall and applyToolsList
+// to reach the check. A unit test on schemaRootViolation alone would pass with
+// the wiring cut.
+func TestToolsListVerdictSurvivesRedaction(t *testing.T) {
+	const listing = `"result":{"tools":[{"name":"search","inputSchema":{"type":"object","properties":{"q":{"type":"string"}}}}]}`
+	findings := func(redacted bool, raw string) []SchemaFinding {
+		t.Helper()
+		s := New()
+		t0 := time.Unix(0, 0)
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{}`))
+		e := resp(2, t0, proxy.ServerToClient, "1", raw)
+		e.Redacted = redacted
+		s.Ingest(e)
+		definitions, ok := s.ToolDefinitions("s1")
+		if !ok || len(definitions) != 1 {
+			t.Fatalf("tool definitions = %v, ok = %v", definitions, ok)
+		}
+		return definitions[0].Findings
+	}
+
+	if got := findings(false, listing); len(got) != 0 {
+		t.Fatalf("a conforming listing reported %v", got)
+	}
+	// What --redact-path '$.result.tools[*].inputSchema' leaves behind.
+	if got := findings(true, `"result":{"tools":[{"name":"search","inputSchema":"[REDACTED]"}]}`); len(got) != 0 {
+		t.Fatalf("a scrubbed schema reported %v, which accuses the server of the user's own redaction", got)
+	}
+	// What --redact-path '$..type' leaves behind.
+	if got := findings(true, `"result":{"tools":[{"name":"search","inputSchema":{"type":"[REDACTED]"}}]}`); len(got) != 0 {
+		t.Fatalf("a scrubbed root type reported %v", got)
+	}
+	// A genuinely rootless schema on a redacted frame is still the server's doing.
+	if got := findings(true, `"result":{"tools":[{"name":"search","inputSchema":{"type":"array"}}]}`); len(got) == 0 {
+		t.Fatal("redaction must not excuse a root type the server really sent")
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -432,7 +432,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.id = string(msg.ID)
 		ev.warning = validationWarning(msg)
 		sess.caps.applyResponseMeta(msg.Result)
-		c, matched := sess.completeCall(ev.id, e.Direction, e.ConnID, e.TS, msg)
+		c, matched := sess.completeCall(ev.id, e.Direction, e.ConnID, e.TS, msg, e.Redacted)
 		ev.call = c
 		if matched && c != nil && c.lateResult {
 			// One-for-one with sess.lateResults++: completeCall returns matched for the
@@ -880,7 +880,7 @@ func requestCallKey(id string, rawID json.RawMessage, e proxy.Envelope) callKey 
 
 // completeCall matches a response to a request. The bool is false for an
 // unmatched response or a duplicate of an already-observed result. Caller holds the lock.
-func (sess *session) completeCall(id string, respDir proxy.Direction, conn string, ts time.Time, msg proxy.RPCMessage) (*call, bool) {
+func (sess *session) completeCall(id string, respDir proxy.Direction, conn string, ts time.Time, msg proxy.RPCMessage, redacted bool) (*call, bool) {
 	c := sess.calls[callKey{dir: opposite(respDir), id: id, conn: conn}]
 	if c == nil {
 		return nil, false // unmatched response (request missed or before backfill)
@@ -915,7 +915,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		// The payload is still the server's answer, so what it declares has to
 		// land. Without this a late tools/list left the tool inventory empty and
 		// `check --fail-on drift` compared nothing and printed green.
-		sess.applyResponseSideEffects(c, msg)
+		sess.applyResponseSideEffects(c, msg, redacted)
 		return c, true
 	}
 	if c.state != Pending && c.state != Streaming {
@@ -962,7 +962,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 	if wasPending {
 		sess.pending--
 	}
-	sess.applyResponseSideEffects(c, msg)
+	sess.applyResponseSideEffects(c, msg, redacted)
 	return c, true
 }
 
@@ -970,14 +970,14 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 // Shared by the ordinary path and the late one, because a response that arrived
 // after a cancellation is still the server's answer and still declares what the
 // server has.
-func (sess *session) applyResponseSideEffects(c *call, msg proxy.RPCMessage) {
+func (sess *session) applyResponseSideEffects(c *call, msg proxy.RPCMessage, redacted bool) {
 	switch c.method {
 	case "initialize":
 		sess.caps.applyResponse(msg.Result)
 	case "server/discover":
 		sess.caps.applyDiscover(msg.Result)
 	case "tools/list":
-		sess.applyToolsList(c.params, msg.Result)
+		sess.applyToolsList(c.params, msg.Result, redacted)
 	}
 }
 
@@ -1210,7 +1210,7 @@ func (c *capabilities) applyResponseMeta(result json.RawMessage) {
 // request is a fresh page one, so its response is the server's current tool set
 // and supersedes what we had (a tools/list_changed re-list can drop tools). A
 // cursored request is a pagination continuation, so it extends the set.
-func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
+func (sess *session) applyToolsList(reqParams, result json.RawMessage, redacted bool) {
 	// The tools array is decoded element by element so each definition's exact
 	// bytes stay available to measure, and so one malformed entry skips only
 	// itself. Decoding straight into a typed slice did neither: it discarded the
@@ -1302,7 +1302,7 @@ func (sess *session) applyToolsList(reqParams, result json.RawMessage) {
 			OutputSchema: append(json.RawMessage(nil), tool.OutputSchema...),
 			Annotations:  append(json.RawMessage(nil), tool.Annotations...),
 			Icons:        append(json.RawMessage(nil), tool.Icons...),
-			Findings:     analyzeSchema(schema),
+			Findings:     analyzeSchema(schema, redacted),
 			paramHeaders: paramHeaders,
 			Cost: ToolCost{
 				Name:             tool.Name,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1220,7 +1220,7 @@ func TestToolDefinitionsCaptureDescriptionsSchemasAndCompletePagination(t *testi
 	}
 
 	s.Ingest(req(3, t0, proxy.ClientToServer, "2", "tools/list", `{"cursor":"p2"}`))
-	s.Ingest(resp(4, t0, proxy.ServerToClient, "2", `"result":{"tools":[{"name":"fetch","description":"Fetch a page","inputSchema":{"oneOf":[{"type":"object"},{"type":"string"}]}}]}`))
+	s.Ingest(resp(4, t0, proxy.ServerToClient, "2", `"result":{"tools":[{"name":"fetch","description":"Fetch a page","inputSchema":{"type":"object","oneOf":[{"type":"object"},{"type":"string"}]}}]}`))
 
 	definitions, ok := s.ToolDefinitions("s1")
 	if !ok {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1563,13 +1563,17 @@ func (m Model) summaryContent() string {
 	return header + "\n\n" + strings.Join(sections, "\n\n")
 }
 
-// schemaHeadlineOrder ranks findings for the single-label SCHEMA column. An
-// external reference leads because it points outside the wire entirely, which is
-// both the least portable case and the one the spec warns implementers about.
-// The composition keywords follow, then an internal reference, then an untyped
-// property, which is the weakest signal since a description often carries the
-// meaning a type would.
+// schemaHeadlineOrder ranks findings for the single-label SCHEMA column. A
+// non-object root leads because it is the only entry here that is a violation
+// rather than an observation: the others say a schema may be read differently
+// across clients, that one says a conforming client refuses the tool outright.
+// An external reference follows because it points outside the wire entirely,
+// which is both the least portable case and the one the spec warns implementers
+// about. The composition keywords come next, then an internal reference, then an
+// untyped property, which is the weakest signal since a description often
+// carries the meaning a type would.
 var schemaHeadlineOrder = []store.SchemaFindingKind{
+	store.FindingNonObjectRoot,
 	store.FindingExternalRef,
 	store.FindingOneOf,
 	store.FindingAnyOf,
@@ -1597,6 +1601,8 @@ func headlineFinding(findings []store.SchemaFinding) store.SchemaFindingKind {
 // narrow SCHEMA column. Display wording is a TUI concern, not the store's.
 func schemaKindLabel(k store.SchemaFindingKind) string {
 	switch k {
+	case store.FindingNonObjectRoot:
+		return "no obj root"
 	case store.FindingExternalRef:
 		return "ext ref"
 	case store.FindingUntypedProperty:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1427,8 +1427,11 @@ func (m Model) capsTitle(label, version string, w int) string {
 // summary table column widths, all padded with lipgloss.Width so styled cells
 // stay aligned.
 const (
-	sumToolW   = 18
-	sumSchemaW = 7
+	sumToolW = 18
+	// Wide enough for the longest schema label plus the "+" that means there is
+	// more than one kind. At the label's own width the marker is truncated away
+	// and a tool with one problem renders exactly like a tool with five.
+	sumSchemaW = 8
 	sumCallsW  = 7
 	sumErrW    = 6
 	sumLatW    = 10
@@ -1547,9 +1550,11 @@ func (m Model) summaryContent() string {
 		if tool.Pending > 0 && tool.Pending == tool.Calls {
 			lat = m.styles.pending.Render(m.spinnerFrame())
 		}
-		// SCHEMA names the most notable construct a tool's advertised schema uses
-		// that is known to travel badly across clients, plus a "+" when there is
-		// more than one kind. Purely observational, so it carries the warn color,
+		// SCHEMA names the most notable thing about a tool's advertised schema,
+		// plus a "+" when there is more than one kind. All but a missing root type
+		// are observations about how a schema travels across clients rather than
+		// verdicts on it, and even that one is a fact about a definition rather
+		// than about a call, so the column carries the warn color throughout and
 		// never the ERR column's red.
 		// An empty cell is left blank rather than dotted. The ERR column already
 		// uses · to mean zero, and repeating it here both adds noise on the common
@@ -1639,7 +1644,7 @@ func headlineFinding(findings []store.SchemaFinding) store.SchemaFindingKind {
 func schemaKindLabel(k store.SchemaFindingKind) string {
 	switch k {
 	case store.FindingNonObjectRoot:
-		return "no obj root"
+		return "no root"
 	case store.FindingExternalRef:
 		return "ext ref"
 	case store.FindingUntypedProperty:

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -68,3 +68,64 @@ func TestTruncateAppendsEllipsisWhenItCuts(t *testing.T) {
 		t.Fatalf("a cut result should end with an ellipsis, got %q", got)
 	}
 }
+
+// TestSchemaColumnLabelsFitBesideTheMoreMarker locks the two things the SCHEMA
+// column promises. The label is shown whole, and the trailing "+" that means
+// "more than one kind" is still visible when it applies. Both are decided by
+// cellL truncating to sumSchemaW, so a label one cell too long silently eats the
+// marker and the row for a tool with five problems becomes the row for a tool
+// with one. Nothing else in the TUI lists a tool's findings, so that marker is
+// the only sign more exists.
+func TestSchemaColumnLabelsFitBesideTheMoreMarker(t *testing.T) {
+	blank := cellL("", sumSchemaW)
+	byCell := map[string]store.SchemaFindingKind{}
+	for _, kind := range store.SchemaFindingKinds {
+		label := schemaKindLabel(kind)
+		one, many := cellL(label, sumSchemaW), cellL(label+"+", sumSchemaW)
+		if strings.Contains(one, "…") {
+			t.Errorf("%s: label %q does not fit the %d-cell column, renders %q", kind, label, sumSchemaW, one)
+		}
+		if !strings.HasSuffix(strings.TrimRight(many, " "), "+") {
+			t.Errorf("%s: the + meaning more than one kind is truncated away, renders %q", kind, many)
+		}
+		for _, cell := range []string{one, many} {
+			if cell == blank {
+				t.Errorf("%s renders as the blank cell a clean schema uses", kind)
+			}
+			if prev, dup := byCell[cell]; dup {
+				t.Errorf("%s renders %q, which is already what %s renders", kind, cell, prev)
+			}
+			byCell[cell] = kind
+		}
+	}
+}
+
+// TestSchemaHeadlineOrderRanksEveryKind. headlineFinding falls back to
+// findings[0], which is the order the schema walk happened to meet them in, so a
+// kind missing from the ranking can outrank a violation. schemaKindLabel falls
+// back to the raw enum name, which for a kind like nonObjectRoot is 13 cells in
+// an 8-cell column. Driven off store.SchemaFindingKinds for the same reason the
+// drift section is driven off store.ToolDriftKinds.
+func TestSchemaHeadlineOrderRanksEveryKind(t *testing.T) {
+	ranked := make(map[store.SchemaFindingKind]bool, len(schemaHeadlineOrder))
+	for _, kind := range schemaHeadlineOrder {
+		ranked[kind] = true
+	}
+	for _, kind := range store.SchemaFindingKinds {
+		if !ranked[kind] {
+			t.Errorf("%s is not ranked, so it wins the column only by where the walk met it", kind)
+		}
+	}
+	if len(schemaHeadlineOrder) != len(store.SchemaFindingKinds) {
+		t.Errorf("ranking has %d kinds, the store emits %d", len(schemaHeadlineOrder), len(store.SchemaFindingKinds))
+	}
+
+	// The violation outranks every observation, which is the whole reason the
+	// order is written down rather than taken from the walk.
+	for _, other := range store.SchemaFindingKinds[1:] {
+		findings := []store.SchemaFinding{{Kind: other}, {Kind: store.FindingNonObjectRoot}}
+		if got := headlineFinding(findings); got != store.FindingNonObjectRoot {
+			t.Errorf("a schema with %s and a non-object root headlines %s, want the violation", other, got)
+		}
+	}
+}


### PR DESCRIPTION
Part 1 of #199.

A tool whose `inputSchema` has no root type is rejected by clients at
registration. `analyzeSchema` walked subschemas for constructs that travel
badly but never read the root type, so the one condition here that is a
violation was the one it could not report.

Adds a `nonObjectRoot` finding, set when `inputSchema` is absent, is not a JSON
object, or has a root type that is not `"object"`. Nothing is resolved and no
dialect is interpreted. The TUI ranks it above every existing kind, since the
others say a schema may be read differently across clients and this one says a
conforming client refuses the tool.

Nine existing fixtures were rootless schemas used to test construct detection,
so they trip the new finding too. I gave each a valid object root rather than
adding the new kind to every `want`, so each test keeps isolating one thing.

Reporting this on the `tools/list` frame so that `check` fails is a follow-up,
kept separate to keep this reviewable.
