### PR TITLE
feat: add optional You.com search integration

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -128,9 +128,14 @@ jobs:
       # The other half of install: false. This one downloads a published release
       # and verifies it, which is the part that has to work on three operating
       # systems and cannot be tested anywhere but here.
+      # Pinned to a known release rather than tracking the newest one. What this
+      # leg tests is that install.sh can fetch and verify a published archive on
+      # three operating systems, and a moving target would make a failure here
+      # ambiguous between the script and whatever was published that morning.
+      # Bumping it is optional and safe; pointing it at "latest" is not.
       - name: Install a published release and check with it
         uses: ./
         with:
           session: captures/clean.jsonl
-          version: v0.20.0
+          version: v0.21.0
           category: mcpsnoop-selftest-release-${{ matrix.os }}

--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -1,0 +1,136 @@
+name: action
+
+# The shell in action/ is covered by CI. This is the half those tests cannot
+# reach: the composite wiring itself. Whether inputs arrive, whether the nested
+# upload runs on the right runs, whether any of it works on a Windows runner,
+# and whether a step that must fail actually does.
+on:
+  push:
+    branches: [main]
+    paths: ["action.yml", "action/**", ".github/workflows/action-selftest.yml", "cmd/mcpsnoop/**"]
+  pull_request:
+    paths: ["action.yml", "action/**", ".github/workflows/action-selftest.yml", "cmd/mcpsnoop/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          check-latest: true
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      # Real captures, recorded by the binary under test against a real stdio
+      # server, rather than fixtures. *.jsonl is ignored in this repository, so a
+      # committed fixture would be silently untracked and every case below would
+      # pass against nothing.
+      - name: Record two captures
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bin" captures
+          go build -o "$RUNNER_TEMP/bin/mcpsnoop" ./cmd/mcpsnoop
+          # GITHUB_PATH, not export. An export lasts as long as this step, and
+          # the steps that use `install: false` below are later ones.
+          echo "$RUNNER_TEMP/bin" >>"$GITHUB_PATH"
+          export PATH="$RUNNER_TEMP/bin:$PATH"
+          cat > server.js <<'JS'
+          let buf = ''
+          const fail = process.env.FAIL === '1'
+          process.stdin.on('data', d => {
+            buf += d
+            let i
+            while ((i = buf.indexOf('\n')) >= 0) {
+              const line = buf.slice(0, i); buf = buf.slice(i + 1)
+              if (!line.trim()) continue
+              const m = JSON.parse(line)
+              if (m.method === 'initialize') process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:m.id,result:{protocolVersion:'2026-07-28',capabilities:{tools:{}},serverInfo:{name:'selftest',version:'1'}}}) + '\n')
+              if (m.method === 'tools/call') process.stdout.write(fail
+                ? JSON.stringify({jsonrpc:'2.0',id:m.id,error:{code:-32601,message:'no such tool'}}) + '\n'
+                : JSON.stringify({jsonrpc:'2.0',id:m.id,result:{content:[{type:'text',text:'ok'}]}}) + '\n')
+            }
+          })
+          JS
+          # A state directory of its own per recording. Picking the newest log out
+          # of a shared one works until the second recording lands in the same
+          # second as the first, and then the two captures are the same file.
+          drive() {
+            export MCPSNOOP_HOME="$RUNNER_TEMP/home-$1"
+            printf '%s\n%s\n' \
+              '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}' \
+              '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ping","arguments":{}}}' \
+              | mcpsnoop -- node server.js > /dev/null
+            find "$MCPSNOOP_HOME/sessions" -name '*.jsonl' | head -1
+          }
+          cp "$(drive clean)" captures/clean.jsonl
+          cp "$(FAIL=1 drive dirty)" captures/dirty.jsonl
+          wc -l captures/*.jsonl
+
+      # install: false, so this leg is about the wiring rather than the download.
+      # It also runs before any release carries this action, which is the state
+      # every pull request that touches it is in.
+      - name: A clean capture passes
+        uses: ./
+        with:
+          session: captures/clean.jsonl
+          install: false
+          category: mcpsnoop-selftest-clean-${{ matrix.os }}
+
+      - name: A finding is reported without failing when asked
+        id: findings
+        uses: ./
+        with:
+          session: captures/dirty.jsonl
+          install: false
+          fail-on-findings: false
+          # Not uploaded: this run has a real finding by construction, and the
+          # Security tab of this repository is not the place to file it.
+          upload-sarif: false
+      - name: ...and says so
+        shell: bash
+        run: |
+          [ "${{ steps.findings.outputs.outcome }}" = findings ] || {
+            echo "outcome was '${{ steps.findings.outputs.outcome }}', want findings"; exit 1; }
+          [ -s "${{ steps.findings.outputs.sarif }}" ] || { echo "no report was written"; exit 1; }
+
+      - name: A capture that is not there is an error, not a finding
+        id: missing
+        continue-on-error: true
+        uses: ./
+        with:
+          session: captures/does-not-exist.jsonl
+          install: false
+          # Even suppressed, this must fail. Nothing was checked.
+          fail-on-findings: false
+          upload-sarif: false
+      - name: ...and fails the step whatever fail-on-findings says
+        shell: bash
+        run: |
+          [ "${{ steps.missing.outcome }}" = failure ] || {
+            echo "the step succeeded on a capture that does not exist"; exit 1; }
+          [ "${{ steps.missing.outputs.outcome }}" = error ] || {
+            echo "outcome was '${{ steps.missing.outputs.outcome }}', want error"; exit 1; }
+
+      # The other half of install: false. This one downloads a published release
+      # and verifies it, which is the part that has to work on three operating
+      # systems and cannot be tested anywhere but here.
+      - name: Install a published release and check with it
+        uses: ./
+        with:
+          session: captures/clean.jsonl
+          version: v0.20.0
+          category: mcpsnoop-selftest-release-${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ jobs:
       - name: go vet
         run: go vet ./...
       - name: staticcheck
-        run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
-          staticcheck ./...
+        run: make staticcheck
       - name: test
         run: go test -race ./...
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           go-version: stable
           check-latest: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         # The npm launcher is the one file in this repo that runs on a user's
         # machine, and its tests drive it with a real node. Stated rather than
         # relying on the runner image happening to carry one.
@@ -59,7 +59,7 @@ jobs:
         with:
           go-version: stable
           check-latest: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
       - name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           go-version: stable
           check-latest: true
+      - uses: actions/setup-node@v4
+        # The npm launcher is the one file in this repo that runs on a user's
+        # machine, and its tests drive it with a real node. Stated rather than
+        # relying on the runner image happening to carry one.
+        with:
+          node-version: "22"
       - name: gofmt -s
         run: |
           out="$(gofmt -s -l .)"
@@ -53,6 +59,9 @@ jobs:
         with:
           go-version: stable
           check-latest: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
       - name: check
         env:
           TZ: UTC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
         run: go test -race ./...
       - name: build
         run: go build ./...
+      # The action is shell, so nothing above compiles or runs it, and it is the
+      # only part of this repository that runs in other people's workflows.
+      - name: action
+        run: make action-test
 
   # Keep the Windows and macOS binaries honest. The release ships both, but the
   # gate above only runs on Linux. macOS is Unix-like, so it runs the full race

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
       - name: staticcheck
         run: make staticcheck
       - name: test
+        # Stated rather than inherited. The runner is UTC today, `make check`
+        # pins CHECK_TZ to UTC to match it, and neither should depend on the
+        # other's default staying put.
+        env:
+          TZ: UTC
         run: go test -race ./...
       - name: build
         run: go build ./...
@@ -49,6 +54,8 @@ jobs:
           go-version: stable
           check-latest: true
       - name: check
+        env:
+          TZ: UTC
         run: ${{ matrix.check }}
       - name: build
         run: go build ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,13 +86,22 @@ jobs:
       # to a bare `npx mcpsnoop`, and a publish claims that tag unless told
       # otherwise, so a v*-rc tag would reach every user with no way to take it
       # back.
+      # Skipping what is already there is what makes re-running this job a real
+      # recovery. A publish that died partway leaves some of the seven on the
+      # registry, and npm refuses to publish over an existing version, so a
+      # plain retry would stop at the first one it had already done.
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          version="${TAG#v}"
           dist_tag="$(go run ./cmd/npmpack -print-dist-tag -version "$TAG")"
-          echo "publishing $TAG under the $dist_tag tag"
-          for dir in $(go run ./cmd/npmpack -print-order); do
-            echo "publishing $dir"
-            npm publish "dist/npm/$dir" --provenance --access public --tag "$dist_tag"
+          echo "publishing $version under the $dist_tag tag"
+          for name in $(go run ./cmd/npmpack -print-order); do
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "$name@$version is already on the registry, skipping"
+              continue
+            fi
+            echo "publishing $name@$version"
+            npm publish "dist/npm/$name" --provenance --access public --tag "$dist_tag"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,17 @@ jobs:
           check-latest: true
       # 24 rather than the 22 that CI runs. Trusted publishing needs npm 11.5.1
       # or later to authenticate by OIDC, and node 22 still carries npm 10.
-      - uses: actions/setup-node@v4
+      #
+      # v7 rather than v4 for two things this job hit. v4 writes always-auth
+      # into the .npmrc, which npm now warns on and says will stop working, and
+      # it exports a dummy NODE_AUTH_TOKEN. Both are gone by v7. Caching is off
+      # because a release must build from what is in the tag, not from whatever
+      # a cache happens to hold.
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       # Without this, an npm too old to speak OIDC fails at the publish with a
       # 401, which reads like a credential problem and is not one.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,21 @@ on:
   push:
     tags:
       - "v*"
+  # The npm half can be re-run on its own. A version cannot be replaced once it
+  # is on npm, so a release that failed partway through has to be finishable
+  # without rebuilding and re-publishing the GitHub release it already made.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "the tag to publish to npm, for example v0.19.0"
+        required: true
 
 permissions:
   contents: write
 
 jobs:
   goreleaser:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,3 +34,65 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm:
+    # Most of the MCP ecosystem is Node and Python, and nobody writing a server
+    # in TypeScript is going to install a Go toolchain to debug it. These seven
+    # packages make the quickstart npx mcpsnoop -- node build/index.js.
+    needs: [goreleaser]
+    # The push path waits for goreleaser. The dispatch path skips it, since the
+    # release it packages is already published.
+    if: always() && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Lets the runner mint the short-lived token npm signs the provenance
+      # attestation with, so anyone can check that these bytes were built here
+      # rather than uploaded from someone's laptop.
+      id-token: write
+    env:
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          check-latest: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # The packages are built from what the release actually published, not
+      # from a build tree, and every archive is checked against the checksums
+      # file published beside it before anything is packed. That way the binary
+      # someone runs with npx is provably the binary on the releases page.
+      - name: Download the published archives
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist \
+            --pattern 'mcpsnoop_*' --pattern 'checksums.txt'
+          ls -l dist
+
+      - name: Build the npm packages
+        run: go run ./cmd/npmpack -version "$TAG" -dist dist -out dist/npm
+
+      # In the order npmpack prints, which puts the root package last. It
+      # resolves to the other six, so publishing it first would serve a broken
+      # install to anyone who asked for mcpsnoop in the window before they land.
+      #
+      # The dist-tag comes from npmpack too. npm hands whatever carries `latest`
+      # to a bare `npx mcpsnoop`, and a publish claims that tag unless told
+      # otherwise, so a v*-rc tag would reach every user with no way to take it
+      # back.
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          dist_tag="$(go run ./cmd/npmpack -print-dist-tag -version "$TAG")"
+          echo "publishing $TAG under the $dist_tag tag"
+          for dir in $(go run ./cmd/npmpack -print-order); do
+            echo "publishing $dir"
+            npm publish "dist/npm/$dir" --provenance --access public --tag "$dist_tag"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,13 +110,28 @@ jobs:
       # registry, and npm refuses to publish over an existing version, so a
       # plain retry would stop at the first one it had already done.
       #
-      # No --provenance and no token. Publishing this way attaches the
-      # attestation on its own, and the flag npm's own guidance calls
-      # unnecessary would only invite the question of why it is here.
+      # --provenance stays even though trusted publishing attaches the
+      # attestation on its own. It is the tripwire. npm generates provenance
+      # inside the success branch of the OIDC exchange and its own guidance says
+      # that exchange never throws, so a misconfigured trusted publisher fails
+      # silently. Asking for provenance outright turns that into a failed
+      # publish rather than a published version nobody can verify.
       - name: Publish
         run: |
           version="${TAG#v}"
           dist_tag="$(go run ./cmd/npmpack -print-dist-tag -version "$TAG")"
+
+          # The one mistake here that cannot be taken back is putting a
+          # prerelease on the `latest` tag, where every bare `npx mcpsnoop`
+          # would pick it up. It rests on one substitution, so check it.
+          case "$TAG" in
+            *-*) want=next ;;
+            *) want=latest ;;
+          esac
+          if [ "$dist_tag" != "$want" ]; then
+            echo "npmpack puts $TAG under '$dist_tag', this step expected '$want'."
+            exit 1
+          fi
           echo "publishing $version under the $dist_tag tag"
           for name in $(go run ./cmd/npmpack -print-order); do
             if npm view "$name@$version" version >/dev/null 2>&1; then
@@ -124,5 +139,5 @@ jobs:
               continue
             fi
             echo "publishing $name@$version"
-            npm publish "dist/npm/$name" --access public --tag "$dist_tag"
+            npm publish "dist/npm/$name" --provenance --access public --tag "$dist_tag"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Lets the runner mint the short-lived token npm signs the provenance
-      # attestation with, so anyone can check that these bytes were built here
-      # rather than uploaded from someone's laptop.
+      # This is the whole of the credential. npm is set up to trust this
+      # workflow in this repository, so the runner mints a short-lived OIDC
+      # token for the publish and signs the provenance attestation with it.
+      # There is no long-lived npm token anywhere, and anyone can check that
+      # these bytes were built here rather than uploaded from someone's laptop.
       id-token: write
     env:
       TAG: ${{ github.event.inputs.tag || github.ref_name }}
@@ -58,10 +60,25 @@ jobs:
         with:
           go-version: stable
           check-latest: true
+      # 24 rather than the 22 that CI runs. Trusted publishing needs npm 11.5.1
+      # or later to authenticate by OIDC, and node 22 still carries npm 10.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+
+      # Without this, an npm too old to speak OIDC fails at the publish with a
+      # 401, which reads like a credential problem and is not one.
+      - name: Check the runner's npm can authenticate by OIDC
+        run: |
+          need=11.5.1
+          have="$(npm --version)"
+          if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | head -1)" != "$need" ]; then
+            echo "npm $have cannot do trusted publishing, which needs $need or later."
+            echo "Raise node-version for this job. Node 24 carries npm 11."
+            exit 1
+          fi
+          echo "npm $have"
 
       # The packages are built from what the release actually published, not
       # from a build tree, and every archive is checked against the checksums
@@ -82,17 +99,21 @@ jobs:
       # resolves to the other six, so publishing it first would serve a broken
       # install to anyone who asked for mcpsnoop in the window before they land.
       #
+      #
       # The dist-tag comes from npmpack too. npm hands whatever carries `latest`
       # to a bare `npx mcpsnoop`, and a publish claims that tag unless told
       # otherwise, so a v*-rc tag would reach every user with no way to take it
       # back.
+      #
       # Skipping what is already there is what makes re-running this job a real
       # recovery. A publish that died partway leaves some of the seven on the
       # registry, and npm refuses to publish over an existing version, so a
       # plain retry would stop at the first one it had already done.
+      #
+      # No --provenance and no token. Publishing this way attaches the
+      # attestation on its own, and the flag npm's own guidance calls
+      # unnecessary would only invite the question of why it is here.
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           version="${TAG#v}"
           dist_tag="$(go run ./cmd/npmpack -print-dist-tag -version "$TAG")"
@@ -103,5 +124,5 @@ jobs:
               continue
             fi
             echo "publishing $name@$version"
-            npm publish "dist/npm/$name" --provenance --access public --tag "$dist_tag"
+            npm publish "dist/npm/$name" --access public --tag "$dist_tag"
           done

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 /mcpsnoop
+/.action-bin/
 /dist/
 *.exe
 *.out

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Go
 /vendor/
 
+# npm. Nothing in the repo creates this, but the npm directory invites an
+# install in it.
+node_modules/
+
 # Editor / OS
 .DS_Store
 .idea/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,22 @@ archives:
       - goos: windows
         formats: [zip]
 
+# Without this, a v*-rc tag publishes as an ordinary release and takes the Latest
+# badge, because prerelease defaults to false and GitHub's own make_latest
+# default is true. The npm half already keeps a prerelease off the `latest`
+# dist-tag, and this is the other half of the same promise. Detection is on the
+# semver prerelease field, not a substring, so any hyphenated tag is caught.
+release:
+  prerelease: auto
+
+git:
+  # Tells git's version sort that -rc marks a prerelease. Without it,
+  # `git tag --points-at HEAD --sort -version:refname` puts v0.20.1-rc.1 above
+  # v0.20.1, so promoting a release candidate by tagging the same commit makes
+  # GoReleaser rebuild the rc and leaves the npm job downloading a release that
+  # was never created.
+  prerelease_suffix: "-rc"
+
 checksum:
   name_template: "checksums.txt"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,13 @@ mcpsnoop follows [Semantic Versioning](https://semver.org), with tags shaped lik
 - **From `1.0.0` on**, breaking changes go in a **major** bump, new features in a
   **minor**, and fixes in a **patch**.
 
+A prerelease tag must be spelled `-rc.N`, as in `v1.0.0-rc.1`. Homebrew keeps
+prereleases out of `brew install mcpsnoop` with a list of keywords that contains
+`rc` and not, say, `next`, so a differently spelled tag would be bumped to every
+Homebrew user.
+
 A release is cut by pushing a version tag. See [RELEASING.md](RELEASING.md) for
-the steps.
+the steps, and for what else is true of a prerelease.
 
 ## Reporting bugs and proposing features
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,16 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 # CI. Bump this deliberately rather than discovering it on an unrelated pull
 # request.
 STATICCHECK_VERSION ?= v0.8.0
+# Pinned for the same reason, one layer down. CI runners are UTC and a
+# contributor's machine is whatever they live in, so a test that renders a local
+# timestamp passes in one and fails in the other. It has: an inventory test took
+# the last six characters of an RFC3339 stamp as its offset, which is the offset
+# at +03:00 and part of the minutes at UTC. `check` claims to match CI, so it
+# pins the zone the way it pins the analyser. Override it to reproduce something
+# zone-specific.
+CHECK_TZ ?= UTC
 
-.PHONY: all build test vet staticcheck fmt fmt-check lint check clean
+.PHONY: all build test vet vet-cross staticcheck fmt fmt-check lint check clean
 
 all: check build
 
@@ -21,6 +29,24 @@ test:
 
 vet:
 	$(GO) vet $(PKG)
+
+# The platforms CI compiles on. The release ships Windows and macOS binaries and
+# the CI matrix vets Windows, but a local `go vet` only ever sees the host, so
+# platform-specific code is compiled here for the first time on somebody else's
+# pull request.
+CROSS_GOOS ?= windows darwin linux
+
+# vet-cross typechecks every package *and its tests* for each of those. Building
+# the binaries is not enough and was not: `GOOS=windows go build ./...` skips
+# test files entirely, so a test calling syscall.Mkfifo behind a runtime
+# GOOS check passed every local gate and broke the Windows job, because a
+# runtime skip does not stop the compiler needing the symbol. Guard that code
+# with a build tag, the way console_unix.go does, and this target proves it.
+vet-cross:
+	@for os in $(CROSS_GOOS); do \
+		echo "GOOS=$$os go vet $(PKG)"; \
+		GOOS=$$os $(GO) vet $(PKG) || exit 1; \
+	done
 
 # staticcheck catches non-idiomatic code (e.g. interface{} over any, dead code).
 # Run through `go run` at the pinned version rather than whatever binary is on
@@ -35,12 +61,12 @@ fmt:
 fmt-check:
 	@out="$$(gofmt -s -l .)"; if [ -n "$$out" ]; then echo "gofmt -s needed:"; echo "$$out"; exit 1; fi
 
-lint: vet staticcheck
+lint: vet vet-cross staticcheck
 
 # check is the pre-commit/CI gate, formatting, static analysis, and the full
 # test suite under the race detector (matching CI).
 check: fmt-check lint
-	$(GO) test -race $(PKG)
+	TZ=$(CHECK_TZ) $(GO) test -race $(PKG)
 
 clean:
 	rm -f $(BIN)

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ action-test: shellcheck-bin
 	@"$(CURDIR)/.action-bin/shellcheck" action/*.sh action/tests/*.sh
 	@PATH="$(CURDIR)/.action-bin:$$PATH" bash action/tests/install_test.sh
 	@PATH="$(CURDIR)/.action-bin:$$PATH" bash action/tests/check_test.sh
+	@bash action/tests/docs_test.sh
 	@rm -rf "$(CURDIR)/.action-bin"
 
 # Resolve a shellcheck of exactly SHELLCHECK_VERSION: the one already installed

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,15 @@ STATICCHECK_VERSION ?= v0.8.0
 # pins the zone the way it pins the analyser. Override it to reproduce something
 # zone-specific.
 CHECK_TZ ?= UTC
+# Pinned for the third time for the same reason, one layer out. `make check` was
+# green on shellcheck 0.11.0 while CI failed on the ubuntu image's older one,
+# which still reports SC2015 for a pattern 0.11 accepts. An analyser the two
+# sides do not share is an analyser that finds things only on somebody else's
+# pull request. Downloaded when the local one is a different version, the way
+# staticcheck is run through `go run` at a fixed version.
+SHELLCHECK_VERSION ?= v0.11.0
 
-.PHONY: all build test vet vet-cross staticcheck fmt fmt-check lint check clean
+.PHONY: all build test vet vet-cross staticcheck fmt fmt-check lint check clean action-test shellcheck-bin
 
 all: check build
 
@@ -61,13 +68,47 @@ fmt:
 fmt-check:
 	@out="$$(gofmt -s -l .)"; if [ -n "$$out" ]; then echo "gofmt -s needed:"; echo "$$out"; exit 1; fi
 
+# The GitHub Action is shell, so the Go gate above cannot see it, and it is the
+# one part of this repository that runs on other people's machines. Its tests
+# drive the real scripts against a stand-in releases page and a stand-in binary,
+# so they need mcpsnoop built but no network. shellcheck is run when it is here,
+# since a contributor working on Go has no reason to have installed it.
+action-test: shellcheck-bin
+	@$(GO) build -o "$(CURDIR)/.action-bin/mcpsnoop" ./cmd/mcpsnoop
+	@"$(CURDIR)/.action-bin/shellcheck" action/*.sh action/tests/*.sh
+	@PATH="$(CURDIR)/.action-bin:$$PATH" bash action/tests/install_test.sh
+	@PATH="$(CURDIR)/.action-bin:$$PATH" bash action/tests/check_test.sh
+	@rm -rf "$(CURDIR)/.action-bin"
+
+# Resolve a shellcheck of exactly SHELLCHECK_VERSION: the one already installed
+# if it is that version, otherwise a downloaded copy. It is a Haskell binary
+# rather than a Go module, so there is no `go run` equivalent to lean on.
+shellcheck-bin:
+	@mkdir -p "$(CURDIR)/.action-bin"
+	@want="$(SHELLCHECK_VERSION)"; want="$${want#v}"; \
+	if command -v shellcheck >/dev/null 2>&1 && \
+		shellcheck --version | grep -qx "version: $$want"; then \
+		ln -sf "$$(command -v shellcheck)" "$(CURDIR)/.action-bin/shellcheck"; \
+	elif [ ! -x "$(CURDIR)/.action-bin/shellcheck" ]; then \
+		case "$$(uname -s)/$$(uname -m)" in \
+			Darwin/arm64) plat=darwin.aarch64 ;; \
+			Darwin/*) plat=darwin.x86_64 ;; \
+			Linux/aarch64|Linux/arm64) plat=linux.aarch64 ;; \
+			Linux/*) plat=linux.x86_64 ;; \
+			*) echo "no pinned shellcheck for $$(uname -s)/$$(uname -m)"; exit 1 ;; \
+		esac; \
+		echo "fetching shellcheck $(SHELLCHECK_VERSION) for $$plat"; \
+		curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$$plat.tar.xz" \
+			| tar -xJ -C "$(CURDIR)/.action-bin" --strip-components=1 "shellcheck-$(SHELLCHECK_VERSION)/shellcheck"; \
+	fi
+
 lint: vet vet-cross staticcheck
 
 # check is the pre-commit/CI gate, formatting, static analysis, and the full
 # test suite under the race detector (matching CI).
-check: fmt-check lint
+check: fmt-check lint action-test
 	TZ=$(CHECK_TZ) $(GO) test -race $(PKG)
 
 clean:
 	rm -f $(BIN)
-	rm -rf dist
+	rm -rf dist .action-bin

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ GO ?= go
 BIN := mcpsnoop
 PKG := ./...
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+# Pinned so `make check` and CI run the same analyser. They did not: the Makefile
+# reused whatever staticcheck was already on PATH while CI installed @latest, so
+# a deprecation a newer release had learned about passed locally and failed in
+# CI. Bump this deliberately rather than discovering it on an unrelated pull
+# request.
+STATICCHECK_VERSION ?= v0.8.0
 
 .PHONY: all build test vet staticcheck fmt fmt-check lint check clean
 
@@ -17,9 +23,10 @@ vet:
 	$(GO) vet $(PKG)
 
 # staticcheck catches non-idiomatic code (e.g. interface{} over any, dead code).
+# Run through `go run` at the pinned version rather than whatever binary is on
+# PATH, so the result does not depend on when a contributor last installed it.
 staticcheck:
-	@command -v staticcheck >/dev/null 2>&1 || $(GO) install honnef.co/go/tools/cmd/staticcheck@latest
-	staticcheck $(PKG)
+	$(GO) run honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION) $(PKG)
 
 fmt:
 	gofmt -s -w .

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CHECK_TZ ?= UTC
 # staticcheck is run through `go run` at a fixed version.
 SHELLCHECK_VERSION ?= v0.11.0
 
-.PHONY: all build test vet vet-cross staticcheck fmt fmt-check lint check clean action-test shellcheck-bin
+.PHONY: all build test vet vet-cross staticcheck fmt fmt-check lint check clean action-test shellcheck-bin release-prep
 
 all: check build
 
@@ -67,6 +67,37 @@ fmt:
 # fmt-check fails (for CI) if any file is not simplified/gofmt'd.
 fmt-check:
 	@out="$$(gofmt -s -l .)"; if [ -n "$$out" ]; then echo "gofmt -s needed:"; echo "$$out"; exit 1; fi
+
+# Bump every release version a reader is meant to copy, before tagging.
+#
+# The README's `uses:` lines are what somebody arriving from the Marketplace
+# listing copies, and the listing renders the README from the default branch
+# while the version beside it comes from the published release. Leaving them
+# behind makes the page recommend one release in its sidebar and hand out an
+# older one in its snippet. The selftest's own pin is deliberately not touched,
+# since that leg exists to prove install.sh against a known archive.
+#
+# TAG reaches the recipe through the environment rather than through make's own
+# substitution, and that is not style. Substituted, the value becomes part of the
+# recipe text before any line of it runs, so a semicolon in it is a second
+# command and no check written below could ever see it. This target was written
+# the other way first, and `TAG='v1.0.0; rm -rf /'` sailed past a case pattern
+# that looked strict: a shell glob is not a regex, and its * matches a semicolon
+# and a space as happily as a digit.
+release-prep: export MCPSNOOP_RELEASE_TAG = $(TAG)
+release-prep:
+	@if [ -z "$$MCPSNOOP_RELEASE_TAG" ]; then \
+		echo "usage: make release-prep TAG=v0.22.0" >&2; exit 1; \
+	fi
+	@printf '%s' "$$MCPSNOOP_RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || { \
+		printf 'TAG must be a full release tag such as v0.22.0, got "%s"\n' "$$MCPSNOOP_RELEASE_TAG" >&2; \
+		exit 1; \
+	}
+	@sed -i.bak -E "s|(kerlenton/mcpsnoop@)v[0-9]+\.[0-9]+\.[0-9]+|\1$$MCPSNOOP_RELEASE_TAG|g" README.md
+	@sed -i.bak -E "s|(for example )v[0-9]+\.[0-9]+\.[0-9]+|\1$$MCPSNOOP_RELEASE_TAG|" action.yml
+	@rm -f README.md.bak action.yml.bak
+	@bash action/tests/docs_test.sh
+	@git --no-pager diff --stat README.md action.yml
 
 # The GitHub Action is shell, so the Go gate above cannot see it, and it is the
 # one part of this repository that runs on other people's machines. Its tests

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ steps:
       session: artifacts/session.jsonl
 ```
 
-Every input, what the exit codes mean, and how to wire it up without the action
-are in [The GitHub Action](#the-github-action) further down.
+Pin whichever release you want; the newest is on the
+[releases page](https://github.com/kerlenton/mcpsnoop/releases). Every input,
+what the exit codes mean, and how to wire it up without the action are in
+[The GitHub Action](#the-github-action) further down.
 
 ## Quick start
 
@@ -560,9 +562,11 @@ steps:
       session: artifacts/session.jsonl
 ```
 
-Pin a release. There is no floating `v1`, deliberately: the pinned release is
-also the binary the action installs, so the two can never disagree and there is
-no version default to go stale.
+Pin a release, whichever one you want; the newest is on the
+[releases page](https://github.com/kerlenton/mcpsnoop/releases). There is no
+floating `v1`, deliberately: the pinned release is also the binary the action
+installs, so the two can never disagree and there is no version default to go
+stale.
 
 | Input | |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -522,13 +522,54 @@ displays only the top 5,000 of what it accepts, so the report is capped at 5,000
 the findings the gate failed on first, then a `mcpsnoop/report-truncated` result
 saying how many were left out. The text and junit formats stay complete.
 
-To put the findings in the Security tab, hand the SARIF log to
-`upload-sarif`. The job needs `security-events: write`, or the upload answers
-403. `check` exits non-zero on a finding, so the upload step needs `if: always()`
-to run at all on the runs that have something to report; `continue-on-error`
-hands the verdict to the code scanning check, which fails on an `error`-level
-alert and can be made a required check. Drop it if you would rather the check
-step itself be what turns the job red.
+### The GitHub Action
+
+Everything below is what the action does for you. It installs mcpsnoop, checks
+the capture, files the findings in the Security tab, and fails the job on what
+you gated on.
+
+```yaml
+permissions:
+  security-events: write
+  contents: read
+
+steps:
+  - uses: kerlenton/mcpsnoop@v0.21.0
+    with:
+      session: artifacts/session.jsonl
+```
+
+Pin a release. There is no floating `v1`, deliberately: the pinned release is
+also the binary the action installs, so the two can never disagree and there is
+no version default to go stale.
+
+| Input | |
+|---|---|
+| `session` | the `.jsonl` capture to check, relative to the repository root. Required |
+| `fail-on` | as `--fail-on`, defaulting to what the CLI defaults to |
+| `args` | any other `check` flags, quoted as on a command line. `--format` is refused, since the action reads the report |
+| `upload-sarif` | send the report to code scanning. `true` |
+| `category` | the code scanning namespace. `mcpsnoop`. Vary it per leg of a matrix, or the legs overwrite each other |
+| `fail-on-findings` | fail the job on a finding. `true`. Set `false` to file the alerts and let code scanning's required check decide |
+| `version` | which mcpsnoop to install. Defaults to the release you pinned |
+| `install` | `false` when mcpsnoop is already on PATH, which is the way in on a platform no release is built for |
+
+Outputs are `outcome`, `sarif` and `exit-code`. `outcome` is `passed`,
+`findings`, or `error`, and the third is worth handling separately: it means
+nothing was checked, which is not the same as nothing being found. **A run that
+could not check fails the job whatever `fail-on-findings` says**, because a
+pipeline that goes green having verified nothing is worse than one that fails.
+
+The job needs `security-events: write`, or the upload answers 403. Set
+`upload-sarif: false` in a repository without code scanning.
+
+### Or wire it up yourself
+
+The action is four steps and no magic. Doing it by hand takes the same care it
+takes. The upload has to run on the runs that have a report, which are the ones
+that exited 0 or 1 and not the ones that exited 2, and the step that fails the
+job has to come after it, or the findings never reach the tab they exist to
+reach.
 
 ```yaml
 permissions:
@@ -540,14 +581,25 @@ permissions:
 
 steps:
 - name: Check captured MCP session
-  continue-on-error: true
-  run: mcpsnoop check --format sarif artifacts/session.jsonl > mcpsnoop.sarif
+  id: check
+  run: |
+    code=0
+    mcpsnoop check --format sarif artifacts/session.jsonl > mcpsnoop.sarif || code=$?
+    echo "exit-code=$code" >> "$GITHUB_OUTPUT"
+    # 2 means the check never happened, so there is no report to publish and
+    # nothing was verified. Stop here rather than uploading an empty file.
+    [ "$code" -le 1 ] || exit 1
 - name: Upload mcpsnoop SARIF report
-  if: always()
+  if: ${{ !cancelled() }}
   uses: github/codeql-action/upload-sarif@v4
   with:
     sarif_file: mcpsnoop.sarif
     category: mcpsnoop
+- name: Fail on findings
+  # Separate, and after the upload, so the findings reach the Security tab on
+  # exactly the runs that have some.
+  if: ${{ !cancelled() && steps.check.outputs.exit-code == '1' }}
+  run: exit 1
 ```
 
 ### Catch a routing header that disagrees with the body

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ more than one of each.
 
 Those are all the keys it supports.
 
+### Web Search Integration
+
+mcpsnoop includes optional You.com web search integration for researching MCP errors, tool specifications, and debugging issues directly from the TUI.
+
+**Setup**: Set your You.com API key via environment variable, flag, or config file:
+```bash
+export YOUCOM_API_KEY="your-api-key"
+# or
+mcpsnoop --youcom-api-key="your-api-key" -- your-server
+# or add to .mcpsnoop.toml:
+youcom-api-key = "your-api-key"
+```
+
+**Usage**: Press `w` in the TUI or use `:search <query>` / `:web <query>` commands. Search results appear in an overlay. Useful for looking up error codes, MCP specifications, or tool documentation while debugging.
+
 The file is only looked up in the current working directory, not in parent
 directories.
 

--- a/README.md
+++ b/README.md
@@ -459,6 +459,13 @@ mcpsnoop check --fail-on error,invalid artifacts/session.jsonl
 mcpsnoop check --fail-on mismatch gateway-run.jsonl
 ```
 
+The exit code says which of two things happened, and a CI wrapper needs the
+difference. **1 means the check ran and something failed the gate**, so the
+findings are real and worth publishing. **2 means the check never happened**: a
+path that is not there, a file that is not a session log, a state directory
+holding nothing, a flag that does not parse. Nothing is written to stdout on a 2,
+so a pipeline never uploads an empty report as though it were a verdict.
+
 Beyond the signal counts, assert the shape of the run. These compose with each
 other and with `--fail-on`, and any failure exits non-zero.
 
@@ -498,13 +505,17 @@ line of the log the frame was decoded from. A signal named in `--fail-on` is
 reported at level `error` and one outside it at level `note`, so the report and
 the gate never disagree.
 
-A result points at the log with a path relative to the working directory, which
-code scanning then resolves against the repository root. The alert renders with
-its surrounding lines only when that path is a file in the analysed commit, so a
-capture the workflow generated into `artifacts/` opens an alert carrying the
-message, the rule and the line number but no source view. Committing a capture
-you want rendered in full is the only way to get one. A log read from the state
-directory or from stdin gets no path at all.
+A result points at the log the finding came from, and how depends on where the
+log was read from. A path inside the working directory becomes a relative one,
+which code scanning resolves against the repository root. Anything else, a path
+elsewhere on disk or a session id resolved out of the state directory, becomes an
+absolute `file://` URI. Reading from stdin gives a result no location at all,
+since there is no file to point at.
+
+The alert renders with its surrounding lines only when that path is a file in the
+analysed commit, so a capture the workflow generated into `artifacts/` opens an
+alert carrying the message, the rule and the line number but no source view.
+Committing a capture you want rendered in full is the only way to get one.
 
 Code scanning rejects a file whose run holds more than 25,000 results and
 displays only the top 5,000 of what it accepts, so the report is capped at 5,000:
@@ -633,10 +644,21 @@ mcpsnoop baseline --accept session.jsonl  # trust a legitimate definition change
 mcpsnoop baseline --reset session.jsonl   # trust the next complete tools/list
 ```
 
-In ephemeral CI the state directory starts empty, so the first run only records
-the baseline and reports no drift. The baseline has to persist across runs for
-later runs to verify against it. Point `--baseline` at a checked-in or cached
-directory, or set `MCPSNOOP_HOME` to a persisted path.
+In ephemeral CI the state directory starts empty, so a run has nothing to
+compare against and records the baseline instead of verifying it. **A run that
+asked to fail on drift and then verified nothing does not pass**, and says which
+directory to persist. That is the only case where recording a baseline is a
+failure: without `drift` in `--fail-on`, recording one is business as usual and
+changes no exit code.
+
+So the baseline has to survive between runs for a drift gate to mean anything.
+Point `--baseline` at a checked-in or cached directory, or set `MCPSNOOP_HOME` to
+a persisted path.
+
+```
+recorded first-seen tool baseline (trusted, not verified)
+check failed: drift
+```
 
 ```bash
 mcpsnoop check --fail-on drift --baseline .mcpsnoop/baselines session.jsonl

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Run `mcpsnoop help` for the full list, or `mcpsnoop help <command>` for the flag
 | Interactive terminal UI | no | yes |
 | Zero-config, no flags or ordering | no | yes |
 | Capability inspector | partial | yes |
-| Replay a captured call | no | yes |
+| Replay a captured call | no | yes, over stdio and over HTTP |
 | Session export (json / html / text / otlp) | no | yes |
 | Single binary, no runtime deps | no | yes |
 
@@ -723,6 +723,65 @@ mcpsnoop still changes nothing about the traffic it forwards.
 
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
+
+### Replay a call captured over HTTP
+
+`r` re-issues a captured call against a live server. For a stdio capture the
+command is in the log, so mcpsnoop launches an isolated copy and sends the
+request to that. An HTTP capture has no command to launch, and the endpoint it
+records is stripped of its userinfo and every query value, so it names the server
+without being an address to dial.
+
+So you say where a replay goes, and mcpsnoop never dials a production endpoint
+because somebody pressed a key.
+
+```bash
+mcpsnoop open --replay-target https://api.example.com/mcp session.jsonl
+mcpsnoop open --replay-target https://api.example.com/mcp \
+  --replay-header 'Authorization: Bearer sk-…' session.jsonl
+```
+
+Without `--replay-target` an HTTP session says so rather than offering a key that
+cannot work. With one, `r` still asks before the first send of a session, the
+same way a recorded command is answered for before it is run.
+
+A credential reaches the server through `--replay-header` and nowhere else.
+mcpsnoop records no `Authorization` header and replays none, so there is nothing
+captured for a replay to leak.
+
+The replayed POST carries what the transport makes mandatory, which a POST of the
+bare captured body does not: `MCP-Protocol-Version`, an `Accept` listing both
+`application/json` and `text/event-stream`, `Mcp-Method`, `Mcp-Name` where the
+spec requires it, and every captured `Mcp-Param-*`. Those are re-sent verbatim
+from the capture, base64 sentinel and all, so they cannot disagree with the body
+the way a re-derivation could. The one header that is not copied is the protocol
+version, because the replayed body declares the revision mcpsnoop speaks and the
+header has to match the body.
+
+`Mcp-Name` is derived from the body being sent rather than copied, because the
+spec sources it from `params.name` or `params.uri` and requires a server to
+reject a header that disagrees with the body, so an edit that renames the tool
+would otherwise send the old name. The `Mcp-Param-*` headers mirror the captured
+arguments, so an edited replay sends none of them rather than asserting
+something about a body somebody rewrote. A capture can only set headers in that
+one family: a log is a file people hand around, and letting it name any header
+would let it overwrite the mandatory ones or add a credential nobody passed.
+
+A `Mcp-Param-*` a redaction rule scrubbed stops the replay with a reason. Sending
+the placeholder would put mcpsnoop's own bytes on a live server as though a user
+had typed them.
+
+A redirect is refused rather than followed. The address is the one you named and
+answered for, and following a 307 would hand that choice to the far end, resending
+the body and, on a hop that only changes the port, the credential too. mcpsnoop
+reports where the server wanted to send it and lets you decide whether to name
+that one instead.
+
+An answer arriving as a single JSON object and one arriving as an event stream
+are both read, and a failure is named rather than numbered: a 401 reports the
+scheme the server demanded, a `-32020` reports what it objected to, and a
+non-JSON-RPC 400 or 404 says the address is not a Streamable HTTP endpoint of
+this revision.
 
 ### Tell the server's latency from the user's
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ more than one of each.
 
 Those are all the keys it supports.
 
+### Web Search Integration
+
+mcpsnoop includes optional You.com web search integration for researching MCP errors, tool specifications, and debugging issues directly from the TUI.
+
+**Setup**: Set your You.com API key via environment variable, flag, or config file:
+```bash
+export YOUCOM_API_KEY="your-api-key"
+# or
+mcpsnoop --youcom-api-key="your-api-key" -- your-server
+# or add to .mcpsnoop.toml:
+youcom-api-key = "your-api-key"
+```
+
+**Usage**: Press `w` in the TUI or use `:search <query>` / `:web <query>` commands. Search results appear in an overlay. Useful for looking up error codes, MCP specifications, or tool documentation while debugging.
+
 The file is only looked up in the current working directory, not in parent
 directories.
 

--- a/README.md
+++ b/README.md
@@ -724,6 +724,55 @@ mcpsnoop still changes nothing about the traffic it forwards.
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
 
+### See what a server asked your user for
+
+Elicitation is the one path in MCP where a person types data into a server, and
+under MRTR the question and the answer are no longer two halves of one exchange.
+The question is buried in an `InputRequiredResult`, the answer comes back inside
+`inputResponses` on a retry under a different id, and the only thing that ties
+them together is the link mcpsnoop already infers.
+
+Without that pairing a declined password request reads as a plain tool error.
+
+```
+tools/call login_legacy [form] creds: decline after 3s
+  password string
+```
+
+Press `l` in the TUI, or read `elicitations` in the json, text and html exports.
+Each row names the operation the question interrupted, the mode, the message,
+what was asked for, what the user did and how long they took. A question no
+retry ever answered shows as pending, which MRTR makes an ordinary outcome
+rather than an error, since the spec tells servers not to assume a client will
+retry at all.
+
+Form rows list the `requestedSchema` property names and their declared types. A
+property whose subschema a redaction rule replaced shows an unknown type rather
+than the placeholder, because a placeholder is not something the server
+declared. URL rows carry the address whole, which the spec makes a client show
+before consent, and name the host on its own, which it says to highlight against
+subdomain spoofing.
+
+**The ledger never carries a submitted value.** What a user typed stays in the
+capture for whoever needs it, and leaving it out of a summary surface built to
+be exported and pasted around is what keeps this out of the redaction story
+entirely. It matters most in url mode, where the spec puts credentials on
+purpose.
+
+A retry answers the round it was issued from and no other. MRTR tells a server
+that when a client omits some of what was asked it should ask again in a new
+round, so an earlier round holding one unanswered key beside an answered one is
+ordinary traffic, and the unanswered half stays pending rather than borrowing the
+later round's answer.
+
+One recorded question is bounded. The message, the url and the field list are
+held for the life of the session, outside the frame budget that releases bodies,
+so a server cannot make one arbitrarily expensive. The limits are far above any
+real question and a truncated message says it was truncated.
+
+Nothing here warns and nothing here changes a `check` exit code. A ledger
+records what happened; it does not judge it.
+
 ### Find the tool that fails one run in four
 
 `check` reads one session and `diff` reads exactly two, so a tool that fails

--- a/README.md
+++ b/README.md
@@ -111,6 +111,63 @@ since it names the auth scheme and the resource metadata to go to next. Filter b
 status with `status:401` in the TUI, or by any failure with `status:err`. A 4xx
 or 5xx counts as an error, so a default `mcpsnoop check` run fails on it.
 
+### Prometheus metrics
+
+Start a headless hub with an explicit metrics address to expose live tool-call
+metrics (use bare `mcpsnoop` when you want the interactive TUI):
+
+```bash
+mcpsnoop --metrics-listen 127.0.0.1:9464
+curl http://127.0.0.1:9464/metrics
+```
+
+The listener is separate from the MCP proxy listener and is disabled unless
+`--metrics-listen` is provided. Startup history replay is not counted as new live
+traffic.
+
+Every series has `server`, `server_id` and `tool` labels. `server_id` is a stable
+short fingerprint of the recorded server identity, so two servers with the same
+label remain separate without exposing commands, paths, endpoints or session IDs.
+Error counters also have `error_type`, either `tool` for `result.isError` or
+`protocol` for a JSON-RPC or other protocol-level failure.
+
+The public metrics are:
+
+| Metric | Meaning |
+|---|---|
+| `mcpsnoop_tool_calls_total` | live tool-call requests observed |
+| `mcpsnoop_tool_errors_total` | live tool errors, split by `error_type` |
+| `mcpsnoop_tool_call_duration_seconds` | request-to-response latency histogram |
+| `mcpsnoop_transport_errors_total` | live transport failures that carried no JSON-RPC message, by `status` |
+
+The histogram exports the standard `_bucket`, `_sum` and `_count` series with
+`0.005`, `0.01`, `0.025`, `0.05`, `0.1`, `0.25`, `0.5`, `1`, `2.5`, `5`, `10`
+and `+Inf` second buckets. Pending and superseded calls, and calls cancelled
+without a result, add no latency observation.
+
+**The endpoint has no authentication.** Anything that can reach the address gets
+the tool names of every server this hub is watching. The `127.0.0.1` above is
+the example for a reason. Binding `:9464` publishes those names to the network.
+
+The `tool` label comes off the wire, so it is bounded on the way in. A name over
+128 bytes is truncated, and past two thousand distinct series per hub the rest
+are counted together under `tool="(over-series-cap)"`. The totals stay right
+either way. Without those bounds a peer choosing tool names decides how much
+memory the hub uses and how large a scrape is, and one 4 MiB name measured out
+at a 71 MB response, which Prometheus drops whole.
+
+`mcpsnoop_tool_errors_total` counts errors that arrive as a JSON-RPC error or as
+`result.isError`. A failure that never became a JSON-RPC message, such as a 502
+from a gateway or a 401 challenge, cannot be attributed to a tool, because
+nothing in the response says which request it answered. Those go to
+`mcpsnoop_transport_errors_total` with the status, and the family is exported
+even when it is empty, so a graph of it on a healthy hub is flat rather than
+absent.
+
+The endpoint reports what this hub has seen since it started. It is not a store
+of record, and a hub restart starts the counters again, which Prometheus reads
+as a counter reset.
+
 No server of your own? [Try it for real](docs/TRY_IT.md) against a published
 test server, driven by your own client. To inspect a session after it happened,
 see [review past sessions from logs](docs/POST_MORTEM.md).
@@ -146,6 +203,7 @@ Explicit command-line flags override values from the config file.
 |---|---|
 | `mcpsnoop -- <server>` | wrap a stdio server as a transparent shim |
 | `mcpsnoop` | open the live TUI |
+| `mcpsnoop --metrics-listen <addr>` | run a headless hub and expose live Prometheus metrics |
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, har, or otlp |
 | `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, late results, or a latency budget |

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ server is written in.
 |---|---|---|---|---|
 | `enter` | inspect / drill in | | `/` | filter |
 | `esc` | back | | `:` | command |
-| `j` / `k` | move | | `r` | replay a call |
+| `j` / `k` | move | | `r` / `R` | replay / edit and replay |
 | `g` / `G` | top / bottom | | `c` | capabilities |
 | `ctrl-f` / `ctrl-b` | page | | `s` | tool summary |
 | `p` | pause | | `y` | copy |

--- a/README.md
+++ b/README.md
@@ -722,6 +722,28 @@ mcpsnoop still changes nothing about the traffic it forwards.
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
 
+### Tell a broken server from a tool that says no
+
+A tool answering `result.isError` is working. It looked and found nothing, or it
+rejected the input. A server answering a JSON-RPC error is broken. Both were one
+number in the tool summary, which meant a well-behaved tool that reports domain
+failures looked exactly like a broken server, and sorted above one.
+
+The `ERR` column separates them. Red is the server side, which is a JSON-RPC
+error or a task that ended failed without saying why. The warning color is the
+tool's own `isError`. A tool with both shows the counts joined, red first, and a
+line under the table names the two totals whenever there is a warn number to
+explain. The export carries the same split as `protocol_errors` and
+`tool_errors` beside the `errors` total they always add up to.
+
+`check --fail-on error` is unchanged and still fires on either, since a gate
+that ignored one of them would be a gate a server could switch off by returning
+the other.
+
+```bash
+mcpsnoop export -T json | jq '.summary.tools[] | {name, errors, protocol_errors, tool_errors}'
+```
+
 ### See what the server costs you in context
 
 Tool definitions enter the model's context on every conversation, and tool
@@ -787,6 +809,25 @@ One case is out of reach. When a server answers with a `requestState` and no
 `inputRequests`, a tampered retry matches nothing and answers no keys, so there
 is nothing left to tie it to the original request and it reads as an unrelated
 call rather than a violation.
+
+An abandoned exchange does not disturb the next one, and is not kept forever
+either. Sixty-four open exchanges is far more than any client has at once, so a
+session holding more is holding ones nobody will finish, and the oldest are
+retired because the spec tells servers to give that state a short expiry and
+reject it afterwards. Retiring is counted rather than silent: the stream footer
+shows `N unlinked` and the export carries `session.retired_exchanges`, because a
+retry that does arrive for a retired operation reads as its own call, and a
+reader comparing counts deserves to be told.
+
+An abandoned exchange does not disturb the next one. MRTR tells servers they
+must not assume a client will ever retry, so a user declining an elicitation
+leaves an operation that no later frame will ever settle. mcpsnoop looks first
+among the operations whose `requestState` presence agrees with the retry's,
+which the spec makes a rule in both directions, so a conforming retry still
+finds the one operation it continues even when an abandoned exchange on the same
+tool is sitting beside it. The check that reports the three violations above
+runs only when nothing agrees, so a genuinely non-conforming retry is still
+named.
 
 ## Watching from another machine
 
@@ -866,6 +907,15 @@ the same key set is applied best effort to the wrapped server's command-line
 arguments, so `--api-key=sk-x` and `--token sk-x` are scrubbed under
 `--redact-secrets`. An argument that carries a secret without a recognizable flag
 name cannot be detected.
+
+The HTTP endpoint is not part of any of that, because it is not a payload you
+chose to send. `--target` is a flag you have to pass to run the proxy at all, so
+its URL would reach the session log whatever your redaction settings are.
+mcpsnoop writes it down with the userinfo, every query value and the fragment
+already removed, always, by construction rather than by pattern. Query keys
+survive, since they are what tells two endpoints of one host apart, and the
+fragment is dropped because it never reached the server to begin with. What is
+recorded identifies the server and is not an address to dial.
 
 Path-based redaction replaces only values selected by a JSONPath expression,
 which is useful when a common key name is sensitive in one location but safe in

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop diff` | compare tools and calls across two captured sessions |
 | `mcpsnoop open` | open a saved session in the TUI |
 | `mcpsnoop inventory` | list every server that has run through mcpsnoop on this machine |
+| `mcpsnoop stats` | fold every stored capture into one row per server and tool |
 | `mcpsnoop prune` | delete saved session logs older than a cutoff |
 | `mcpsnoop wrap <server>` | route one of Claude Desktop's servers through mcpsnoop |
 | `mcpsnoop unwrap <server>` | put that server's entry back the way it was |
@@ -722,6 +723,66 @@ mcpsnoop still changes nothing about the traffic it forwards.
 
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
+
+### Find the tool that fails one run in four
+
+`check` reads one session and `diff` reads exactly two, so a tool that fails
+occasionally stays invisible until somebody opens the captures by hand. Over
+sixteen captures of a server whose `run_query` answers `isError` about a quarter
+of the time, `check` reports the newest one, honestly, as clean.
+
+```bash
+mcpsnoop stats
+mcpsnoop stats --since 7d --label prod
+mcpsnoop stats --limit 20 --format json
+```
+
+```
+read 16 logs of 16 in ~/.local/state/mcpsnoop/sessions
+
+SERVER       TOOL          CALLS   ERR  PROTO    FAIL%       SESS       p50      p95      p99      DEF
+flaky-demo   run_query        13     3      0    23.1%       3/13     434ms    519ms    519ms     195B
+docs-mirror  run_query         3     1      0    33.3%        1/3     357ms    434ms    434ms     195B
+docs-mirror  search_docs      12     0      0     0.0%        0/3     377ms    386ms    386ms     200B
+flaky-demo   search_docs      52     0      0     0.0%       0/13      42ms     58ms      59ms    200B
+```
+
+`ERR` and `PROTO` are separate columns because the specification makes them
+separate things. A tool answering `isError` is reporting something a model can
+act on and retry; a JSON-RPC error is the request or the server being wrong.
+`SESS` is the count of sessions that saw a failure over the sessions that called
+the tool, which is the "one run in ten" question a rate over calls cannot
+answer.
+
+Rows key on the server and the label together. The server is the recorded
+command and working directory for stdio and the endpoint for HTTP, the same
+identity `inventory` uses. Either half alone pools something it should not: the
+label alone merges two servers that derive one name, which happens whenever two
+checkouts of a project run the same entry point, and the identity alone merges
+one command deliberately run as `prod` and again as `staging`. Both mistakes
+smear two clean distributions into one that describes neither.
+
+When two rows do share a label, the `SERVER` cell carries the working directory
+or endpoint that tells them apart, and the JSON carries `command`, `cwd` and
+`endpoint` on every row. A name that was never ambiguous is left alone, so the
+ordinary table is unchanged.
+
+Every session in a log is folded, not just the first, so a file made by
+concatenating captures counts all of them.
+
+Percentiles are pooled over the raw durations. A median of medians is a median
+of nothing. One multi round-trip operation is one call with one duration however
+many requests it took, and a call still open counts toward `CALLS` while
+contributing no latency.
+
+One capture is resident at a time. A log is loaded, folded into the running
+counters, and dropped before the next one opens, so a directory of hundreds
+costs the largest single capture rather than their sum.
+
+`--limit` defaults to a hundred of the newest logs and the header says how many
+of how many were read, so a bounded answer never passes for a complete one.
+`stats` reports and does not gate: it writes nothing, touches no baseline, opens
+no socket, and exits 0 whenever the walk succeeded.
 
 ### See which servers have actually run here
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop baseline` | inspect, accept, or reset trusted tool definitions |
 | `mcpsnoop diff` | compare tools and calls across two captured sessions |
 | `mcpsnoop open` | open a saved session in the TUI |
+| `mcpsnoop inventory` | list every server that has run through mcpsnoop on this machine |
 | `mcpsnoop prune` | delete saved session logs older than a cutoff |
 | `mcpsnoop wrap <server>` | route one of Claude Desktop's servers through mcpsnoop |
 | `mcpsnoop unwrap <server>` | put that server's entry back the way it was |
@@ -721,6 +722,66 @@ mcpsnoop still changes nothing about the traffic it forwards.
 
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
+
+### See which servers have actually run here
+
+The finding people keep repeating about Shadow MCP is that organisations
+discover several times more MCP servers running than anyone approved, because a
+server is often just a dependency somebody added to an IDE plugin. The same
+thing happens in miniature on one laptop, and mcpsnoop has been recording the
+answer the whole time without ever showing it.
+
+```bash
+mcpsnoop inventory
+mcpsnoop inventory --tools          # also count what each server last advertised
+mcpsnoop inventory --format json    # for something else to read
+```
+
+One row per server rather than per session. The row key is the recorded command
+and working directory, never the label, because the label comes from the
+command's last path element and `node ~/one/build/index.js` and
+`node ~/two/build/index.js` both derive `index.js`. An HTTP session keys on the
+endpoint it proxied instead, since mcpsnoop launched nothing there.
+
+Reading is one envelope per log, the meta frame the proxy writes first, so this
+stays cheap over a directory of large captures. `--tools` is the exception and
+reads one log per server, the most recent run of each, which is why it is a flag
+rather than a column. Even then the read is bounded, because a tool inventory is
+session state the store folds in as it goes, so a hundred-megabyte capture is
+read through a fixed window rather than held whole to produce one integer.
+
+When there is no count the row says which of three things happened, because a
+log that could not be read is not a server that advertised nothing, and one
+sentence for both would make mcpsnoop state something false.
+
+A command a `--redact` rule rewrote is printed as recorded and marked, rather
+than passed off as the command that ran. Two runs of one server, one scrubbed
+and one not, are two rows: mcpsnoop cannot know what the placeholder replaced,
+and merging them would mean guessing the hidden halves matched. One server run
+under two `--label` values is one row carrying both names, since the key is the
+command rather than the name.
+
+Nothing in a row is written by mcpsnoop. A command comes from whoever installed
+the server, a working directory comes off the filesystem, and a derived label
+comes from the command. A value holding a control character is quoted rather
+than printed raw, so a directory whose name contains a newline cannot close the
+field it is printed in and make the following lines read as servers that never
+ran. An argument containing a space is quoted too, because `node "~/My Project/
+build/index.js"` is otherwise indistinguishable from two arguments.
+
+Anything the walk could not fold in is named in the header rather than dropped.
+Empty logs are counted apart from damaged ones, since a zero-byte log is the
+ordinary residue of a run whose exec failed or of an HTTP proxy nobody called.
+
+Output is sorted by name rather than by recency so two runs over one directory
+produce the same bytes, which is what makes it usable as a baseline to diff
+against later.
+
+Two gaps are there by construction rather than by oversight. A run with
+`--trace-file` wrote outside the sessions directory and will not appear, and
+`prune` deletes logs, so first seen is only ever as old as what is still on
+disk. mcpsnoop reports what ran on this machine through it; it scans no network,
+reads no client config it was not pointed at, and judges nothing.
 
 ### Tell a broken server from a tool that says no
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ Run `mcpsnoop help` for the full list, or `mcpsnoop help <command>` for the flag
 
 ## Install
 
+### npm
+
+No Go toolchain needed. Most MCP servers are written in Node or Python, so this
+is the shortest way in.
+
+```bash
+npx mcpsnoop -- node build/index.js
+```
+
+The npm package ships no code of its own. Six platform packages each carry one
+build, and npm installs the single one that matches your machine, so there is
+nothing to download at install time and nothing to unblock in a proxy. To keep it
+around rather than fetching it each run, `npm i -g mcpsnoop`.
+
 ### Go
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -196,6 +196,27 @@ another limit, or `mcpsnoop --history-limit 0` to load the full history. Older
 sessions remain available through `mcpsnoop open <session-id>` and
 `mcpsnoop export <session-id>`.
 
+The history limit bounds how many sessions are loaded. Inside a session, the live
+TUI is bounded twice over, because a hub left watching a chatty server otherwise
+grows until it is killed. It keeps at most 64 MiB of frame bodies, releasing the
+oldest first, and at most 200,000 frames, dropping the oldest entirely past that.
+The first bound is what a capture of large payloads runs into and the second what
+a long stream of small notifications does.
+
+Neither bound changes an answer. A frame whose body was released keeps its row,
+its verdict and its place in the timeline, and its inspector says the body is
+gone rather than showing an empty frame. A frame that was dropped outright takes
+its tool call's statistics with it into the running totals first, so the tool
+summary and what the server costs you in context describe every call the session
+made, not only the recent ones. The stream footer says how many older frames are
+on disk only, and `r` refuses a frame whose params it no longer holds rather than
+replaying something else.
+
+`mcpsnoop open <session-id>` reads the log and holds all of it, and exporting
+from the TUI reads the log too, so neither is bounded. `check`, `export` and
+`diff` build an unbounded store on purpose, since a gate that under-reports on a
+large capture is worse than one that uses the memory.
+
 The history limit bounds what is loaded; `mcpsnoop prune` bounds what is kept.
 It deletes saved session logs older than a cutoff, and never runs on its own.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ steps:
       session: artifacts/session.jsonl
 ```
 
-Pin whichever release you want; the newest is on the
+Pin whichever release you want. The newest is on the
 [releases page](https://github.com/kerlenton/mcpsnoop/releases). Every input,
 what the exit codes mean, and how to wire it up without the action are in
 [The GitHub Action](#the-github-action) further down.
@@ -106,11 +106,10 @@ mcpsnoop http --target http://localhost:3000/mcp --listen :7000
 The HTTP status of every response shows in the stream, so a response that carries
 no JSON-RPC message of its own is still a visible frame rather than nothing: the
 401 challenge, the 403 on a rejected Origin, the 202 that acknowledges a
-notification, and the 502 when the target cannot be reached at all. A 401's
-`WWW-Authenticate` header is kept verbatim and shown in the inspector, since it
-names the auth scheme and the resource metadata to go to next. Filter by status
-with `status:401` in the TUI, or by any failure with `status:err`. A 4xx or 5xx
-counts as an error, so a default `mcpsnoop check` run fails on it.
+notification, and the 502 when the target cannot be reached at all. A 401's `WWW-Authenticate` header is kept verbatim and shown in the inspector,
+since it names the auth scheme and the resource metadata to go to next. Filter by
+status with `status:401` in the TUI, or by any failure with `status:err`. A 4xx
+or 5xx counts as an error, so a default `mcpsnoop check` run fails on it.
 
 No server of your own? [Try it for real](docs/TRY_IT.md) against a published
 test server, driven by your own client. To inspect a session after it happened,
@@ -256,7 +255,7 @@ from the TUI reads the log too, so neither is bounded. `check`, `export` and
 `diff` build an unbounded store on purpose, since a gate that under-reports on a
 large capture is worse than one that uses the memory.
 
-The history limit bounds what is loaded; `mcpsnoop prune` bounds what is kept.
+The history limit bounds what is loaded. `mcpsnoop prune` bounds what is kept.
 It deletes saved session logs older than a cutoff, and never runs on its own.
 
 ```bash
@@ -334,7 +333,7 @@ mcpsnoop export -T json|html|text|har|otlp [-o file|-] [session-id|log.jsonl|-]
 | `html` | a self-contained browser file with search and collapsible JSON |
 | `text` | a pretty plain-text dump |
 | `har` | one entry per correlated call, openable in browser devtools and anything else that reads HAR |
-| `otlp` | OTLP JSON with a span per correlated call; W3C trace context joins caller traces, otherwise one trace is used per session |
+| `otlp` | OTLP JSON with a span per correlated call, with W3C trace context joining caller traces where it is present and one trace per session otherwise |
 
 MCP is not HTTP, so a HAR entry's URL, status code, and timings are a deliberate
 mapping of each call rather than a wire transcript.
@@ -357,6 +356,8 @@ Omit `-o` to write to stdout, and omit the session to take the newest, or pass
 `-` to read JSONL from stdin. In the TUI, press `e` to export the selected
 session as HTML, or run `:export json|html|text|har|otlp [path]` from command mode.
 
+### Redaction
+
 To scrub an existing capture before inspecting or sharing it, pass the same
 redaction flags used during capture to `export` or `open`:
 
@@ -371,21 +372,25 @@ and writes through a temporary file that is renamed into place, so a run that
 fails leaves the previous file whole.
 
 A tool's `inputSchema` and `outputSchema`, as advertised in a `tools/list`
-result, are left alone by `--redact-key` and `--redact-secrets`. A name inside a
-schema is a type declaration rather than a value, the name itself stays in the
-log either way, and scrubbing the subschema under a property called `token`
-would take the tool's own checks with it. The exemption is that position only,
-so an argument that happens to be called `inputSchema` is scrubbed like any
-other, and it stops at `default`, `const`, `examples` and `enum`, which hold
-data rather than structure. Use `--redact-path` to name something inside a
-schema, or `--redact-value`, which matches text wherever it sits except in the
-two keywords mcpsnoop parses, `type` and `x-mcp-header`.
+result, are left alone by `--redact-key` and `--redact-secrets`, for three reasons.
+
+- A name inside a schema is a type declaration rather than a value.
+- The name itself stays in the log either way.
+- Scrubbing the subschema under a property called `token` would take the tool's
+  own checks with it.
+
+The exemption is that position only, so an argument that happens to be called
+`inputSchema` is scrubbed like any other, and it stops at `default`, `const`,
+`examples` and `enum`, which hold data rather than structure. Use
+`--redact-path` to name something inside a schema, or `--redact-value`, which
+matches text wherever it sits except in the two keywords mcpsnoop parses, `type`
+and `x-mcp-header`.
 
 What each flag reaches differs, so check the result rather than assuming. All
 four scrub JSON-RPC payloads, and `--redact-key`, `--redact-path` and
 `--redact-secrets` reach only those. Only `--redact-value` also scrubs stderr,
 other non-JSON text, and the inside of a string. An `Mcp-Param-*` header is
-scrubbed alongside the body value it mirrors; the other envelope metadata,
+scrubbed alongside the body value it mirrors. The other envelope metadata,
 server labels, `Mcp-Name`, `Mcp-Method` and the HTTP status, is left as
 captured. Redaction is best effort, so use a separate output path and read the
 result before sharing it.
@@ -424,14 +429,20 @@ mcpsnoop diff old.jsonl new.jsonl
 The report shows tools that were added or removed, description and `inputSchema`
 changes, matching tool calls whose status changed, and notable duration shifts. Calls
 are matched by tool name and arguments, so reordered calls still compare correctly.
-By default, duration changes must differ by at least 100 ms and 2x; use
+By default, duration changes must differ by at least 100 ms and 2x. Use
 `--duration-threshold` and `--duration-ratio` to adjust those cutoffs.
 
-Pass `--exit-code` to gate CI on regressions: it exits non-zero when the after
-session drops a tool, changes a tool description, title, input schema, output
-schema or annotations, has a call whose status got worse, or slows down.
-Improvements (added tools, fixed calls, speedups) still exit zero, and so does an
-icon change, which alters how a tool looks without changing what it does.
+Pass `--exit-code` to gate CI on regressions. It exits non-zero when the after
+session:
+
+- drops a tool
+- changes a tool description, title, input schema, output schema or annotations
+- has a call whose status got worse
+- slows down
+
+An icon change does not, since it alters how a tool looks without changing what
+it does. Improvements, meaning added tools, fixed calls and speedups, still exit
+zero.
 
 ## Checking sessions in CI
 
@@ -472,9 +483,11 @@ check failed: error
 ```
 
 The dropped-frame count travels with the artifacts too, so a capture that
-understates itself says so wherever it is opened: `missing_frames` in the JSON
-export, `log.comment` in HAR, and the `mcpsnoop.session.missing_frames` resource
-attribute in OTLP.
+understates itself says so wherever it is opened:
+
+- `missing_frames` in the JSON export
+- `log.comment` in HAR
+- the `mcpsnoop.session.missing_frames` resource attribute in OTLP
 
 ```bash
 mcpsnoop check build-agent
@@ -489,12 +502,15 @@ path that is not there, a file that is not a session log, a state directory
 holding nothing, a flag that does not parse. Nothing is written to stdout on a 2,
 so a pipeline never uploads an empty report as though it were a verdict.
 
+### Assert what must and must not happen
+
 Beyond the signal counts, assert the shape of the run. These compose with each
-other and with `--fail-on`, and any failure exits non-zero.
+other and with `--fail-on`, and any failure exits 1, the code that means the
+check ran and found something.
 
 | Flag | Fails when |
 |---|---|
-| `--max-duration <dur>` | one or more completed tool calls exceeded the budget; reports their count and the worst call |
+| `--max-duration <dur>` | one or more completed tool calls exceeded the budget, reporting their count and the worst call |
 | `--expect-tool <name>` | the named tool was never called (repeatable) |
 | `--forbid-tool <name>` | the named tool was called (repeatable) |
 
@@ -529,11 +545,14 @@ reported at level `error` and one outside it at level `note`, so the report and
 the gate never disagree.
 
 A result points at the log the finding came from, and how depends on where the
-log was read from. A path inside the working directory becomes a relative one,
-which code scanning resolves against the repository root. Anything else, a path
-elsewhere on disk or a session id resolved out of the state directory, becomes an
-absolute `file://` URI. Reading from stdin gives a result no location at all,
-since there is no file to point at.
+log was read from.
+
+- A path inside the working directory becomes a relative one, which code
+  scanning resolves against the repository root.
+- A path elsewhere on disk, or a session id resolved out of the state
+  directory, becomes an absolute `file://` URI.
+- Reading from stdin gives a result no location at all, since there is no file
+  to point at.
 
 The alert renders with its surrounding lines only when that path is a file in the
 analysed commit, so a capture the workflow generated into `artifacts/` opens an
@@ -562,9 +581,9 @@ steps:
       session: artifacts/session.jsonl
 ```
 
-Pin a release, whichever one you want; the newest is on the
+Pin a release, whichever one you want. The newest is on the
 [releases page](https://github.com/kerlenton/mcpsnoop/releases). There is no
-floating `v1`, deliberately: the pinned release is also the binary the action
+floating `v1`, deliberately. The pinned release is also the binary the action
 installs, so the two can never disagree and there is no version default to go
 stale.
 
@@ -580,7 +599,7 @@ stale.
 | `install` | `false` when mcpsnoop is already on PATH, which is the way in on a platform no release is built for |
 
 Outputs are `outcome`, `sarif` and `exit-code`. `outcome` is `passed`,
-`findings`, or `error`, and the third is worth handling separately: it means
+`findings`, or `error`, and the third is worth handling separately. It means
 nothing was checked, which is not the same as nothing being found. **A run that
 could not check fails the job whatever `fail-on-findings` says**, because a
 pipeline that goes green having verified nothing is worse than one that fails.
@@ -658,7 +677,7 @@ itself is never reported as a disagreement.
 
 The routing headers above were the only ones a frame carried, so the rest of the
 Streamable HTTP transport's mandatory headers reached nothing that could check
-them. `Content-Type` was the sharpest case: the response side already read it to
+them. `Content-Type` was the sharpest case. The response side already read it to
 tell an SSE stream from a JSON body, then threw it away.
 
 An HTTP frame now carries the headers the transport states rules about, and two
@@ -666,12 +685,12 @@ of those rules are checkable.
 
 | Rule | Reported as |
 |---|---|
-| the client **MUST** send an `Accept` listing both `application/json` and `text/event-stream` | `warn` on the request |
-| a server answering a JSON-RPC request **MUST** return `Content-Type: application/json` or `text/event-stream` | `warn` on the response |
+| the client MUST send an `Accept` listing both `application/json` and `text/event-stream` | `warn` on the request |
+| a server answering a JSON-RPC request MUST return `Content-Type: application/json` or `text/event-stream` | `warn` on the response |
 
 Both sentences read the same in 2025-11-25 and 2026-07-28, so unlike the drift
 and extension checks these need no revision gate. `Origin` is recorded too, since
-servers **MUST** validate it and **MUST** answer `403` when it is invalid, but
+servers MUST validate it and MUST answer `403` when it is invalid, but
 mcpsnoop cannot know your allowed origins so it shows the value rather than
 judging it.
 
@@ -683,25 +702,34 @@ them at all.
 
 `Authorization` is deliberately not captured. Turning a challenge into token
 facts is its own problem and putting a bearer token on disk is not the answer to
-it. `Mcp-Session-Id` and `Last-Event-ID` are not captured either: 2026-07-28
-removed both and tells a server to ignore them, so there is no rule left to check.
+it. `Mcp-Session-Id` and `Last-Event-ID` are not captured either. The
+2026-07-28 revision removed both and tells a server to ignore them, so there is
+no rule left to check.
 
 ### Detect tool definition drift
 
 The first complete `tools/list` observed for a server label becomes its trusted
-baseline. Later sessions compare that baseline field by field: the description,
-the title, the input and output schemas, the annotations and the icons, plus
-tools that were added or removed. Annotations matter most, since a tool approved
-with `readOnlyHint` that later declares itself destructive is the rug-pull this
-check exists for, and the spec tells clients to treat annotations as untrusted.
-The title and the icons are tracked because they are what the user sees, and the
-spec ranks a tool's `title` above `annotations.title` and its name. The sessions
-table and tool summary flag drift without blocking or changing MCP traffic.
+baseline. Later sessions compare that baseline field by field:
+
+- the description
+- the title
+- the input and output schemas
+- the annotations and the icons
+
+Tools that were added or removed are compared too, which is a set comparison
+rather than a field one.
+
+Annotations matter most, since a tool approved with `readOnlyHint` that later
+declares itself destructive is the rug-pull this check exists for, and the spec
+tells clients to treat annotations as untrusted. The title and the icons are
+tracked because they are what the user sees, and the spec ranks a tool's `title`
+above `annotations.title` and its name. The sessions table and tool summary flag
+drift without blocking or changing MCP traffic.
 
 Annotations are compared through their spec defaults, so a server that starts
 spelling out a hint it was already relying on is not reported. A baseline
 recorded before mcpsnoop tracked a field keeps working for the fields it does
-record and says which ones it cannot answer for; re-record with
+record and says which ones it cannot answer for. Re-record with
 `mcpsnoop baseline --accept` once you trust the current definitions.
 
 Changing what redaction records changes what drift compares. A baseline taken
@@ -725,7 +753,7 @@ In ephemeral CI the state directory starts empty, so a run has nothing to
 compare against and records the baseline instead of verifying it. **A run that
 asked to fail on drift and then verified nothing does not pass**, and says which
 directory to persist. That is the only case where recording a baseline is a
-failure: without `drift` in `--fail-on`, recording one is business as usual and
+failure. Without `drift` in `--fail-on`, recording one is business as usual and
 changes no exit code.
 
 So the baseline has to survive between runs for a drift gate to mean anything.
@@ -741,7 +769,7 @@ check failed: drift
 mcpsnoop check --fail-on drift --baseline .mcpsnoop/baselines session.jsonl
 ```
 
-`drift` is opt-in for `check`; the default `error,invalid,warn` gate is unchanged.
+`drift` is opt-in for `check`. The default `error,invalid,warn` gate is unchanged.
 
 ### Catch a feature neither side negotiated
 
@@ -751,7 +779,7 @@ them, so on 2026-07-28 a `tasks/get`, a `notifications/tasks` or a `tools/call`
 answered with a task handle only means anything when the other side said it
 speaks Tasks.
 
-When it did not, the spec is explicit: the supporting party **MUST** either fall
+When it did not, the spec is explicit: the supporting party MUST either fall
 back to core behaviour or reject the request. Doing it anyway is why a feature
 appears to be wired up and then quietly does nothing, and what a reader gets
 instead is a `-32601` or a `-32021` several frames later, or a task that never
@@ -877,7 +905,7 @@ reject a header that disagrees with the body, so an edit that renames the tool
 would otherwise send the old name. The `Mcp-Param-*` headers mirror the captured
 arguments, so an edited replay sends none of them rather than asserting
 something about a body somebody rewrote. A capture can only set headers in that
-one family: a log is a file people hand around, and letting it name any header
+one family. A log is a file people hand around, and letting it name any header
 would let it overwrite the mandatory ones or add a credential nobody passed.
 
 A `Mcp-Param-*` a redaction rule scrubbed stops the replay with a reason. Sending
@@ -891,10 +919,12 @@ reports where the server wanted to send it and lets you decide whether to name
 that one instead.
 
 An answer arriving as a single JSON object and one arriving as an event stream
-are both read, and a failure is named rather than numbered: a 401 reports the
-scheme the server demanded, a `-32020` reports what it objected to, and a
-non-JSON-RPC 400 or 404 says the address is not a Streamable HTTP endpoint of
-this revision.
+are both read, and a failure is named rather than numbered:
+
+- a 401 reports the scheme the server demanded
+- a `-32020` reports what it objected to
+- a non-JSON-RPC 400 or 404 says the address is not a Streamable HTTP endpoint
+  of this revision
 
 ### Tell the server's latency from the user's
 
@@ -984,7 +1014,7 @@ declared. URL rows carry the address whole, which the spec makes a client show
 before consent, and name the host on its own, which it says to highlight against
 subdomain spoofing.
 
-**The ledger never carries a submitted value.** What a user typed stays in the
+The ledger never carries a submitted value. What a user typed stays in the
 capture for whoever needs it, and leaving it out of a summary surface built to
 be exported and pasted around is what keeps this out of the redaction story
 entirely. It matters most in url mode, where the spec puts credentials on
@@ -1002,7 +1032,7 @@ so a server cannot make one arbitrarily expensive. The limits are far above any
 real question and a truncated message says it was truncated.
 
 Nothing here warns and nothing here changes a `check` exit code. A ledger
-records what happened; it does not judge it.
+records what happened. It does not judge it.
 
 ### Find the tool that fails one run in four
 
@@ -1029,7 +1059,7 @@ flaky-demo   search_docs      52     0      0     0.0%       0/13      42ms     
 
 `ERR` and `PROTO` are separate columns because the specification makes them
 separate things. A tool answering `isError` is reporting something a model can
-act on and retry; a JSON-RPC error is the request or the server being wrong.
+act on and retry. A JSON-RPC error is the request or the server being wrong.
 `SESS` is the count of sessions that saw a failure over the sessions that called
 the tool, which is the "one run in ten" question a rate over calls cannot
 answer.
@@ -1097,7 +1127,7 @@ sentence for both would make mcpsnoop state something false.
 
 A command a `--redact` rule rewrote is printed as recorded and marked, rather
 than passed off as the command that ran. Two runs of one server, one scrubbed
-and one not, are two rows: mcpsnoop cannot know what the placeholder replaced,
+and one not, are two rows. mcpsnoop cannot know what the placeholder replaced,
 and merging them would mean guessing the hidden halves matched. One server run
 under two `--label` values is one row carrying both names, since the key is the
 command rather than the name.
@@ -1121,7 +1151,7 @@ against later.
 Two gaps are there by construction rather than by oversight. A run with
 `--trace-file` wrote outside the sessions directory and will not appear, and
 `prune` deletes logs, so first seen is only ever as old as what is still on
-disk. mcpsnoop reports what ran on this machine through it; it scans no network,
+disk. mcpsnoop reports what ran on this machine through it. It scans no network,
 reads no client config it was not pointed at, and judges nothing.
 
 ### Tell a broken server from a tool that says no
@@ -1155,8 +1185,8 @@ you actually captured.
 The `definitions` line is the fixed cost: what this server's `tools/list`
 weighs before a single call is made. The `DEF` column breaks that down per
 tool and `RESULT` is what each tool's answers have cost so far. The table stays
-sorted by errors and latency, so scan `DEF` to find the expensive definitions;
-the export lists them heaviest first. A line under the table names the single
+sorted by errors and latency, so scan `DEF` to find the expensive definitions.
+The export lists them heaviest first. A line under the table names the single
 heaviest result, which a total hides.
 
 Definition figures are the JSON with insignificant whitespace removed, so a
@@ -1172,10 +1202,10 @@ mcpsnoop export -T json | jq '.summary.definitions'
 The export carries the same figures, per tool and split into description and
 schema bytes, so a fat description and a fat schema stay separable and either
 can be tracked across captures. `mcpsnoop diff` tells you a description or
-schema changed between two sessions; the export is where the size of that
+schema changed between two sessions. The export is where the size of that
 change lives.
 
-These are **bytes, not tokens**. A token count depends on the model, so
+**These are bytes, not tokens.** A token count depends on the model, so
 measuring one would mean shipping a tokeniser and picking whose. Bytes are
 exact and you can apply your own ratio. An unfinished `tools/list` reports what
 it saw as a floor and says so, rather than passing a partial sum off as the
@@ -1216,7 +1246,7 @@ An abandoned exchange does not disturb the next one, and is not kept forever
 either. Sixty-four open exchanges is far more than any client has at once, so a
 session holding more is holding ones nobody will finish, and the oldest are
 retired because the spec tells servers to give that state a short expiry and
-reject it afterwards. Retiring is counted rather than silent: the stream footer
+reject it afterwards. Retiring is counted rather than silent. The stream footer
 shows `N unlinked` and the export carries `session.retired_exchanges`, because a
 retry that does arrive for a retired operation reads as its own call, and a
 reader comparing counts deserves to be told.
@@ -1308,6 +1338,12 @@ mcpsnoop runs the server command you wrap, so only wrap servers you trust, and
 run untrusted ones in a container. It never executes anything you didn't put in
 your client config.
 
+For remote workflows, use SSH tunnelling or SSH file transfer so transport auth,
+encryption, host verification, key rotation, and audit policy stay in your
+existing SSH setup.
+
+### Redacting what you capture
+
 Captured frames can include prompts, tool arguments, credentials, and tool
 results. If payloads can carry secrets, opt in to redaction to scrub the
 observed trace copies while the proxied bytes still pass through unchanged.
@@ -1365,10 +1401,6 @@ mcpsnoop --redact-value 'sk-[A-Za-z0-9]+' -- node build/index.js
 # combine the layers in http mode
 mcpsnoop http --target http://localhost:3000/mcp --redact-secrets --redact-value 'Bearer\s+\S+'
 ```
-
-For remote workflows, use SSH tunnelling or SSH file transfer so transport auth,
-encryption, host verification, key rotation, and audit policy stay in your
-existing SSH setup.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ between your AI client and your MCP servers, live in your terminal.
 [![CI](https://github.com/kerlenton/mcpsnoop/actions/workflows/ci.yml/badge.svg)](https://github.com/kerlenton/mcpsnoop/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/kerlenton/mcpsnoop.svg)](https://pkg.go.dev/github.com/kerlenton/mcpsnoop)
 [![MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![Marketplace](https://img.shields.io/badge/marketplace-mcpsnoop-blue?logo=github)](https://github.com/marketplace/actions/mcpsnoop)
 
 <p align="center">
   <img src="docs/demo.gif" alt="mcpsnoop demo">
@@ -24,6 +25,26 @@ call just hangs, you're left digging through logs and guessing.
 
 **mcpsnoop sits in the real data path instead.** Wrap your server command with
 it and watch every JSON-RPC frame live, as your real client and server talk.
+
+## In CI
+
+This page is also the listing for the [mcpsnoop GitHub Action](https://github.com/marketplace/actions/mcpsnoop),
+so here is the whole of it. It checks a captured session, files every finding as
+a code scanning alert, and fails the job on what you gated on.
+
+```yaml
+permissions:
+  security-events: write
+  contents: read
+
+steps:
+  - uses: kerlenton/mcpsnoop@v0.21.0
+    with:
+      session: artifacts/session.jsonl
+```
+
+Every input, what the exit codes mean, and how to wire it up without the action
+are in [The GitHub Action](#the-github-action) further down.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop` | open the live TUI |
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, har, or otlp |
-| `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, or late results |
+| `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, late results, or a latency budget |
 | `mcpsnoop baseline` | inspect, accept, or reset trusted tool definitions |
 | `mcpsnoop diff` | compare tools and calls across two captured sessions |
 | `mcpsnoop open` | open a saved session in the TUI |
@@ -723,6 +723,65 @@ mcpsnoop still changes nothing about the traffic it forwards.
 
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
+
+### Tell the server's latency from the user's
+
+Under multi round-trip requests one tool call is several requests, and the
+seconds a person spent answering an elicitation sit inside the span. That is
+deliberate, since that interval is usually the one you most want to see, but it
+means one number cannot answer both questions.
+
+On a `book_flight` chain where the server worked 1.2 seconds while the user took
+37, `check --max-duration 5s` blames the tool for 38.2 seconds. It still does,
+because changing what that flag means would loosen every pipeline that already
+sets it. Two siblings name what they measure instead.
+
+```bash
+mcpsnoop check --max-server-duration 1s session.jsonl   # the server's share alone
+mcpsnoop check --max-round-trips 2 session.jsonl        # how chatty a tool is
+```
+
+```
+assertion failed: 1 tool call exceeded the 1s server budget (worst: tool "book_flight" held for 1.2s)
+assertion failed: 1 tool call exceeded the 2 round trip budget (worst: tool "book_flight" took 3)
+```
+
+Both are off by default, so a default `check` run is unaffected, and both are
+read off frame timestamps and a link mcpsnoop already inferred, so neither
+guesses at intent.
+
+Press `i` in the TUI for the breakdown, or read `interactions` in the json,
+text and html exports. Each entry is one logical operation with its round trip
+count, its total, the share the server held it for and the share it was waiting
+on the client, plus a per-hop line naming what each answer asked for. The
+per-tool summary gains a `TRIPS` column so a chatty tool is visible without
+opening anything.
+
+`export --format har` puts the server's share in `wait` and the rest in
+`blocked`, which is what that field is for, so a viewer stops drawing a 38-second
+server wait that never happened.
+
+The counts and the two shares are accumulated as frames arrive rather than
+derived when you ask, because the live store releases old frames to stay inside
+its budget and a derived answer would quietly be a window instead of a chain.
+The per-hop breakdown is read from the frames still held, and says so when it is
+only part of one. `ServerTime + ClientTurnaround` equals the total by
+construction rather than by arithmetic anyone has to trust.
+
+`--max-round-trips` judges a chain that is still running, because every request
+it has already made is countable and a server asking again and again produces
+exactly the operation nobody ever finishes. `--max-server-duration` waits for an
+ending, which is the rule `--max-duration` already applies, since an operation
+still open has no latency to judge.
+
+An operation mcpsnoop could not link stays its own single-hop entry. `matchRetry`
+refuses an ambiguous link on purpose, and this view does not fill that gap in.
+
+An operation that took one request carries no hop breakdown, because a single
+hop restates the totals above it word for word. A chain reports one hop per
+request, and says so when the store no longer holds every frame or when work
+settled off the request and answer pair a hop is made of, which a task handle
+does.
 
 ### See what a server asked your user for
 

--- a/README.md
+++ b/README.md
@@ -550,6 +550,38 @@ definition stay observational. Key- and value-based redaction applies to capture
 parameter-header values before they reach a sink, and a value mcpsnoop scrubbed
 itself is never reported as a disagreement.
 
+### Check the transport headers the spec makes mandatory
+
+The routing headers above were the only ones a frame carried, so the rest of the
+Streamable HTTP transport's mandatory headers reached nothing that could check
+them. `Content-Type` was the sharpest case: the response side already read it to
+tell an SSE stream from a JSON body, then threw it away.
+
+An HTTP frame now carries the headers the transport states rules about, and two
+of those rules are checkable.
+
+| Rule | Reported as |
+|---|---|
+| the client **MUST** send an `Accept` listing both `application/json` and `text/event-stream` | `warn` on the request |
+| a server answering a JSON-RPC request **MUST** return `Content-Type: application/json` or `text/event-stream` | `warn` on the response |
+
+Both sentences read the same in 2025-11-25 and 2026-07-28, so unlike the drift
+and extension checks these need no revision gate. `Origin` is recorded too, since
+servers **MUST** validate it and **MUST** answer `403` when it is invalid, but
+mcpsnoop cannot know your allowed origins so it shows the value rather than
+judging it.
+
+Wildcards count. A client sending `*/*` has offered both types and is never
+reported, and a `charset` parameter on a `Content-Type` is ignored. A log
+captured before mcpsnoop recorded these headers stays silent rather than
+reporting every frame in it for a header nobody wrote down, and stdio never has
+them at all.
+
+`Authorization` is deliberately not captured. Turning a challenge into token
+facts is its own problem and putting a bearer token on disk is not the answer to
+it. `Mcp-Session-Id` and `Last-Event-ID` are not captured either: 2026-07-28
+removed both and tells a server to ignore them, so there is no rule left to check.
+
 ### Detect tool definition drift
 
 The first complete `tools/list` observed for a server label becomes its trusted

--- a/README.md
+++ b/README.md
@@ -990,6 +990,14 @@ shows `N unlinked` and the export carries `session.retired_exchanges`, because a
 retry that does arrive for a retired operation reads as its own call, and a
 reader comparing counts deserves to be told.
 
+Retiring one also lets the live store release it. A parked operation stays
+pending on purpose, so its duration spans the whole exchange, and the store
+refuses to forget a pending call because a response may still be coming. Once
+the cap has retired an operation nothing can answer it, so holding it keeps a
+call alive that no reader can reach. What the session reports does not move. It
+is still counted pending and still counted in `N unlinked`, because how much
+memory a record occupies and what the record says are different questions.
+
 An abandoned exchange does not disturb the next one. MRTR tells servers they
 must not assume a client will ever retry, so a user declining an elicitation
 leaves an operation that no later frame will ever settle. mcpsnoop looks first

--- a/README.md
+++ b/README.md
@@ -596,6 +596,31 @@ mcpsnoop check --fail-on drift --baseline .mcpsnoop/baselines session.jsonl
 
 `drift` is opt-in for `check`; the default `error,invalid,warn` gate is unchanged.
 
+### Catch a feature neither side negotiated
+
+SEP-2133 moved optional features out of the core protocol and into extensions,
+advertised in the `extensions` map of each side's capabilities. Tasks is one of
+them, so on 2026-07-28 a `tasks/get`, a `notifications/tasks` or a `tools/call`
+answered with a task handle only means anything when the other side said it
+speaks Tasks.
+
+When it did not, the spec is explicit: the supporting party **MUST** either fall
+back to core behaviour or reject the request. Doing it anyway is why a feature
+appears to be wired up and then quietly does nothing, and what a reader gets
+instead is a `-32601` or a `-32021` several frames later, or a task that never
+progresses. mcpsnoop warns on the frame that reached for the extension and names
+which side never advertised it.
+
+```
+tool "slow" answered with a task handle uses the io.modelcontextprotocol/tasks
+extension, which the client never advertised
+```
+
+It is a `warn`, so a default `check` run fails on it. It stays quiet whenever the
+capture cannot show what was negotiated, which is a capture that starts after the
+handshake or one whose capabilities your own redaction scrubbed, and on revisions
+before 2026-07-28, where `tasks/*` are core protocol and using them is correct.
+
 ### Flag deprecated protocol features
 
 The 2026-07-28 revision deprecates Roots, Sampling, and Logging. They keep working

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -141,6 +141,14 @@ tree, with no listing involved. What the box affects is the version the listing
 advertises, so forgetting it leaves the page recommending an older release than
 the one that exists.
 
+The listing body is this repository's README, read from the default branch rather
+than from the release, so a documentation fix reaches the page without
+republishing anything. The version beside it comes from the release, so the two
+drift: after a tag, the sidebar advertises the new version while the snippet in
+the text still pins the old one, and the reader copies the snippet. **Update the
+`uses:` versions in README.md before tagging**, which `action/tests/docs_test.sh`
+keeps consistent with each other but cannot keep current.
+
 The listing is keyed on the `name` field in `action.yml`, not on the repository,
 so that field must not change. Do not rename `action.yml` to `action.yaml`
 either, and do not create a floating major tag such as `v1`: Homebrew autobumps

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -132,8 +132,14 @@ checkbox only appears when a release is edited in the web UI. Publishing also
 asks for two-factor authentication.
 
 So after a release lands, open it on the releases page, tick the box, and publish
-again. Skipping it does not break anything, it only leaves the listing pointing
-at the previous release.
+again.
+
+Skipping it breaks nothing. `uses: kerlenton/mcpsnoop@vX.Y.Z` resolves the
+repository at that git ref and never consults the Marketplace, which the action's
+own self-test proves on every pull request: it runs the action from the working
+tree, with no listing involved. What the box affects is the version the listing
+advertises, so forgetting it leaves the page recommending an older release than
+the one that exists.
 
 The listing is keyed on the `name` field in `action.yml`, not on the repository,
 so that field must not change. Do not rename `action.yml` to `action.yaml`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,15 +16,23 @@ publishes a GitHub Release. That half needs only the default `GITHUB_TOKEN`.
 ## npm
 
 A second job then publishes the same release to npm, so that
-`npx mcpsnoop -- node build/index.js` works without a Go toolchain. This one
-needs an `NPM_TOKEN` secret, a granular automation token with publish rights on
-`mcpsnoop` and on the `@mcpsnoop` scope.
+`npx mcpsnoop -- node build/index.js` works without a Go toolchain. It needs no
+secret either. Each of the seven packages names this workflow in this repository
+as its [trusted publisher](https://docs.npmjs.com/trusted-publishers), so the
+runner mints a short-lived OIDC token for the publish and npm attaches the
+provenance attestation on its own. There is no long-lived npm credential to
+leak, rotate, or let expire.
 
-It downloads the archives the release just published, checks each one against the
-`checksums.txt` published beside it, and packs those exact bytes. So the binary
-someone gets from npm is provably the binary on the releases page, and
-`--provenance` records that it was built by this workflow rather than uploaded
-from somebody's laptop.
+That is why the job runs node 24 rather than the 22 that CI runs. Authenticating
+by OIDC needs npm 11.5.1 or later, and node 22 still carries npm 10. A step
+checks this before the publish, because an npm too old fails with a 401 that
+reads like a credential problem and is not one.
+
+The job downloads the archives the release just published, checks each one
+against the `checksums.txt` published beside it, and packs those exact bytes. So
+the binary someone gets from npm is provably the binary on the releases page,
+and the attestation records that it was built by this workflow rather than
+uploaded from somebody's laptop.
 
 Seven packages go out. Six carry one binary each and name the machine they are
 for through npm's `os` and `cpu` fields, and the seventh is the thin `mcpsnoop`
@@ -49,11 +57,13 @@ A prerelease goes out under the `next` tag rather than claiming `latest`, so a
 a package that has never been published is not documented, and the first release
 is the one time there is no existing `latest` to protect.
 
-The first release of a package has to go through the token, because npm's
-[trusted publishing](https://docs.npmjs.com/trusted-publishers) is configured in
-an existing package's settings. Once all seven exist, each can be switched to
-trusted publishing on npmjs.com and the `NPM_TOKEN` secret deleted, which drops
-the long-lived credential entirely. That needs npm 11.5.1 or later on the runner.
+Adding a platform, or moving the workflow to another filename, means visiting
+all seven packages under Settings and Trusted publishing on npmjs.com. The
+trusted publisher is pinned to `release.yml` in `kerlenton/mcpsnoop` by name, so
+a rename that looks harmless in the repository stops every publish. A new
+package also has to be given its trusted publisher, and that is only possible
+once it exists, so the very first publish of one needs a granular token with
+publish rights, deleted again straight after.
 
 To see what would be published without publishing it, build the packages from a
 downloaded release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -123,6 +123,25 @@ gh release download vX.Y.Z --dir dist --pattern 'mcpsnoop_*' --pattern 'checksum
 go run ./cmd/npmpack -version vX.Y.Z -dist dist -out dist/npm
 ```
 
+## GitHub Marketplace
+
+The repository root carries `action.yml`, so each release can also be published
+to the Marketplace. That part is manual and stays manual: GoReleaser creates the
+release through the API, and the "Publish this Action to the GitHub Marketplace"
+checkbox only appears when a release is edited in the web UI. Publishing also
+asks for two-factor authentication.
+
+So after a release lands, open it on the releases page, tick the box, and publish
+again. Skipping it does not break anything, it only leaves the listing pointing
+at the previous release.
+
+The listing is keyed on the `name` field in `action.yml`, not on the repository,
+so that field must not change. Do not rename `action.yml` to `action.yaml`
+either, and do not create a floating major tag such as `v1`: Homebrew autobumps
+this project by reading raw git tags through `/\D*(.+)/`, which reads `v1` as
+version 1, above every 0.x release, and would bump every `brew install mcpsnoop`
+user to a tag that moves under them.
+
 Pick the version with [SemVer](https://semver.org), and see the full policy in
 [CONTRIBUTING](CONTRIBUTING.md#versioning). While on `0.x`, a `0.Y.0` bump may
 change behaviour and a `0.y.Z` bump is bug fixes only.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,8 +11,50 @@ git push origin vX.Y.Z
 
 The [release workflow](.github/workflows/release.yml) runs GoReleaser. It
 cross-compiles the binaries, builds the archives and `checksums.txt`, and
-publishes a GitHub Release. The only secret it needs is the default
-`GITHUB_TOKEN`.
+publishes a GitHub Release. That half needs only the default `GITHUB_TOKEN`.
+
+## npm
+
+A second job then publishes the same release to npm, so that
+`npx mcpsnoop -- node build/index.js` works without a Go toolchain. This one
+needs an `NPM_TOKEN` secret, a granular automation token with publish rights on
+`mcpsnoop` and on the `@mcpsnoop` scope.
+
+It downloads the archives the release just published, checks each one against the
+`checksums.txt` published beside it, and packs those exact bytes. So the binary
+someone gets from npm is provably the binary on the releases page, and
+`--provenance` records that it was built by this workflow rather than uploaded
+from somebody's laptop.
+
+Seven packages go out. Six carry one binary each and name the machine they are
+for through npm's `os` and `cpu` fields, and the seventh is the thin `mcpsnoop`
+package that holds the launcher and lists the other six as optional dependencies.
+npm installs whichever one matches and skips the rest, which is why there is no
+download step at install time and why it works under `--ignore-scripts`.
+
+The order matters and `npmpack -print-order` decides it. The root package
+resolves to the other six, so it goes last.
+
+Nothing here can be taken back. **npm does not let a published version be
+replaced**, and unpublishing is restricted to a 72 hour window. The packaging
+step refuses to write anything unless all six archives are present and match
+their checksums, for that reason. If the npm half fails after the GitHub Release
+is out, do not re-tag. Re-run the `npm` job on its own from the Actions tab with
+`workflow_dispatch`, giving it the same tag.
+
+The first release of a package has to go through the token, because npm's
+[trusted publishing](https://docs.npmjs.com/trusted-publishers) is configured in
+an existing package's settings. Once all seven exist, each can be switched to
+trusted publishing on npmjs.com and the `NPM_TOKEN` secret deleted, which drops
+the long-lived credential entirely. That needs npm 11.5.1 or later on the runner.
+
+To see what would be published without publishing it, build the packages from a
+downloaded release.
+
+```bash
+gh release download vX.Y.Z --dir dist --pattern 'mcpsnoop_*' --pattern 'checksums.txt'
+go run ./cmd/npmpack -version vX.Y.Z -dist dist -out dist/npm
+```
 
 Pick the version with [SemVer](https://semver.org), and see the full policy in
 [CONTRIBUTING](CONTRIBUTING.md#versioning). While on `0.x`, a `0.Y.0` bump may

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,8 +25,17 @@ leak, rotate, or let expire.
 
 That is why the job runs node 24 rather than the 22 that CI runs. Authenticating
 by OIDC needs npm 11.5.1 or later, and node 22 still carries npm 10. A step
-checks this before the publish, because an npm too old fails with a 401 that
-reads like a credential problem and is not one.
+checks the runner's npm before the publish, so that cause is ruled out up front.
+
+Which leaves the trusted publisher itself as what a 401 or 404 at the publish
+means. npm's OIDC exchange is documented never to throw, so a publisher pinned
+to the wrong workflow filename, or scoped to a GitHub environment this job never
+enters, or missing `npm publish` under allowed actions, produces silence and then
+an unhelpful status from the registry. Check the seven configurations on
+npmjs.com before suspecting anything in this repository. The publish keeps
+`--provenance` for the same reason: provenance is generated inside the success
+branch of that exchange, so asking for it outright turns a silent failure into a
+failed publish rather than a published version nobody can verify.
 
 The job downloads the archives the release just published, checks each one
 against the `checksums.txt` published beside it, and packs those exact bytes. So
@@ -51,11 +60,52 @@ is out, do not re-tag. Re-run the `npm` job on its own from the Actions tab with
 `workflow_dispatch`, giving it the same tag. It skips whatever is already on the
 registry, so a publish that died partway through picks up where it stopped.
 
-A prerelease goes out under the `next` tag rather than claiming `latest`, so a
-`vX.Y.Z-rc.1` does not reach everyone running `npx mcpsnoop`. Do not make the
-*first* release of a package a prerelease, though. npm's handling of `latest` on
-a package that has never been published is not documented, and the first release
-is the one time there is no existing `latest` to protect.
+## Prereleases
+
+A prerelease is a tag with a semver prerelease part, and it must be spelled
+`-rc.N`. Both halves of the release then keep it away from the people who did not
+ask for it. npm publishes it under the `next` dist-tag, so `npx mcpsnoop` stays
+on the last stable version, and the publish step refuses to run if those two
+disagree. GoReleaser flags the GitHub Release a prerelease, and GitHub will not
+give the Latest badge to one.
+
+The spelling is not cosmetic. mcpsnoop is in homebrew-core with autobump on and
+no `livecheck` block, so the only thing keeping a prerelease out of
+`brew install mcpsnoop` is Homebrew's list of unstable keywords, which contains
+`rc` but not `next`. A tag spelled `v1.0.0-next.1` would be bumped to every
+Homebrew user.
+
+Four more things are true of a prerelease and worth knowing before cutting one.
+
+**It is as permanent as a final release.** npm's 72 hour unpublish window only
+applies while nothing in the registry depends on the package, and the root
+package lists all six platform packages. The moment the seventh publish lands,
+the six each have a public dependent, so a withdrawal has to run in the reverse
+of the publish order, root first.
+
+**Do not put the final tag on the rc's commit.** `git:prerelease_suffix` in
+`.goreleaser.yaml` makes git sort the final above the rc, so this is handled, but
+the failure it prevents is quiet: GoReleaser would take the rc as the current tag
+and rebuild it, and the npm job would then look for a release that was never
+created.
+
+**The final release's notes will start from the rc, not from the last stable
+version**, because `github-native` generates them for the range since the nearest
+preceding tag. Set `GORELEASER_PREVIOUS_TAG` in the goreleaser job for that
+release, or fix the notes by hand afterwards.
+
+**Retire the `next` dist-tag** once the final version is out, or `npm i
+mcpsnoop@next` keeps installing a release candidate nobody supports.
+
+```bash
+for p in $(go run ./cmd/npmpack -print-order); do
+  npm dist-tag add "$p@X.Y.Z" next
+done
+```
+
+Do not make the *first* release of a package a prerelease. npm's handling of
+`latest` on a package that has never been published is not documented, and the
+first release is the one time there is no existing `latest` to protect.
 
 Adding a platform, or moving the workflow to another filename, means visiting
 all seven packages under Settings and Trusted publishing on npmjs.com. The

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,7 +40,14 @@ replaced**, and unpublishing is restricted to a 72 hour window. The packaging
 step refuses to write anything unless all six archives are present and match
 their checksums, for that reason. If the npm half fails after the GitHub Release
 is out, do not re-tag. Re-run the `npm` job on its own from the Actions tab with
-`workflow_dispatch`, giving it the same tag.
+`workflow_dispatch`, giving it the same tag. It skips whatever is already on the
+registry, so a publish that died partway through picks up where it stopped.
+
+A prerelease goes out under the `next` tag rather than claiming `latest`, so a
+`vX.Y.Z-rc.1` does not reach everyone running `npx mcpsnoop`. Do not make the
+*first* release of a package a prerelease, though. npm's handling of `latest` on
+a package that has never been published is not documented, and the first release
+is the one time there is no existing `latest` to protect.
 
 The first release of a package has to go through the token, because npm's
 [trusted publishing](https://docs.npmjs.com/trusted-publishers) is configured in

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,22 @@
 # Releasing
 
-A release is just a pushed tag. Tag a commit on `main` and GitHub Actions takes
-over from there.
+A release is a pushed tag, and one commit before it. GitHub Actions takes over
+from the tag.
 
 ```bash
 git switch main && git pull
+make release-prep TAG=vX.Y.Z
+git commit -am "docs: point at vX.Y.Z"
+git push
 git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
+
+The bump comes first so that the tagged tree documents the release it is. It
+rewrites the versions a reader is meant to copy, which is the `uses:` lines in
+the README and the example in `action.yml`, and prints what it changed. Between
+that push and the tag, `main` names a release that does not exist yet, which
+lasts a minute and breaks nothing.
 
 The [release workflow](.github/workflows/release.yml) runs GoReleaser. It
 cross-compiles the binaries, builds the archives and `checksums.txt`, and
@@ -145,9 +154,10 @@ The listing body is this repository's README, read from the default branch rathe
 than from the release, so a documentation fix reaches the page without
 republishing anything. The version beside it comes from the release, so the two
 drift: after a tag, the sidebar advertises the new version while the snippet in
-the text still pins the old one, and the reader copies the snippet. **Update the
-`uses:` versions in README.md before tagging**, which `action/tests/docs_test.sh`
-keeps consistent with each other but cannot keep current.
+the text still pins the old one, and the reader copies the snippet. `make release-prep` at the top of this file is what bumps them, which is why it
+comes before the tag rather than after. `action/tests/docs_test.sh` keeps the two
+`uses:` lines consistent with each other, but nothing can tell whether they are
+current, which is why this is a step and not a check.
 
 The listing is keyed on the `name` field in `action.yml`, not on the repository,
 so that field must not change. Do not rename `action.yml` to `action.yaml`

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,13 @@ name: mcpsnoop
 description: Fail CI on what an MCP server actually did on the wire, and file every finding as a code scanning alert.
 author: kerlenton
 
+# The badge GitHub generates for the Marketplace listing. A custom logo is not
+# possible here: it is always one Feather icon on one of nine fixed colours.
+# git-commit is a node cut into the middle of a line, which is the same sentence
+# the project mark says and what a transparent proxy is. It also survives the
+# 16-pixel size the search results use, where a heartbeat does not.
 branding:
-  icon: activity
+  icon: git-commit
   color: blue
 
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,124 @@
+# The mcpsnoop GitHub Action.
+#
+# This file is at the repository root because GitHub Marketplace lists an action
+# only when its metadata file is there, and only one per repository. Do not
+# rename it to action.yaml; the spelling is part of what the listing is keyed on.
+#
+# There is deliberately no floating `v1` tag. Homebrew autobumps this project by
+# reading raw git tags through /\D*(.+)/, which reads `v1` as version 1, above
+# every 0.x release, and would bump every `brew install mcpsnoop` user to a tag
+# that moves. Callers pin a release, which is also what makes the action install
+# the binary from that same release with no version default to go stale.
+name: mcpsnoop
+description: Fail CI on what an MCP server actually did on the wire, and file every finding as a code scanning alert.
+author: kerlenton
+
+branding:
+  icon: activity
+  color: blue
+
+inputs:
+  session:
+    description: |
+      Path to the .jsonl capture to check, relative to the repository root.
+      Record one by wrapping your server with mcpsnoop in an earlier step.
+    required: true
+  fail-on:
+    description: |
+      Comma-separated signals to fail on, any of error, invalid, warn, mismatch,
+      pending, late-result, drift, deprecated, incomplete, schema. Defaults to
+      what the CLI defaults to, which is error,invalid,warn.
+    default: ""
+  args:
+    description: |
+      Any other mcpsnoop check flags, quoted as they would be on a command line,
+      for example: --expect-tool search --max-server-duration 500ms
+      --format is not accepted: the action reads the report this step produces.
+    default: ""
+  upload-sarif:
+    description: |
+      Upload the report to code scanning. Needs security-events: write on the
+      job. Set to false in a repository without code scanning, or to keep the
+      report to yourself.
+    default: "true"
+  category:
+    description: |
+      The code scanning category the report is filed under. A category is a
+      namespace: two analyses sharing one overwrite each other, so give each tool
+      its own, and vary it per leg of a matrix.
+    default: mcpsnoop
+  fail-on-findings:
+    description: |
+      Fail the job when the check finds something. Set to false to file the
+      alerts and let code scanning's own required check decide the build. A run
+      that could not check at all fails either way, since nothing was verified.
+    default: "true"
+  version:
+    description: |
+      Which mcpsnoop to install, for example v0.21.0. Defaults to the release you
+      pinned the action to, so normally there is nothing to set. Needed only when
+      pinning a branch or a commit, which names no release.
+    default: ""
+  install:
+    description: |
+      Install the binary. Set to false when mcpsnoop is already on PATH, which is
+      the way in on a platform no release is built for.
+    default: "true"
+
+outputs:
+  outcome:
+    description: passed, findings, or error. error means nothing was checked, which is not the same as nothing being found.
+    value: ${{ steps.check.outputs.outcome }}
+  sarif:
+    description: Absolute path to the SARIF report, empty when there is none.
+    value: ${{ steps.check.outputs.sarif }}
+  exit-code:
+    description: The exit code mcpsnoop check returned.
+    value: ${{ steps.check.outputs.exit-code }}
+
+runs:
+  using: composite
+  steps:
+    # $GITHUB_ACTION_PATH rather than ${{ github.action_path }} throughout. On
+    # Windows the expression carries backslashes into the script body, where bash
+    # reads them as escapes; the environment variable is expanded at runtime,
+    # where they survive.
+    - name: Install mcpsnoop
+      if: ${{ inputs.install != 'false' }}
+      shell: bash
+      env:
+        MCPSNOOP_VERSION: ${{ inputs.version }}
+      run: bash "$GITHUB_ACTION_PATH/action/install.sh"
+
+    # Records the verdict rather than failing on it, so the upload below runs on
+    # exactly the runs that have something to report.
+    - name: Run mcpsnoop check
+      id: check
+      shell: bash
+      env:
+        MCPSNOOP_SESSION: ${{ inputs.session }}
+        MCPSNOOP_FAIL_ON: ${{ inputs.fail-on }}
+        MCPSNOOP_ARGS: ${{ inputs.args }}
+        MCPSNOOP_UPLOAD: ${{ inputs.upload-sarif }}
+      run: bash "$GITHUB_ACTION_PATH/action/check.sh"
+
+    # Pinned by commit with the version beside it, so an organisation running an
+    # allowed-actions list can permit this nested action by hash.
+    - name: Upload the report to code scanning
+      if: ${{ !cancelled() && steps.check.outputs.upload == 'true' }}
+      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      with:
+        sarif_file: ${{ steps.check.outputs.sarif }}
+        category: ${{ inputs.category }}
+
+    # !cancelled() rather than a bare if:, so the verdict is still stated when
+    # the upload itself failed. Otherwise a 403 from code scanning would be the
+    # only annotation on a run that also had real findings.
+    - name: Report the verdict
+      if: ${{ !cancelled() }}
+      shell: bash
+      env:
+        MCPSNOOP_OUTCOME: ${{ steps.check.outputs.outcome }}
+        MCPSNOOP_SESSION: ${{ inputs.session }}
+        MCPSNOOP_FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+      run: bash "$GITHUB_ACTION_PATH/action/gate.sh"

--- a/action/check.sh
+++ b/action/check.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Run `mcpsnoop check` over one capture and record the verdict, without ever
+# failing.
+#
+# Not failing is the point. The report has to reach the Security tab on exactly
+# the runs that have something to report, and a step that failed here would stop
+# the upload that follows. The verdict goes to an output instead, and a later
+# step turns it into the job's result.
+set -uo pipefail
+
+out() { printf '%s=%s\n' "$1" "$2" >>"${GITHUB_OUTPUT:-/dev/null}"; }
+
+# refuse says why, records that nothing was checked, and returns cleanly.
+#
+# Cleanly, because this step must not fail. Failing it would leave the steps
+# after it with no verdict to read, and the one that turns a verdict into the
+# job's result is the only place that decides whether the job is red. A run that
+# never got as far as looking is an error there, and an error there is not
+# suppressible, so nothing is being let through by returning zero here.
+refuse() {
+	printf 'mcpsnoop-action: %s\n' "$1" >&2
+	shift
+	for line in "$@"; do printf '  %s\n' "$line" >&2; done
+	out outcome error
+	out exit-code ""
+	out sarif ""
+	out upload false
+	printf '### mcpsnoop\n\n**Could not check.** See the step log; this is not a finding.\n' \
+		>>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+	exit 0
+}
+
+session="${MCPSNOOP_SESSION:-}"
+report="${RUNNER_TEMP:-}/mcpsnoop.sarif"
+# Neither is anything a caller can get wrong through the action's inputs, so
+# there is no help to offer beyond saying which one is missing.
+if [ -z "$session" ]; then
+	printf 'mcpsnoop-action: the session input is not set\n' >&2
+	exit 1
+fi
+if [ -z "${RUNNER_TEMP:-}" ]; then
+	printf 'mcpsnoop-action: RUNNER_TEMP is not set, which means this is not running on a GitHub runner\n' >&2
+	exit 1
+fi
+
+# The action reports through a file, so a capture piped in on stdin has nothing
+# for a result to point at and every alert would arrive with no location.
+[ "$session" = "-" ] && refuse "session cannot be -." \
+	"" \
+	"The report points at the file each finding came from, and a capture read from" \
+	"stdin has no file. Write it out first and pass the path."
+[ -e "$session" ] || refuse "there is no capture at \"$session\"." \
+	"" \
+	"session is a path to a .jsonl capture, relative to the repository root." \
+	"Record one by wrapping your server with mcpsnoop before this step."
+
+command -v mcpsnoop >/dev/null 2>&1 || refuse "mcpsnoop is not on PATH." \
+	"" \
+	"With install: false the binary has to be there already, and putting it on" \
+	"PATH in an earlier step needs GITHUB_PATH rather than an export, which" \
+	"lasts only as long as the step that ran it:" \
+	"" \
+	"  echo \"\$RUNNER_TEMP/bin\" >> \"\$GITHUB_PATH\"" \
+	"" \
+	"Or drop install: false and let the action fetch the release you pinned."
+
+flags=()
+if [ -n "${MCPSNOOP_FAIL_ON:-}" ]; then
+	flags+=(--fail-on "$MCPSNOOP_FAIL_ON")
+fi
+# xargs rather than word splitting, so a value with a space in it survives being
+# quoted the way it would be on a command line.
+#
+# Its exit status has to be caught here, before the tokens are read. xargs emits
+# whatever it parsed before giving up, so an unbalanced quote yields a shorter
+# command line and a zero status, and `--expect-tool 'oops` quietly becomes
+# `--expect-tool` swallowing whatever came next. Reading it through a pipe or a
+# process substitution hides that failure completely.
+if [ -n "${MCPSNOOP_ARGS:-}" ]; then
+	if ! split="$(printf '%s' "$MCPSNOOP_ARGS" | xargs -n1 printf '%s\n' 2>&1)"; then
+		refuse "args is not something a command line can be read out of." \
+			"" \
+			"  ${split##*: }" \
+			"" \
+			"Quote args the way you would on a command line:" \
+			"" \
+			"  args: --expect-tool search --max-server-duration 500ms"
+	fi
+	while IFS= read -r token; do
+		[ -n "$token" ] || continue
+		case "$token" in
+		--format | --format=*)
+			refuse "args cannot set --format." \
+				"" \
+				"The action reads the SARIF report this step produces, so the format is" \
+				"not yours to change. Everything else check accepts is fine here."
+			;;
+		-h | --help)
+			refuse "args cannot ask for help text, which check writes where the report goes."
+			;;
+		esac
+		flags+=("$token")
+	done <<<"$split"
+fi
+
+printf 'mcpsnoop check --format sarif %s -- %s\n' "${flags[*]-}" "$session"
+mcpsnoop check --format sarif ${flags[@]+"${flags[@]}"} -- "$session" >"$report"
+code=$?
+
+# 1 means the check ran and something failed the gate, so the report is real and
+# worth publishing. Anything else non-zero means the check never happened: a
+# capture that would not load, a flag that would not parse. The difference is a
+# contract the CLI keeps and a test in that repository pins, because without it a
+# typo in the session path would read here as a clean run.
+case "$code" in
+0) outcome=passed ;;
+1) outcome=findings ;;
+*) outcome=error ;;
+esac
+
+# Belt and braces against the contract changing under us. A report that is not a
+# mcpsnoop SARIF document is not something to hand to code scanning, whatever the
+# exit code said. Checked without a JSON parser, since a runner is not obliged to
+# carry one.
+if [ "$outcome" != error ]; then
+	if [ ! -s "$report" ] || ! grep -q '"mcpsnoop"' "$report" 2>/dev/null; then
+		printf 'mcpsnoop-action: check exited %s but wrote no usable SARIF report\n' "$code" >&2
+		outcome=error
+	fi
+fi
+if [ "$outcome" = error ]; then
+	# Nothing here is a report. Leaving the file behind invites the upload step,
+	# or a later artifact upload, to treat it as one.
+	rm -f "$report"
+fi
+
+out outcome "$outcome"
+out exit-code "$code"
+out sarif "$report"
+# Written as if/else rather than && ||, because in the latter the right-hand
+# side also runs when the left-hand side merely fails, and the two branches here
+# say opposite things about whether a report should be published.
+if [ "$outcome" = error ]; then
+	out upload false
+else
+	out upload "${MCPSNOOP_UPLOAD:-true}"
+fi
+
+# The job summary is a convenience and never a reason to fail. python3 is on
+# every GitHub-hosted image; a container without one still gets the verdict.
+{
+	printf '### mcpsnoop\n\n'
+	# The backticks below are markdown for the summary, not command substitution.
+	# shellcheck disable=SC2016
+	case "$outcome" in
+	passed) printf '**Passed.** `%s` violated nothing that was gated on.\n' "$session" ;;
+	findings) printf '**Findings.** `%s` violated a gated signal.\n' "$session" ;;
+	error) printf '**Could not check `%s`.** See the step log; this is not a finding.\n' "$session" ;;
+	esac
+	if [ "$outcome" != error ] && command -v python3 >/dev/null 2>&1; then
+		python3 - "$report" <<-'PY' 2>/dev/null || true
+			import collections, json, sys
+			results = json.load(open(sys.argv[1]))["runs"][0]["results"]
+			if not results:
+			    raise SystemExit
+			by = collections.Counter((r["level"], r["ruleId"]) for r in results)
+			print("\n| Level | Rule | Count |\n|---|---|---|")
+			for level in ("error", "warning", "note"):
+			    for (lv, rule), n in sorted(by.items()):
+			        if lv == level:
+			            print(f"| {lv} | `{rule}` | {n} |")
+		PY
+	fi
+} >>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+exit 0

--- a/action/gate.sh
+++ b/action/gate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Turn the verdict the check step recorded into the job's result.
+#
+# Separate from the check itself so that the report reaches the Security tab
+# first. A step that failed before the upload would keep every finding out of the
+# place the findings exist to reach.
+set -euo pipefail
+
+# Anything other than the two known-good verdicts is an error, an unset value
+# included. A step that did not run, or one that died before writing its verdict,
+# has not approved anything.
+outcome="${MCPSNOOP_OUTCOME:-}"
+session="${MCPSNOOP_SESSION:-the capture}"
+
+case "$outcome" in
+passed)
+	printf 'mcpsnoop: %s passed\n' "$session"
+	;;
+findings)
+	# Suppressible, because a repository may want the alerts filed and the build
+	# left alone, which is what code scanning's own required check is for.
+	if [ "${MCPSNOOP_FAIL_ON_FINDINGS:-true}" = "false" ]; then
+		printf '::notice title=mcpsnoop::%s violated a gated signal. Reported, not failed, because fail-on-findings is false.\n' "$session"
+	else
+		printf '::error title=mcpsnoop::%s violated a gated signal. See the Security tab, or set fail-on-findings to false to report without failing.\n' "$session"
+		exit 1
+	fi
+	;;
+*)
+	# Never suppressible. fail-on-findings answers "should a finding fail the
+	# build", and this is the other thing: nothing was checked. A run that could
+	# not look is not a run that looked and approved, and silencing it is how a
+	# green pipeline comes to mean nothing.
+	printf '::error title=mcpsnoop::could not check %s. This is not a finding: nothing was verified. See the step log above.\n' "$session"
+	exit 1
+	;;
+esac

--- a/action/install.sh
+++ b/action/install.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Put the mcpsnoop binary of one release on PATH, having proved it is the binary
+# that release published.
+#
+# This runs in other people's repositories, so it fails loudly and never guesses.
+# Every input that reaches a URL, a filesystem path or another interpreter is
+# validated first, and the archive is checked against the checksums file
+# published beside it before anything is unpacked or run.
+set -euo pipefail
+
+die() {
+	printf 'mcpsnoop-action: %s\n' "$1" >&2
+	shift
+	for line in "$@"; do printf '  %s\n' "$line" >&2; done
+	exit 1
+}
+
+# ---------------------------------------------------------------- the version
+
+version="${MCPSNOOP_VERSION:-}"
+if [ -z "$version" ]; then
+	# The ref the caller pinned. `uses: kerlenton/mcpsnoop@v0.21.0` asks for the
+	# action from that release, so it asks for that release's binary too, and
+	# there is no default in this file to go stale.
+	version="${GITHUB_ACTION_REF:-}"
+fi
+case "$version" in
+v[0-9]*.[0-9]*.[0-9]*) ;;
+*)
+	die "cannot tell which mcpsnoop to install." \
+		"" \
+		"The version comes from the ref you pinned the action to, and \"${version:-<empty>}\" is not a release tag." \
+		"Pin a release:" \
+		"" \
+		"  - uses: kerlenton/mcpsnoop@v0.21.0" \
+		"" \
+		"or, when pinning a branch or a commit, say which binary to use:" \
+		"" \
+		"  - uses: kerlenton/mcpsnoop@<sha>" \
+		"    with:" \
+		"      version: v0.21.0" \
+		"" \
+		"See https://github.com/kerlenton/mcpsnoop/releases"
+	;;
+esac
+# Belt and braces. The check above already excludes everything below, and this
+# one says so out loud, because the value goes into a URL and, on Windows, into
+# another interpreter's command line.
+case "$version" in
+*[!0-9A-Za-z.v+-]*) die "version \"$version\" contains characters a release tag cannot have" ;;
+esac
+plain="${version#v}"
+
+# --------------------------------------------------------------- the platform
+
+case "${RUNNER_OS:-}/${RUNNER_ARCH:-}" in
+Linux/X64) goos=linux goarch=amd64 ext=tar.gz binary=mcpsnoop ;;
+Linux/ARM64) goos=linux goarch=arm64 ext=tar.gz binary=mcpsnoop ;;
+macOS/X64) goos=darwin goarch=amd64 ext=tar.gz binary=mcpsnoop ;;
+macOS/ARM64) goos=darwin goarch=arm64 ext=tar.gz binary=mcpsnoop ;;
+Windows/X64) goos=windows goarch=amd64 ext=zip binary=mcpsnoop.exe ;;
+Windows/ARM64) goos=windows goarch=arm64 ext=zip binary=mcpsnoop.exe ;;
+*)
+	die "no mcpsnoop release is built for ${RUNNER_OS:-<unknown OS>} on ${RUNNER_ARCH:-<unknown arch>}." \
+		"" \
+		"Releases cover Linux, macOS and Windows on X64 and ARM64." \
+		"On anything else, install it yourself and set install: false:" \
+		"" \
+		"  go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@$version"
+	;;
+esac
+
+archive="mcpsnoop_${plain}_${goos}_${goarch}.${ext}"
+base="https://github.com/kerlenton/mcpsnoop/releases/download/${version}"
+dir="${RUNNER_TEMP:?RUNNER_TEMP is not set, which means this is not running on a GitHub runner}/mcpsnoop-${plain}"
+
+if [ -x "$dir/$binary" ]; then
+	# A workflow that calls the action twice should not download twice.
+	printf 'mcpsnoop %s is already installed at %s\n' "$plain" "$dir"
+else
+	mkdir -p "$dir"
+	fetch() {
+		curl --fail --silent --show-error --location --retry 3 --retry-delay 2 \
+			--output "$2" "$1" ||
+			die "could not download $1" "" "Check that $version is a published release." \
+				"See https://github.com/kerlenton/mcpsnoop/releases"
+	}
+	fetch "$base/$archive" "$dir/$archive"
+	fetch "$base/checksums.txt" "$dir/checksums.txt"
+
+	# Exactly one line, matched on the whole name rather than by a substring, so
+	# a checksums file that ever grows a similarly named artifact cannot make
+	# this silently verify the wrong one.
+	want="$(awk -v name="$archive" '$2 == name || $2 == "*" name { print $1; n++ } END { if (n != 1) exit 1 }' "$dir/checksums.txt")" ||
+		die "checksums.txt for $version does not list exactly one entry for $archive"
+
+	# The file on stdin rather than named as an argument. Given a name, GNU
+	# coreutils escapes the line it prints when that name contains a backslash,
+	# and prefixes the whole thing with one. RUNNER_TEMP on a Windows runner is
+	# D:\a\_temp, so every hash came back as \<hash> and never matched anything.
+	if command -v sha256sum >/dev/null 2>&1; then
+		got="$(sha256sum <"$dir/$archive" | cut -d' ' -f1)"
+	elif command -v shasum >/dev/null 2>&1; then
+		got="$(shasum -a 256 <"$dir/$archive" | cut -d' ' -f1)"
+	else
+		die "neither sha256sum nor shasum is available, so the download cannot be verified"
+	fi
+	if [ "$got" != "$want" ]; then
+		die "$archive does not match its checksum, so it is not the archive $version published." \
+			"  expected $want" \
+			"  got      $got"
+	fi
+
+	case "$ext" in
+	tar.gz) tar -xzf "$dir/$archive" -C "$dir" "$binary" ;;
+	zip)
+		if command -v unzip >/dev/null 2>&1; then
+			unzip -q -o "$dir/$archive" "$binary" -d "$dir"
+		else
+			# No caller-controlled text reaches this command line. The version is
+			# validated above and everything else comes from RUNNER_TEMP.
+			powershell.exe -NoProfile -NonInteractive -Command \
+				"Expand-Archive -LiteralPath '$(cygpath -w "$dir/$archive")' -DestinationPath '$(cygpath -w "$dir")' -Force" ||
+				die "could not unpack $archive"
+		fi
+		;;
+	esac
+	chmod +x "$dir/$binary" 2>/dev/null || true
+	[ -s "$dir/$binary" ] || die "$archive unpacked without a $binary in it"
+fi
+
+printf '%s\n' "$dir" >>"$GITHUB_PATH"
+
+# The resolved version belongs in every job log, so a report that looks wrong can
+# be traced to the build that produced it without re-running anything.
+"$dir/$binary" --version

--- a/action/tests/check_test.sh
+++ b/action/tests/check_test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Exercise action/check.sh and action/gate.sh over every verdict they can reach.
+#
+# What matters here is not what mcpsnoop finds, which its own tests cover, but
+# what the action does with each answer: whether it uploads, and whether the job
+# ends up red. Getting that wrong in either direction is worse than a wrong
+# finding. Green on a run that checked nothing is the failure this whole shape
+# exists to prevent, and red on a real finding keeps the report out of the place
+# it exists to reach.
+#
+# Captures are written here rather than committed, because *.jsonl is ignored in
+# this repository and a fixture git silently refused to track would make every
+# case below pass against nothing.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+check_sh="$here/../check.sh"
+gate_sh="$here/../gate.sh"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+
+command -v mcpsnoop >/dev/null 2>&1 || {
+	echo "check.sh: mcpsnoop is not on PATH; build it first (go build -o <dir>/mcpsnoop ./cmd/mcpsnoop)" >&2
+	exit 1
+}
+
+fail=0
+ok() { printf '  ok    %s\n' "$1"; }
+bad() {
+	printf '  FAIL  %s\n' "$1"
+	shift
+	for line in "$@"; do printf '        %s\n' "$line"; done
+	fail=1
+}
+
+envelope() { # seq direction json
+	printf '{"session_id":"t","server_label":"t","seq":%s,"ts":"2026-01-01T00:00:00Z","direction":"%s","transport":"stdio","raw":%s}\n' "$1" "$2" "$3"
+}
+{
+	envelope 1 c2s '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ok"}}'
+	envelope 2 s2c '{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"fine"}]}}'
+} >"$root/clean.jsonl"
+{
+	envelope 1 c2s '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"boom"}}'
+	envelope 2 s2c '{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"no such tool"}}'
+} >"$root/dirty.jsonl"
+printf 'this is not a capture\n' >"$root/garbage.jsonl"
+
+# run drives check.sh and then gate.sh the way action.yml wires them, and prints
+# what a job would have ended up doing.
+run() { # session [env=value ...]
+	local session="$1"
+	shift
+	rm -rf "${root:?}/temp" "${root:?}/home"
+	mkdir -p "$root/temp"
+	: >"$root/out"
+	: >"$root/summary"
+	env RUNNER_TEMP="$root/temp" MCPSNOOP_HOME="$root/home" \
+		GITHUB_OUTPUT="$root/out" GITHUB_STEP_SUMMARY="$root/summary" \
+		MCPSNOOP_SESSION="$session" "$@" bash "$check_sh" >"$root/log" 2>&1
+	check_code=$?
+	outcome="$(sed -n 's/^outcome=//p' "$root/out")"
+	upload="$(sed -n 's/^upload=//p' "$root/out")"
+	sarif="$(sed -n 's/^sarif=//p' "$root/out")"
+	env MCPSNOOP_OUTCOME="$outcome" MCPSNOOP_SESSION="$session" "$@" \
+		bash "$gate_sh" >>"$root/log" 2>&1
+	gate_code=$?
+}
+
+expect() { # label wantOutcome wantUpload wantGate
+	local label="$1" wo="$2" wu="$3" wg="$4"
+	local got="outcome=$outcome upload=$upload gate=$gate_code"
+	local want="outcome=$wo upload=$wu gate=$wg"
+	if [ "$check_code" != 0 ]; then
+		bad "$label" "check.sh exited $check_code; it must never fail, or the steps after it have no verdict to read" "$(cat "$root/log")"
+	elif [ "$got" != "$want" ]; then
+		bad "$label" "got  $got" "want $want" "$(cat "$root/log")"
+	else
+		ok "$label"
+	fi
+}
+
+echo "check.sh"
+
+run "$root/clean.jsonl"
+expect "a clean capture uploads and passes" passed true 0
+
+run "$root/dirty.jsonl"
+expect "a finding uploads and fails" findings true 1
+if [ -s "$sarif" ] && grep -q '"mcpsnoop"' "$sarif"; then
+	ok "and leaves a SARIF report behind"
+else
+	bad "a finding left no usable report to upload" "$(cat "$root/log")"
+fi
+
+run "$root/dirty.jsonl" MCPSNOOP_FAIL_ON_FINDINGS=false
+expect "a finding can be reported without failing" findings true 0
+
+run "$root/dirty.jsonl" MCPSNOOP_FAIL_ON=pending
+expect "a finding nobody gated on passes" passed true 0
+
+run "$root/clean.jsonl" MCPSNOOP_UPLOAD=false
+expect "upload can be turned off without changing the verdict" passed false 0
+
+# Everything below is the same thing said six ways: the check did not happen.
+# None of it may pass, and none of it may be suppressed by fail-on-findings,
+# because a run that could not look has not approved anything.
+for case in \
+	"a path that is not there|$root/no-such-file.jsonl|" \
+	"a file that is not a capture|$root/garbage.jsonl|" \
+	"a capture piped in on stdin|-|" \
+	"args changing the format|$root/clean.jsonl|MCPSNOOP_ARGS=--format text" \
+	"args asking for help text|$root/clean.jsonl|MCPSNOOP_ARGS=--help" \
+	"args with an unbalanced quote|$root/clean.jsonl|MCPSNOOP_ARGS=--expect-tool 'oops"; do
+	IFS='|' read -r label session extra <<<"$case"
+	if [ -n "$extra" ]; then run "$session" "$extra"; else run "$session"; fi
+	expect "$label is an error, not a finding" error false 1
+
+	if [ -n "$extra" ]; then run "$session" "$extra" MCPSNOOP_FAIL_ON_FINDINGS=false; else run "$session" MCPSNOOP_FAIL_ON_FINDINGS=false; fi
+	[ "$gate_code" = 1 ] || bad "$label was suppressed by fail-on-findings" "gate exited $gate_code"
+
+	[ -z "$sarif" ] || [ ! -e "$sarif" ] ||
+		bad "$label left a file where the report goes, which the upload would take for one"
+done
+
+# The two safeguards, pinned one at a time.
+#
+# The exit code and the shape of the report each decide the verdict on their own,
+# and against the real CLI they always agree, so either one alone keeps every
+# case above green and neither is actually being tested. A stand-in that
+# disagrees with itself separates them. It also says what happens if the CLI ever
+# regresses, which is the whole reason for having both.
+stub() { # exitCode stdout
+	mkdir -p "$root/stub"
+	{
+		printf '#!/usr/bin/env bash\n'
+		printf 'printf %%s %s\n' "$(printf '%q' "$2")"
+		printf 'exit %s\n' "$1"
+	} >"$root/stub/mcpsnoop"
+	chmod +x "$root/stub/mcpsnoop"
+}
+# $schema is a JSON key, not a shell variable, so the quoting is deliberate.
+# shellcheck disable=SC2016
+valid_sarif='{"$schema":"x","version":"2.1.0","runs":[{"tool":{"driver":{"name":"mcpsnoop"}},"results":[]}]}'
+
+stub 2 "$valid_sarif"
+PATH="$root/stub:$PATH" run "$root/clean.jsonl"
+expect "a report that looks right does not rescue a run that failed" error false 1
+
+stub 0 "Check a captured session against signals (errors, invalid frames, ...)"
+PATH="$root/stub:$PATH" run "$root/clean.jsonl"
+expect "a clean exit does not make help text a report" error false 1
+
+stub 1 "session t: errors=1 ... check failed: error"
+PATH="$root/stub:$PATH" run "$root/clean.jsonl"
+expect "nor does a finding make a text summary one" error false 1
+
+# For these two the message is the whole value of the refusal. Both end in an
+# error anyway if they are let through, --format because the report then is not
+# one and - because there is no such file, so the outcome cannot tell whether the
+# refusal is there and the caller is left to work out what went wrong.
+run "$root/clean.jsonl" "MCPSNOOP_ARGS=--format text"
+grep -q "args cannot set --format" "$root/log" ||
+	bad "refusing --format did not say that is what happened" "$(cat "$root/log")"
+
+run "-"
+grep -q "session cannot be -" "$root/log" ||
+	bad "refusing stdin did not say why a report needs a file" "$(cat "$root/log")"
+
+# install: false with nothing installed. Left alone this is a bare "command not
+# found" from the shell, which reads as a broken action rather than as the one
+# mistake it almost always is.
+# Every directory holding a mcpsnoop taken out of PATH, rather than PATH
+# replaced, since the harness itself needs the ordinary tools to run at all.
+# Every one, not the first: a machine can carry an installed copy as well as the
+# build this suite put there, and leaving either behind proves nothing.
+without_mcpsnoop="$PATH"
+for _ in 1 2 3 4 5; do
+	found="$(PATH="$without_mcpsnoop" bash -c 'command -v mcpsnoop' 2>/dev/null)" || break
+	[ -n "$found" ] || break
+	without_mcpsnoop="$(printf '%s' "$without_mcpsnoop" | tr ':' '\n' | grep -vFx "$(dirname "$found")" | paste -sd: -)"
+done
+if PATH="$without_mcpsnoop" bash -c 'command -v mcpsnoop' >/dev/null 2>&1; then
+	bad "could not build a PATH without mcpsnoop on it, so the case below would prove nothing"
+else
+	PATH="$without_mcpsnoop" run "$root/clean.jsonl"
+	expect "a missing binary is an error, not a finding" error false 1
+	grep -q "GITHUB_PATH" "$root/log" ||
+		bad "the missing-binary message does not say how to put it on PATH" "$(cat "$root/log")"
+fi
+
+# A verdict that was never written is the same as an error: a check step that
+# died before writing one has approved nothing.
+if env MCPSNOOP_SESSION=x bash "$gate_sh" >/dev/null 2>&1; then
+	bad "an unset verdict did not fail"
+else
+	ok "an unset verdict fails rather than crashing the gate"
+fi
+
+exit "$fail"

--- a/action/tests/docs_test.sh
+++ b/action/tests/docs_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Check what the Marketplace listing tells a reader to copy.
+#
+# The listing's body is this repository's README, read from the default branch
+# rather than from a release, so what the page shows is whatever was merged last.
+# The README carries the `uses:` line twice, once near the top for someone who
+# arrived from the listing and once in the section explaining the inputs. Bumping
+# one and forgetting the other leaves the page telling two stories about which
+# release to pin, and the reader takes whichever they scroll to first.
+#
+# None of this can tell whether the pin is the newest release. That is a person's
+# job at release time and RELEASING.md says so. What it can do is insist the two
+# agree, and that the page says the pin is the reader's to choose.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readme="$here/../../README.md"
+
+fail=0
+ok() { printf '  ok    %s\n' "$1"; }
+bad() {
+	printf '  FAIL  %s\n' "$1"
+	shift
+	for line in "$@"; do printf '        %s\n' "$line"; done
+	fail=1
+}
+
+echo "docs"
+
+pins="$(grep -oE 'kerlenton/mcpsnoop@v[0-9][^ "`]*' "$readme" | sed 's/.*@//')"
+count="$(printf '%s\n' "$pins" | grep -c .)"
+distinct="$(printf '%s\n' "$pins" | sort -u | grep -c .)"
+
+if [ "$count" -lt 2 ]; then
+	bad "README.md carries $count pinned uses: lines" \
+		"it is meant to carry the quickstart one and the one beside the inputs"
+elif [ "$distinct" -ne 1 ]; then
+	bad "README.md pins more than one version of the action" \
+		"$(printf '%s\n' "$pins" | sort -u | tr '\n' ' ')" \
+		"the listing would tell two stories about which release to use"
+else
+	ok "every uses: line in the README pins the same release"
+fi
+
+first="$(printf '%s\n' "$pins" | head -1)"
+# A full tag, not a branch and not a bare major. There is no floating v1:
+# Homebrew autobumps this project by reading raw git tags through /\D*(.+)/,
+# which reads v1 as version 1, above every 0.x release.
+if printf '%s' "$first" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+	ok "and pins a full release tag rather than a branch or a floating major"
+else
+	bad "README.md pins the action at \"$first\", which is not a full release tag"
+fi
+
+if grep -q "releases page" "$readme"; then
+	ok "and points at the releases page, so the pin reads as the reader's choice"
+else
+	bad "README.md pins a version without pointing at the releases page" \
+		"the number then reads as an instruction rather than an example, and it goes stale"
+fi
+
+exit "$fail"

--- a/action/tests/install_test.sh
+++ b/action/tests/install_test.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Exercise action/install.sh against a stand-in for the releases page.
+#
+# The download is replaced by a curl on PATH that serves a local directory, so
+# the checksum verification can be given an archive that does not match and be
+# seen to reject it. Without the stand-in a test cannot tamper with anything: the
+# real script re-downloads, which quietly restores whatever the test corrupted
+# and turns the test into a check that curl works.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install_sh="$here/../install.sh"
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+
+fail=0
+ok() { printf '  ok    %s\n' "$1"; }
+bad() {
+	printf '  FAIL  %s\n' "$1"
+	shift
+	for line in "$@"; do printf '        %s\n' "$line"; done
+	fail=1
+}
+
+# serve builds a fake releases directory and a curl that reads from it.
+serve() {
+	local dir="$root/serve"
+	rm -rf "${dir:?}" "${root:?}/bin"
+	mkdir -p "$dir" "$root/bin"
+	printf '#!/bin/sh\nexit 0\n' >"$dir/mcpsnoop"
+	chmod +x "$dir/mcpsnoop"
+	tar -czf "$dir/mcpsnoop_9.9.9_linux_amd64.tar.gz" -C "$dir" mcpsnoop
+	sum "$dir/mcpsnoop_9.9.9_linux_amd64.tar.gz" >"$dir/sum"
+	printf '%s  mcpsnoop_9.9.9_linux_amd64.tar.gz\n' "$(cat "$dir/sum")" >"$dir/checksums.txt"
+
+	cat >"$root/bin/curl" <<-'CURL'
+		#!/usr/bin/env bash
+		# Serve the last URL argument out of $SERVE_DIR, into the file after --output.
+		out=""; url=""
+		while [ $# -gt 0 ]; do
+		  case "$1" in
+		    --output) out="$2"; shift 2 ;;
+		    -*) shift ;;
+		    *) url="$1"; shift ;;
+		  esac
+		done
+		src="$SERVE_DIR/$(basename "$url")"
+		[ -f "$src" ] || { echo "curl: (56) not found: $url" >&2; exit 22; }
+		cp "$src" "$out"
+	CURL
+	chmod +x "$root/bin/curl"
+}
+
+sum() {
+	if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1; else shasum -a 256 "$1" | cut -d' ' -f1; fi
+}
+
+run() {
+	rm -rf "$root/temp"
+	mkdir -p "$root/temp"
+	: >"$root/path"
+	env PATH="$root/bin:$PATH" SERVE_DIR="$root/serve" \
+		RUNNER_TEMP="$root/temp" GITHUB_PATH="$root/path" \
+		RUNNER_OS=Linux RUNNER_ARCH=X64 GITHUB_ACTION_REF=v9.9.9 \
+		bash "$install_sh" 2>&1
+}
+
+echo "install.sh"
+
+serve
+if out="$(run)"; then
+	if [ -x "$root/temp/mcpsnoop-9.9.9/mcpsnoop" ] && grep -q "mcpsnoop-9.9.9" "$root/path"; then
+		ok "installs a release whose archive matches its checksum"
+	else
+		bad "the install reported success without leaving a binary on PATH" "$out"
+	fi
+else
+	bad "a well formed release was rejected" "$out"
+fi
+
+serve
+# One byte on the end. The checksums file still describes the original.
+printf 'x' >>"$root/serve/mcpsnoop_9.9.9_linux_amd64.tar.gz"
+if out="$(run)"; then
+	bad "installed an archive that does not match its checksum" "$out"
+else
+	case "$out" in
+	*"does not match its checksum"*) ok "rejects an archive that does not match its checksum" ;;
+	*) bad "rejected it for the wrong reason" "$out" ;;
+	esac
+fi
+
+serve
+# A checksums file that vouches for something else entirely.
+printf '%s  some-other-artifact.tar.gz\n' "$(cat "$root/serve/sum")" >"$root/serve/checksums.txt"
+if out="$(run)"; then
+	bad "installed an archive the checksums file never mentions" "$out"
+else
+	case "$out" in
+	*"does not list exactly one entry"*) ok "rejects an archive the checksums file does not vouch for" ;;
+	*) bad "rejected it for the wrong reason" "$out" ;;
+	esac
+fi
+
+serve
+# Two lines for one name. Taking either would be a guess.
+cat "$root/serve/checksums.txt" "$root/serve/checksums.txt" >"$root/serve/c" && mv "$root/serve/c" "$root/serve/checksums.txt"
+if out="$(run)"; then
+	bad "installed an archive listed twice with no way to tell which line is authoritative" "$out"
+else
+	# The message matters, not just the rejection. Two identical lines also fail
+	# the byte comparison further down, with "does not match its checksum",
+	# which sends the reader after a corrupt download that never happened.
+	case "$out" in
+	*"does not list exactly one entry"*) ok "rejects a checksums file that lists the archive more than once, and says so" ;;
+	*) bad "rejected it, but blamed the wrong thing" "$out" ;;
+	esac
+fi
+
+serve
+# A hasher that escapes its own output, which is what GNU coreutils does when the
+# name it was handed contains a backslash: it escapes the line and prefixes the
+# whole thing with one. RUNNER_TEMP on a Windows runner is D:\a\_temp, so every
+# hash came back as \<hash> and matched nothing, and the install failed on
+# releases that were fine.
+#
+# A stand-in rather than a real path with a backslash in it. The escaping is what
+# is under test; putting a backslash in a directory name instead drags in how tar
+# and the filesystem treat one, which differs between platforms and is not the
+# bug. macOS also ships a sha256sum that does not escape at all, so a test using
+# whatever is installed proves nothing on a developer's machine.
+# The real hasher resolved to an absolute path here, before the stand-in goes on
+# PATH under the same name. Written as a bare name it would find itself, and a
+# stand-in that recurses returns a pile of backslashes and nothing to compare, so
+# the case would pass whatever the script did.
+real_hasher=""
+for candidate in sha256sum shasum; do
+	if path="$(command -v "$candidate")"; then
+		case "$candidate" in
+		sha256sum) real_hasher="$path" ;;
+		shasum) real_hasher="$path -a 256" ;;
+		esac
+		break
+	fi
+done
+[ -n "$real_hasher" ] || bad "no hasher to build the stand-in from, so the case below would prove nothing"
+cat >"$root/bin/sha256sum" <<GNU
+#!/usr/bin/env bash
+line="\$($real_hasher "\$@")"
+hash="\${line%% *}"
+# Named as an argument, escape the way GNU does when the name holds a backslash.
+# Read from stdin there is no name to escape, which is the whole way out.
+if [ \$# -gt 0 ]; then printf '\\\\%s  %s\\n' "\$hash" "\$1"; else printf '%s  -\\n' "\$hash"; fi
+GNU
+chmod +x "$root/bin/sha256sum"
+# The stand-in has to produce the right hash for the file, or it is testing
+# nothing but itself.
+[ "$("$root/bin/sha256sum" <"$root/serve/mcpsnoop_9.9.9_linux_amd64.tar.gz" | cut -d' ' -f1)" = "$(cat "$root/serve/sum")" ] ||
+	bad "the stand-in hasher does not agree with the real one, so the case below proves nothing"
+if out="$(run)"; then
+	ok "is not fooled by a hasher that escapes its own output, as GNU does on Windows"
+else
+	bad "an escaping hasher broke the verification" "$out"
+fi
+rm -f "$root/bin/sha256sum"
+
+serve
+# A checksums file that also vouches for an artifact whose name contains the
+# archive's. A release that grows a signature or an SBOM alongside each archive
+# produces exactly this, and a substring match would then have two candidates
+# and no way to tell which line describes the file it is about to unpack.
+{
+	printf '%s  %s\n' "$(cat "$root/serve/sum")" "mcpsnoop_9.9.9_linux_amd64.tar.gz.sig"
+	cat "$root/serve/checksums.txt"
+} >"$root/serve/c" && mv "$root/serve/c" "$root/serve/checksums.txt"
+if out="$(run)"; then
+	ok "picks its own line out of a checksums file listing a similarly named artifact"
+else
+	bad "a checksums file listing a sibling artifact broke the install" "$out"
+fi
+
+serve
+# Each of these must be turned away by the validation, not by the download
+# failing later. A ref that reaches curl has already been used to build a URL,
+# which is the whole thing the validation exists to prevent, and a 404 would let
+# the test pass while it did.
+refused=1
+for bad_ref in main v1 "0.20.0" "v1.0.0';whoami;'" "v1.0.0/../../other/repo" "v1.0.0
+v2"; do
+	if out="$(rm -rf "$root/temp" && mkdir -p "$root/temp" && : >"$root/path" && env PATH="$root/bin:$PATH" SERVE_DIR="$root/serve" \
+		RUNNER_TEMP="$root/temp" GITHUB_PATH="$root/path" RUNNER_OS=Linux RUNNER_ARCH=X64 \
+		GITHUB_ACTION_REF="$bad_ref" bash "$install_sh" 2>&1)"; then
+		bad "accepted \"$bad_ref\" as a release tag" "$out"
+		refused=0
+		continue
+	fi
+	case "$out" in
+	*"is not a release tag"* | *"contains characters a release tag cannot have"*) ;;
+	*)
+		bad "\"$bad_ref\" failed, but not at the validation" "$out"
+		refused=0
+		;;
+	esac
+done
+[ "$refused" = 1 ] && ok "refuses a ref that is not a release tag before it reaches a URL"
+
+serve
+if out="$(rm -rf "$root/temp" && mkdir -p "$root/temp" && : >"$root/path" && env PATH="$root/bin:$PATH" SERVE_DIR="$root/serve" \
+	RUNNER_TEMP="$root/temp" GITHUB_PATH="$root/path" RUNNER_OS=Linux RUNNER_ARCH=RISCV \
+	GITHUB_ACTION_REF=v9.9.9 bash "$install_sh" 2>&1)"; then
+	bad "claimed to install a binary for a platform no release is built for" "$out"
+else
+	case "$out" in
+	*"no mcpsnoop release is built for"*) ok "names the platform it has nothing for, and says what to do instead" ;;
+	*) bad "the message does not name the platform" "$out" ;;
+	esac
+fi
+
+exit "$fail"

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -80,7 +80,14 @@ func newCheckCmd() *cobra.Command {
 			sessionLog, err := loadCheckSession(cmd, arg, format.needsLineIndex())
 			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
-				return exitCode(1)
+				// 2, not 1, and the difference is the whole contract a CI wrapper
+				// rests on. 1 means the check ran and something failed the gate, so
+				// a wrapper reports the findings and carries on. This is the other
+				// thing: a path that is not there, a file that is not a session log.
+				// Sharing an exit code with a real finding lets a typo in a workflow
+				// read as a checked run, which is the one outcome a gate must never
+				// produce.
+				return exitCode(2)
 			}
 			st := sessionLog.store
 
@@ -102,7 +109,9 @@ func newCheckCmd() *cobra.Command {
 			case checkFormatJUnit:
 				if err := writeCheckJUnit(cmd.OutOrStdout(), summaries, signals, assertionFailures); err != nil {
 					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
-					return exitCode(1)
+					// The report never reached the reader, so no verdict was delivered
+					// whatever the traffic held. Same bucket as a log that would not load.
+					return exitCode(2)
 				}
 				if checkFailed(summaries, signals) {
 					anyFailed = true
@@ -110,7 +119,7 @@ func newCheckCmd() *cobra.Command {
 			case checkFormatSARIF:
 				if err := writeCheckSARIF(cmd.OutOrStdout(), sessionLog, summaries, signals, assertionFailures); err != nil {
 					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop check:", err)
-					return exitCode(1)
+					return exitCode(2)
 				}
 				if checkFailed(summaries, signals) {
 					anyFailed = true
@@ -430,6 +439,28 @@ func checkFailed(summaries []checkSummary, selected map[checkSignal]bool) bool {
 	return false
 }
 
+// driftUnverified says why this run compared nothing against the tool baseline,
+// and is empty when it did compare. Two causes, one consequence. A baseline that
+// would not load is one. A baseline recorded for the first time is the other, and
+// it is the ordinary state of an ephemeral CI, where the state directory starts
+// empty on every run and every run is therefore a first run.
+//
+// The text and junit formats have always said so out loud. Saying so was not
+// enough: a run that asked to fail on drift and then verified nothing still
+// passed, which is exactly the reading the baseline mechanism exists to prevent.
+// So a selected drift signal fails on either cause. Nothing changes for a run
+// that did not select it.
+func (s checkSummary) driftUnverified() string {
+	if s.drift.BaselineError != "" {
+		return "tool baseline error: " + s.drift.BaselineError
+	}
+	if s.baselineCreated {
+		return "recorded first-seen tool baseline, so no tool definition was verified; " +
+			"point --baseline at a directory that survives between runs"
+	}
+	return ""
+}
+
 func (s checkSummary) count(signal checkSignal) int {
 	switch signal {
 	case checkError:
@@ -445,10 +476,10 @@ func (s checkSummary) count(signal checkSignal) int {
 	case checkLateResult:
 		return s.lateResults
 	case checkDrift:
-		// A baseline error is not drift, but it means drift could not be verified,
-		// so count it as a drift failure for a run that selected the drift signal.
+		// Not being able to verify is not the same as having verified and found
+		// nothing, so it counts for a run that selected the drift signal.
 		n := s.drift.Count()
-		if s.drift.BaselineError != "" {
+		if s.driftUnverified() != "" {
 			n++
 		}
 		return n

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -159,7 +159,9 @@ func newCheckCmd() *cobra.Command {
 	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, late-result, drift, deprecated, incomplete, schema")
 	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text, junit, or sarif")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
-	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
+	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this wall-clock duration, including time a user spent answering an elicitation (e.g. 500ms), disabled when zero")
+	cmd.Flags().DurationVar(&assertions.maxServerDuration, "max-server-duration", 0, "fail if the server's own share of any completed tool call exceeds this duration, excluding time the client took to answer, disabled when zero")
+	cmd.Flags().IntVar(&assertions.maxRoundTrips, "max-round-trips", 0, "fail if any tool call took more than this many requests, which multi round-trip requests make possible, disabled when zero")
 	cmd.Flags().StringArrayVar(&assertions.expectTools, "expect-tool", nil, "fail if this tool was never called, repeatable")
 	cmd.Flags().StringArrayVar(&assertions.forbidTools, "forbid-tool", nil, "fail if this tool was called, repeatable")
 	return cmd
@@ -168,9 +170,18 @@ func newCheckCmd() *cobra.Command {
 // checkAssertions holds the first-class check assertions, evaluated per session
 // on top of the signal counts.
 type checkAssertions struct {
-	maxDuration time.Duration
-	expectTools []string
-	forbidTools []string
+	// maxDuration is wall clock for the whole interaction and deliberately stays
+	// that way. Under multi round-trip requests one tool call is several requests
+	// and the seconds a person spent answering are inside the span, which is the
+	// point: that interval is the one you most want to see. Redefining this flag
+	// to measure only the server would quietly loosen every pipeline that already
+	// sets it, so the two figures underneath get flags of their own that say what
+	// they measure.
+	maxDuration       time.Duration
+	maxServerDuration time.Duration
+	maxRoundTrips     int
+	expectTools       []string
+	forbidTools       []string
 }
 
 // eval returns one message per assertion the session violates, empty when all
@@ -178,7 +189,8 @@ type checkAssertions struct {
 // The latency budget only judges calls that got a response, since a call that
 // never did has no real latency and is the pending signal's job.
 func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
-	if a.maxDuration <= 0 && len(a.expectTools) == 0 && len(a.forbidTools) == 0 {
+	if a.maxDuration <= 0 && a.maxServerDuration <= 0 && a.maxRoundTrips <= 0 &&
+		len(a.expectTools) == 0 && len(a.forbidTools) == 0 {
 		return nil
 	}
 	calls := st.Calls(sessionID)
@@ -209,13 +221,12 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 			}
 		}
 		if exceeded > 0 {
-			callWord := "calls"
-			if exceeded == 1 {
-				callWord = "call"
-			}
 			failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %s budget (worst: tool %q took %s)",
-				exceeded, callWord, a.maxDuration, worstTool, worstDuration.Round(time.Millisecond)))
+				exceeded, callWord(exceeded), a.maxDuration, worstTool, worstDuration.Round(time.Millisecond)))
 		}
+	}
+	if a.maxServerDuration > 0 || a.maxRoundTrips > 0 {
+		failures = append(failures, a.evalInteractions(st, sessionID)...)
 	}
 	for _, name := range a.expectTools {
 		if !called[name] {
@@ -228,6 +239,66 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 		}
 	}
 	return failures
+}
+
+// evalInteractions judges the two figures underneath a wall-clock duration, the
+// share the server held the operation for and how many requests it took.
+//
+// Both are read off frame timestamps and a link mcpsnoop already inferred, so
+// neither guesses at intent, which is what a check has to be able to say. A tool
+// call that never completed is skipped for the same reason --max-duration skips
+// it: an operation still open has no latency to judge, and the pending signal is
+// what reports it.
+func (a checkAssertions) evalInteractions(st *store.Store, sessionID string) []string {
+	var failures []string
+	slowest, slowestTool, slowCount := time.Duration(0), "", 0
+	mostTrips, tripsTool, tripsCount := 0, "", 0
+	for _, in := range st.Interactions(sessionID) {
+		if in.ToolName == "" {
+			continue
+		}
+		// A round trip count needs no ending. Every request of the chain has already
+		// happened, so a runaway one is countable while it is still running, and
+		// that is the case the budget exists for: a server asking again and again is
+		// exactly the operation nobody ever finishes. Skipping it made the assertion
+		// silent on its own headline case.
+		if a.maxRoundTrips > 0 && in.RoundTrips > a.maxRoundTrips {
+			tripsCount++
+			if in.RoundTrips > mostTrips {
+				mostTrips, tripsTool = in.RoundTrips, in.ToolName
+			}
+		}
+		// A latency does need one, which is the rule --max-duration already applies.
+		// An operation still open has no round trip to judge, a superseded one was
+		// never answered, and a cancelled one without a late result delivered
+		// nothing. The pending signal is what reports those.
+		if !in.Measurable() {
+			continue
+		}
+		if a.maxServerDuration > 0 && in.ServerTime > a.maxServerDuration {
+			slowCount++
+			if in.ServerTime > slowest {
+				slowest, slowestTool = in.ServerTime, in.ToolName
+			}
+		}
+	}
+	if slowCount > 0 {
+		failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %s server budget (worst: tool %q held for %s)",
+			slowCount, callWord(slowCount), a.maxServerDuration, slowestTool, slowest.Round(time.Millisecond)))
+	}
+	if tripsCount > 0 {
+		failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %d round trip budget (worst: tool %q took %d)",
+			tripsCount, callWord(tripsCount), a.maxRoundTrips, tripsTool, mostTrips))
+	}
+	return failures
+}
+
+// callWord picks the noun for a count, so a failure line reads as a sentence.
+func callWord(n int) string {
+	if n == 1 {
+		return "call"
+	}
+	return "calls"
 }
 
 func parseCheckSignals(value string) (map[checkSignal]bool, error) {

--- a/cmd/mcpsnoop/check_junit.go
+++ b/cmd/mcpsnoop/check_junit.go
@@ -96,11 +96,13 @@ func buildCheckJUnit(summaries []checkSummary, selected map[checkSignal]bool, as
 			}
 			if selected[signal] && count > 0 {
 				reason := checkSignalFailureReason(summary.sessionID, signal, count)
-				// A baseline that could not be read is not a tool change, and telling a
-				// CI reader to go looking for one sends them after something that never
-				// happened. The text format already says which it is.
-				if signal == checkDrift && summary.drift.BaselineError != "" {
-					reason = "tool baseline error: " + summary.drift.BaselineError
+				// A baseline that could not be read, or one being written for the first
+				// time, is not a tool change, and telling a CI reader to go looking for
+				// one sends them after something that never happened.
+				if signal == checkDrift && summary.drift.Count() == 0 {
+					if why := summary.driftUnverified(); why != "" {
+						reason = why
+					}
 				}
 				testcase.Failure = &checkJUnitFailure{
 					Message: reason,

--- a/cmd/mcpsnoop/check_sarif.go
+++ b/cmd/mcpsnoop/check_sarif.go
@@ -205,14 +205,17 @@ type sarifBuilder struct {
 // over the same log produce byte-identical output.
 func (b *sarifBuilder) session(st *store.Store, summary checkSummary) {
 	sessionID := summary.sessionID
-	if summary.baselineCreated {
-		// A first-seen baseline is recorded, not verified, which the text and junit
-		// formats both say out loud. SARIF has no equivalent of junit's <skipped>,
-		// so it is a note: the run is not failing, but it verified nothing either,
-		// and a log carrying no result at all would read as though it had.
-		b.add(sessionID, sarifRuleID(checkDrift), sarifLevelNote,
-			fmt.Sprintf("session %s: recorded first-seen tool baseline (trusted, not verified)", sessionID),
-			"baseline-recorded", 0)
+	if why := summary.driftUnverified(); why != "" && b.selected[checkDrift] {
+		// Only when the run asked to be gated on drift. A code-scanning alert is a
+		// thing somebody has to dismiss by hand, and it outlives the run that filed
+		// it; a first-seen baseline is the ordinary state of an ephemeral CI, so
+		// filing one unconditionally opened an alert on every clean run for ever.
+		// It is also a fact about the run rather than about the traffic, which is
+		// what a text summary is for. Where the gate does care, the level follows
+		// the gate, the way every other result here does.
+		b.add(sessionID, sarifRuleID(checkDrift), b.level(checkDrift),
+			fmt.Sprintf("session %s: %s", sessionID, why),
+			"baseline-unverified", 0)
 	}
 
 	var toolListSeq uint64

--- a/cmd/mcpsnoop/check_sarif_test.go
+++ b/cmd/mcpsnoop/check_sarif_test.go
@@ -341,9 +341,12 @@ func TestCheckSARIFReportsAssertionFailures(t *testing.T) {
 	}
 }
 
-// TestCheckSARIFMarksTheFirstSeenBaseline. A run that recorded a baseline
-// verified nothing, and a log with no result at all would read as though it had.
-func TestCheckSARIFMarksTheFirstSeenBaseline(t *testing.T) {
+// TestCheckSARIFFilesNoAlertForACleanRunThatRecordedABaseline. A code-scanning
+// alert is something a person has to dismiss by hand and it outlives the run
+// that filed it. Recording a first-seen baseline is the ordinary state of an
+// ephemeral CI, where the state directory starts empty every time, so filing one
+// for it opened an alert on every clean run for ever.
+func TestCheckSARIFFilesNoAlertForACleanRunThatRecordedABaseline(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	log := encodeCheckLog(t,
@@ -353,18 +356,41 @@ func TestCheckSARIFMarksTheFirstSeenBaseline(t *testing.T) {
 
 	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--baseline", dir, "-"}, log)
 	if code != 0 {
-		t.Fatalf("exit = %d, want 0: recording a baseline is not a failure", code)
+		t.Fatalf("exit = %d, want 0: recording a baseline is not a failure when drift is not gated", code)
+	}
+	report := decodeCheckSARIF(t, stdout)
+	if n := len(report.Runs[0].Results); n != 0 {
+		t.Fatalf("a clean session produced %d results, want none\n%s", n, stdout)
+	}
+}
+
+// TestCheckSARIFReportsAnUnverifiableBaselineWhenDriftIsGated. Where the gate
+// does care, the report says so, at the level the gate uses, the way every other
+// result here does. The message has to carry the way out, since the reader is
+// looking at an alert and not at the terminal that printed the text summary.
+func TestCheckSARIFReportsAnUnverifiableBaselineWhenDriftIsGated(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","inputSchema":{"type":"object"}}]}}`),
+	)
+
+	code, stdout, _ := executeCheck(t, []string{"--format", "sarif", "--fail-on", "drift", "--baseline", dir, "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1: a run gated on drift that verified nothing has not passed", code)
 	}
 	results := sarifResultsFor(decodeCheckSARIF(t, stdout), "mcpsnoop/drift")
 	if len(results) != 1 {
-		t.Fatalf("drift results = %d, want the baseline note\n%s", len(results), stdout)
+		t.Fatalf("drift results = %d, want one\n%s", len(results), stdout)
 	}
-	if !strings.Contains(results[0].Message.Text, "recorded first-seen tool baseline (trusted, not verified)") {
-		t.Fatalf("the baseline note must say what junit's <skipped> says: %q", results[0].Message.Text)
+	if results[0].Level != "error" {
+		t.Fatalf("level = %q, want error so the report and the gate agree", results[0].Level)
 	}
-	// A first-seen baseline is not drift, so its level never follows the gate.
-	if results[0].Level != "note" {
-		t.Fatalf("baseline level = %q, want note", results[0].Level)
+	for _, want := range []string{"recorded first-seen tool baseline", "--baseline"} {
+		if !strings.Contains(results[0].Message.Text, want) {
+			t.Errorf("the message does not mention %q: %q", want, results[0].Message.Text)
+		}
 	}
 }
 

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -206,8 +206,11 @@ func TestCheckRejectsUnknownOrEmptyFailOnValues(t *testing.T) {
 func TestCheckReportsMalformedInput(t *testing.T) {
 	t.Setenv("MCPSNOOP_HOME", t.TempDir())
 	code, stdout, stderr := executeCheck(t, []string{"-"}, "not-json\n")
-	if code != 1 {
-		t.Fatalf("exit = %d, want 1", code)
+	// 2, the same as a bad flag, because both mean the check never happened.
+	// Sharing 1 with a real finding is what lets a wrapper report a checked run
+	// after checking nothing.
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2: input that will not load is not a finding", code)
 	}
 	if stdout != "" {
 		t.Fatalf("stdout = %q, want empty", stdout)
@@ -345,8 +348,11 @@ func TestCheckFailsOnToolDefinitionDriftWhenSelected(t *testing.T) {
 		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
 		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"Search docs","inputSchema":{"type":"object"}}]}}`),
 	)
+	// The first run has no baseline to compare against, and a run that selected
+	// the drift signal and then verified nothing does not pass. It records the
+	// baseline all the same, which is what lets the second run below verify.
 	code, _, stderr := executeCheck(t, []string{"--fail-on", "drift", "-"}, baseline)
-	if code != 0 || stderr != "" {
+	if code != 1 || stderr != "" {
 		t.Fatalf("baseline check = code %d, stderr %q", code, stderr)
 	}
 
@@ -378,9 +384,10 @@ func TestCheckBaselineFlagRecordsThenDetectsDrift(t *testing.T) {
 		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search","description":"Search docs","inputSchema":{"type":"object"}}]}}`),
 	)
 
-	// First run against an empty baseline dir records; it does not verify.
+	// First run against an empty baseline dir records; it does not verify, and a
+	// run gated on drift that verified nothing is not a pass.
 	code, stdout, stderr := executeCheck(t, []string{"--fail-on", "drift", "--baseline", dir, "-"}, baseline)
-	if code != 0 || stderr != "" {
+	if code != 1 || stderr != "" {
 		t.Fatalf("first run = code %d, stderr %q", code, stderr)
 	}
 	if !strings.Contains(stdout, "recorded first-seen tool baseline") {
@@ -963,5 +970,87 @@ func TestCheckRoundTripsCountsAnUnfinishedChain(t *testing.T) {
 	code, stdout, _ = executeCheck(t, []string{"--max-server-duration", "1ms", "-"}, log)
 	if code != 0 {
 		t.Fatalf("the server budget judged an operation that never completed, code %d: %s", code, stdout)
+	}
+}
+
+// TestCheckSeparatesAFindingFromNotHavingChecked pins the contract every CI
+// wrapper rests on, and the one this command had wrong.
+//
+// A wrapper has to decide what to do with a non-zero exit. On 1 it publishes the
+// findings and lets the gate decide the build. On anything else it must stop and
+// say the run did not happen. While a missing file and a real finding shared an
+// exit code, neither choice was right: treating 1 as findings made a typo in a
+// workflow path read as a checked run, and treating it as a hard error kept
+// genuine findings out of the report they exist to reach.
+//
+// The report side is the same promise. A run that did the work writes a whole
+// SARIF document to stdout and nothing to stderr; a run that could not writes
+// nothing to stdout, so a wrapper never uploads a truncated or empty report as
+// though it were a verdict.
+func TestCheckSeparatesAFindingFromNotHavingChecked(t *testing.T) {
+	dirty := encodeCheckLog(t,
+		checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"boom"}}`),
+		checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"no such tool"}}`),
+	)
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		stdin    string
+		wantCode int
+		wantJSON bool
+	}{
+		{
+			name: "a clean session", args: []string{"--format", "sarif", "-"},
+			stdin: encodeCheckLog(t,
+				checkEnvelope(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+				checkEnvelope(2, proxy.ServerToClient, `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`),
+			),
+			wantCode: 0, wantJSON: true,
+		},
+		{
+			name: "a session with a finding", args: []string{"--format", "sarif", "-"},
+			stdin: dirty, wantCode: 1, wantJSON: true,
+		},
+		{
+			name: "a log that will not parse", args: []string{"--format", "sarif", "-"},
+			stdin: "not-json\n", wantCode: 2, wantJSON: false,
+		},
+		{
+			name: "a path that is not there", args: []string{"--format", "sarif", "no-such-file.jsonl"},
+			wantCode: 2, wantJSON: false,
+		},
+		{
+			name: "a state directory holding nothing", args: []string{"--format", "sarif"},
+			wantCode: 2, wantJSON: false,
+		},
+		{
+			name: "a signal that does not exist", args: []string{"--format", "sarif", "--fail-on", "nonsense", "-"},
+			stdin: dirty, wantCode: 2, wantJSON: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MCPSNOOP_HOME", t.TempDir())
+			code, stdout, stderr := executeCheck(t, tc.args, tc.stdin)
+			if code != tc.wantCode {
+				t.Fatalf("exit = %d, want %d\nstdout %q\nstderr %q", code, tc.wantCode, stdout, stderr)
+			}
+			if !tc.wantJSON {
+				if stdout != "" {
+					t.Errorf("wrote %d bytes to stdout for a run that did not happen, which a wrapper would upload as a report", len(stdout))
+				}
+				if stderr == "" {
+					t.Error("said nothing on stderr, so the reason is nowhere")
+				}
+				return
+			}
+			if stderr != "" {
+				t.Errorf("stderr = %q, want empty on a run that did the work", stderr)
+			}
+			report := decodeCheckSARIF(t, stdout)
+			if len(report.Runs) != 1 || report.Runs[0].Tool.Driver.Name != "mcpsnoop" {
+				t.Fatalf("stdout is not a mcpsnoop SARIF document:\n%s", stdout)
+			}
+		})
 	}
 }

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -801,3 +801,167 @@ func TestCheckRejectsAnUnknownSignalAndAcceptsEveryKnownOne(t *testing.T) {
 		t.Fatal("an unknown signal must be rejected rather than silently ignored")
 	}
 }
+
+// mrtrCheckLog is the capture from issue #201, encoded for check -. The server
+// works 1.2s in total while the user takes 37s, so the wall clock is 38.2s.
+func mrtrCheckLog(t *testing.T) string {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	envs := make([]proxy.Envelope, 0, len(frames))
+	for i, f := range frames {
+		envs = append(envs, proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Raw: json.RawMessage(f.raw)})
+	}
+	return encodeCheckLog(t, envs...)
+}
+
+// TestCheckServerDurationBlamesTheServerAlone is the reason the flag exists.
+// --max-duration blames a tool for 38.2s of which it is responsible for 1.2s,
+// because the seconds a person spent answering are inside the span. That figure
+// stays what it is, and this one names what it measures.
+func TestCheckServerDurationBlamesTheServerAlone(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := mrtrCheckLog(t)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-server-duration", "1s", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for a server over the budget", code)
+	}
+	if !strings.Contains(stdout, `1 tool call exceeded the 1s server budget (worst: tool "book_flight" held for 1.2s)`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if strings.Contains(stdout, "38.2s") {
+		t.Fatalf("the server budget reported the wall clock:\n%s", stdout)
+	}
+
+	code, stdout, _ = executeCheck(t, []string{"--max-server-duration", "2s", "-"}, log)
+	if code != 0 || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("a server within budget should pass, code %d stdout %q", code, stdout)
+	}
+}
+
+// TestCheckRoundTripsAssertion covers the second sibling, which multi round-trip
+// requests make possible: the specification puts no bound on how many times a
+// server may ask again.
+func TestCheckRoundTripsAssertion(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := mrtrCheckLog(t)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-round-trips", "2", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for a chain over the budget", code)
+	}
+	if !strings.Contains(stdout, `1 tool call exceeded the 2 round trip budget (worst: tool "book_flight" took 3)`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+
+	code, stdout, _ = executeCheck(t, []string{"--max-round-trips", "3", "-"}, log)
+	if code != 0 || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("a chain within budget should pass, code %d stdout %q", code, stdout)
+	}
+}
+
+// TestCheckWallClockIsUnchangedByTheSiblings is the promise the whole flag
+// surface rests on. Nobody's pipeline changes behaviour on upgrade, so
+// --max-duration still means the whole interaction including the human.
+func TestCheckWallClockIsUnchangedByTheSiblings(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := mrtrCheckLog(t)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-duration", "5s", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stdout, `1 tool call exceeded the 5s budget (worst: tool "book_flight" took 38.2s)`) {
+		t.Fatalf("--max-duration no longer means wall clock: %q", stdout)
+	}
+
+	// And the new ones are opt in, so a default run over the same capture passes.
+	code, stdout, _ = executeCheck(t, []string{"-"}, log)
+	if code != 0 || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("a default run should be unaffected, code %d stdout %q", code, stdout)
+	}
+}
+
+// TestCheckSiblingsSkipAnOperationWithNoLatency keeps the two new assertions to
+// the same rule --max-duration already applies. An operation still open has no
+// latency to judge, and reporting one would blame a server for a chain the
+// client walked away from.
+func TestCheckSiblingsSkipAnOperationWithNoLatency(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	// A chain the client abandoned after two answers, over an hour of wall clock.
+	log := encodeCheckLog(t,
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0, Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book"}}`)},
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Hour), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st","inputRequests":{"q":{"method":"elicitation/create"}}}}`)},
+	)
+	for _, args := range [][]string{
+		{"--max-server-duration", "1ms", "-"},
+		{"--max-round-trips", "1", "-"},
+	} {
+		code, stdout, _ := executeCheck(t, args, log)
+		if code != 0 {
+			t.Fatalf("%v exited %d on an operation that never completed: %s", args, code, stdout)
+		}
+	}
+}
+
+// TestCheckRoundTripsCountsAnUnfinishedChain is the case the assertion exists
+// for. A server asking again and again produces exactly the operation nobody
+// finishes, so gating the count on completion made the budget silent on its own
+// headline case. A latency still needs an ending; a count of requests already
+// made does not.
+func TestCheckRoundTripsCountsAnUnfinishedChain(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"a":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 5000, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"a":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 5400, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"b":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 9000, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"b":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 9400, `{"jsonrpc":"2.0","id":3,"result":{"resultType":"input_required","requestState":"st-3","inputRequests":{"c":{"method":"elicitation/create"}}}}`},
+	}
+	envs := make([]proxy.Envelope, 0, len(frames))
+	for i, f := range frames {
+		envs = append(envs, proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir, Raw: json.RawMessage(f.raw)})
+	}
+	log := encodeCheckLog(t, envs...)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-round-trips", "2", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; the chain took three requests and nobody finished it\n%s", code, stdout)
+	}
+	if !strings.Contains(stdout, `exceeded the 2 round trip budget (worst: tool "book_flight" took 3)`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+
+	// A latency, by contrast, still needs an ending, so the server budget stays
+	// quiet on the same capture.
+	code, stdout, _ = executeCheck(t, []string{"--max-server-duration", "1ms", "-"}, log)
+	if code != 0 {
+		t.Fatalf("the server budget judged an operation that never completed, code %d: %s", code, stdout)
+	}
+}

--- a/cmd/mcpsnoop/config.go
+++ b/cmd/mcpsnoop/config.go
@@ -19,6 +19,7 @@ type config struct {
 	RedactKeys    redactKeysFlag
 	RedactValues  redactValuesFlag
 	RedactPaths   redactPathsFlag
+	YouComAPIKey  string
 }
 
 func loadConfig() (config, bool, error) {
@@ -135,6 +136,9 @@ func parseConfig(r io.Reader) (config, error) {
 				return config{}, err
 			}
 
+		case "youcom-api-key":
+			cfg.YouComAPIKey = value
+
 		default:
 			return config{}, fmt.Errorf("unknown config key %q", key)
 		}
@@ -156,6 +160,7 @@ func applyConfig(
 	redactKeys *redactKeysFlag,
 	redactValues *redactValuesFlag,
 	redactPaths *redactPathsFlag,
+	youcomAPIKey *string,
 ) {
 	if !ok {
 		return
@@ -187,5 +192,9 @@ func applyConfig(
 
 	if !fs.Changed("redact-path") {
 		*redactPaths = cfg.RedactPaths
+	}
+
+	if !fs.Changed("youcom-api-key") {
+		*youcomAPIKey = cfg.YouComAPIKey
 	}
 }

--- a/cmd/mcpsnoop/config.go
+++ b/cmd/mcpsnoop/config.go
@@ -19,6 +19,7 @@ type config struct {
 	RedactKeys    redactKeysFlag
 	RedactValues  redactValuesFlag
 	RedactPaths   redactPathsFlag
+	YouComAPIKey  string
 }
 
 func loadConfig() (config, bool, error) {
@@ -135,6 +136,9 @@ func parseConfig(r io.Reader) (config, error) {
 				return config{}, err
 			}
 
+		case "youcom-api-key":
+			cfg.YouComAPIKey = value
+
 		default:
 			return config{}, fmt.Errorf("unknown config key %q", key)
 		}
@@ -156,6 +160,7 @@ func applyConfig(
 	redactKeys *redactKeysFlag,
 	redactValues *redactValuesFlag,
 	redactPaths *redactPathsFlag,
+	youcomAPIKey *string,
 ) {
 	if !ok {
 		return
@@ -187,5 +192,9 @@ func applyConfig(
 
 	if !fs.Changed("redact-path") {
 		*redactPaths = cfg.RedactPaths
+	}
+
+	if youcomAPIKey != nil && !fs.Changed("youcom-api-key") {
+		*youcomAPIKey = cfg.YouComAPIKey
 	}
 }

--- a/cmd/mcpsnoop/config_test.go
+++ b/cmd/mcpsnoop/config_test.go
@@ -164,7 +164,7 @@ func TestApplyConfigUsesConfigWhenFlagNotSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths, nil)
 
 	if *label != "filesystem" {
 		t.Fatalf("expected label %q, got %q", "filesystem", *label)
@@ -246,7 +246,7 @@ func TestApplyConfigExplicitFlagOverridesConfig(t *testing.T) {
 		Label: "from-config",
 	}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths, nil)
 
 	if *label != "cli" {
 		t.Fatalf("expected CLI value %q, got %q", "cli", *label)
@@ -275,7 +275,7 @@ func TestApplyConfigNoConfigFile(t *testing.T) {
 		RedactKeys:    []string{"token"},
 	}
 
-	applyConfig(fs, cfg, false, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths)
+	applyConfig(fs, cfg, false, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths, nil)
 
 	if *label != "" {
 		t.Fatal("expected label to remain unchanged")
@@ -320,7 +320,7 @@ func TestApplyConfigExplicitFalseBoolOverridesConfig(t *testing.T) {
 		NoTrace: true,
 	}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths, nil)
 
 	if *noTrace {
 		t.Fatal("expected explicit --no-trace=false to override config")
@@ -345,7 +345,7 @@ func TestApplyConfigExplicitRedactKeyOverridesConfig(t *testing.T) {
 	}
 	cfg := config{RedactKeys: []string{"config-key"}}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths, nil)
 
 	if len(redactKeys) != 1 || redactKeys[0] != "cli-key" {
 		t.Fatalf("expected explicit redact-key to win, got %v", redactKeys)
@@ -374,7 +374,7 @@ func TestApplyConfigExplicitRedactPathOverridesConfig(t *testing.T) {
 	}
 	cfg := config{RedactPaths: configPaths}
 
-	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths)
+	applyConfig(fs, cfg, true, label, traceFile, noTrace, redactSecrets, &redactKeys, &redactValues, &redactPaths, nil)
 
 	if got, want := redactPaths.String(), "$.cli.password"; got != want {
 		t.Fatalf("redact paths = %q, want %q", got, want)

--- a/cmd/mcpsnoop/inventory.go
+++ b/cmd/mcpsnoop/inventory.go
@@ -1,0 +1,524 @@
+package main
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/jsonwire"
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func newInventoryCmd() *cobra.Command {
+	var format string
+	var withTools bool
+	cmd := &cobra.Command{
+		Use:   "inventory [--tools] [--format text|json]",
+		Short: "List every MCP server that has run through mcpsnoop on this machine",
+		Long: "Fold the saved session logs into one row per server rather than one per session, reporting what launched it, from where, when it first and last ran, and how many times.\n\n" +
+			"The row key is the recorded command and working directory, not the label, because the label is derived from the command's last path element and two different servers routinely produce the same one. An HTTP session is keyed on the endpoint it proxied instead, since mcpsnoop launched nothing.\n\n" +
+			"Reading is one envelope per log, the meta frame the proxy writes first, so this stays cheap over a large sessions directory. --tools is the exception and reads each log in full to count what the server last advertised.\n\n" +
+			"Local and read only. It reports what ran on this machine through mcpsnoop, and knows nothing about servers it never wrapped. A run with --trace-file wrote outside the sessions directory and will not appear, and prune deletes logs, so first seen is only ever as old as what is still on disk.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if format != "text" && format != "json" {
+				fmt.Fprintf(cmd.ErrOrStderr(), "mcpsnoop inventory: invalid --format %q, want text or json\n", format)
+				return exitCode(2)
+			}
+			dir := paths.SessionsDir()
+			inv, err := takeInventory(dir, withTools)
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop inventory:", err)
+				return exitCode(1)
+			}
+			if format == "json" {
+				return writeInventoryJSON(cmd.OutOrStdout(), inv)
+			}
+			return writeInventoryText(cmd.OutOrStdout(), inv, withTools)
+		},
+	}
+	cmd.Flags().SortFlags = false
+	cmd.Flags().BoolVar(&withTools, "tools", false, "also count the tools each server last advertised, which reads every log in full")
+	cmd.Flags().StringVar(&format, "format", "text", "output format: text or json")
+	return cmd
+}
+
+// serverRow is one server as the inventory reports it, folded from every session
+// that shares its key.
+type serverRow struct {
+	// Key is what makes two sessions the same server. It is never printed.
+	Key string `json:"-"`
+	// Label is the name to show, and Labels holds every distinct one the runs of
+	// this server carried. They differ when someone passed --label, since the key
+	// is the command and directory: one server run once as prod and once as
+	// staging is one server, and showing only the first name would quietly drop
+	// the other.
+	Label     string   `json:"label"`
+	Labels    []string `json:"labels,omitempty"`
+	Transport string   `json:"transport,omitempty"`
+	Command   []string `json:"command,omitempty"`
+	CWD       string   `json:"cwd,omitempty"`
+	// Endpoint is the MCP endpoint of an HTTP server, already stripped of
+	// userinfo, query values and the fragment by the proxy that recorded it.
+	Endpoint string `json:"endpoint,omitempty"`
+	Runs     int    `json:"runs"`
+	// Redacted marks a row whose command is not the command that ran, because a
+	// --redact rule rewrote part of it before it was written down.
+	Redacted  bool      `json:"redacted,omitempty"`
+	FirstSeen time.Time `json:"first_seen"`
+	LastSeen  time.Time `json:"last_seen"`
+	// Tools is what the server advertised the last time it ran, and is filled in
+	// only under --tools. A nil pointer means there is no count, and ToolsNote
+	// then says why, so "not asked for", "asked and the server advertised none",
+	// "asked and the listing never finished" and "asked and the log could not be
+	// read" are four answers rather than one absent field.
+	Tools     *int   `json:"tools,omitempty"`
+	ToolsNote string `json:"tools_note,omitempty"`
+	// newestLog is the log of the most recent run, which is the only one --tools
+	// reads. Held here so the count happens once per server after the fold rather
+	// than once per session that was briefly the newest.
+	newestLog string
+	// sawMeta records that at least one of this server's logs opened with a meta
+	// frame, so a row with neither a command nor an endpoint can say whether the
+	// frame was missing or was there and carried nothing usable.
+	sawMeta bool
+	labels  map[string]struct{}
+}
+
+// inventory is the whole answer, including what it could not read. A skipped log
+// is reported rather than dropped: a zero-byte file is what a run whose exec
+// failed leaves behind, and a reader comparing session counts deserves to know
+// the difference between "nothing ran" and "something ran and left nothing
+// readable".
+type inventory struct {
+	Dir     string `json:"sessions_dir"`
+	Scanned int    `json:"scanned"`
+	// Empty counts zero-byte logs and Skipped counts the rest. They are separate
+	// because an empty log is what correct operation leaves behind, twice over: a
+	// run whose exec failed, and an HTTP proxy started and never called, which
+	// holds its meta frame back on purpose so it does not hijack a bare check or
+	// export. Calling those unreadable would report ordinary housekeeping as
+	// damage.
+	Empty   int         `json:"empty"`
+	Skipped int         `json:"skipped"`
+	Servers []serverRow `json:"servers"`
+}
+
+// sessionHead is what the first envelope of a log says about the run it opens.
+type sessionHead struct {
+	label     string
+	transport string
+	command   []string
+	cwd       string
+	endpoint  string
+	// redacted comes from the meta frame alone, never from a traffic frame. The
+	// note it drives is about the command, and a log whose head is traffic has no
+	// command to qualify, so carrying the flag across would print "part of this
+	// was rewritten" under a row that shows nothing to have rewritten.
+	redacted bool
+	meta     bool
+	started  time.Time
+}
+
+// takeInventory folds every readable log in dir into one row per server. A log it
+// cannot read is counted and stepped over, never fatal, because an unreadable one
+// among many says nothing about the rest.
+func takeInventory(dir string, withTools bool) (inventory, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return inventory{}, err
+	}
+	inv := inventory{Dir: dir}
+	rows := make(map[string]*serverRow)
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		// Stat before opening. The sessions directory is an ordinary directory that
+		// anything can write to, and os.Open on a fifo blocks in open(2) until a
+		// writer appears, which hung the whole command before it printed a line. A
+		// stat follows a symlink, so a link to a real log still works and a link to
+		// a fifo is skipped along with the fifo itself.
+		info, err := os.Stat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			inv.Skipped++
+			continue
+		}
+		if info.Size() == 0 {
+			inv.Empty++
+			continue
+		}
+		head, err := readSessionHead(path)
+		if err != nil {
+			inv.Skipped++
+			continue
+		}
+		inv.Scanned++
+		row := rows[head.key()]
+		if row == nil {
+			row = &serverRow{
+				Key: head.key(), Label: head.label, Transport: head.transport,
+				Command: head.command, CWD: head.cwd, Endpoint: head.endpoint,
+				FirstSeen: head.started, LastSeen: head.started,
+				labels: make(map[string]struct{}),
+			}
+			rows[head.key()] = row
+		}
+		row.Runs++
+		row.sawMeta = row.sawMeta || head.meta
+		if head.label != "" {
+			row.labels[head.label] = struct{}{}
+		}
+		// Redaction is sticky across runs. One scrubbed capture is enough to make
+		// the command shown here not the command that ran, and saying so on only
+		// some of a server's runs would be saying it nowhere a reader looks.
+		row.Redacted = row.Redacted || head.redacted
+		// A zero timestamp is not an early one. An envelope with no ts decodes to
+		// the zero instant, which is before everything, so taking it as the minimum
+		// would date every run of the server to year one.
+		if !head.started.IsZero() && (row.FirstSeen.IsZero() || head.started.Before(row.FirstSeen)) {
+			row.FirstSeen = head.started
+		}
+		if head.started.After(row.LastSeen) || row.Runs == 1 {
+			row.LastSeen = head.started
+			row.newestLog = path
+		}
+	}
+
+	inv.Servers = make([]serverRow, 0, len(rows))
+	for _, row := range rows {
+		row.Labels = slices.Sorted(maps.Keys(row.labels))
+		if len(row.Labels) > 0 {
+			row.Label = row.Labels[0]
+		}
+		// The count is what the server advertised the last time it ran, so exactly
+		// one log per server is read, after the fold has settled which one that is.
+		// Doing it during the fold would read every log that was briefly the newest
+		// and throw all but one away.
+		if withTools {
+			n, status := countTools(row.newestLog)
+			switch status {
+			case toolsCounted:
+				row.Tools = &n
+			case toolsIncomplete:
+				row.ToolsNote = "the newest run has no complete tools/list"
+			case toolsUnreadable:
+				row.ToolsNote = "the newest run's log could not be read past its head"
+			}
+		}
+		inv.Servers = append(inv.Servers, *row)
+	}
+	// Sorted by name and then by key rather than by recency, so running this twice
+	// with nothing new produces the same bytes and a diff between two machines or
+	// two dates shows what actually differs rather than what merely ran again.
+	slices.SortFunc(inv.Servers, func(a, b serverRow) int {
+		if c := cmp.Compare(a.Label, b.Label); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Key, b.Key)
+	})
+	return inv, nil
+}
+
+// openLog opens one session log. It is a variable so a test can observe how much
+// of a file the walk actually pulls, which is the one thing the whole design
+// rests on and which no assertion about the returned rows can see: json.Decoder
+// stops at the end of the first value however many bytes it was handed, so a
+// reader that slurped the file whole first would answer identically.
+var openLog = func(path string) (io.ReadCloser, error) { return os.Open(path) }
+
+// countTools is the only read that goes past a log's head, and is a variable for
+// the same reason: nothing about the rows says whether it ran, so a test that
+// needs to know the plain path left it alone has to be told.
+var countTools = countAdvertisedTools
+
+// readSessionHead reads the first envelope of a log and nothing else. The proxy
+// writes the meta frame first on both transports, so one decode answers what a
+// run was, and json.Decoder stops at the end of that value rather than reading
+// the file. A log large enough to matter is exactly the log worth not reading.
+func readSessionHead(path string) (sessionHead, error) {
+	f, err := openLog(path)
+	if err != nil {
+		return sessionHead{}, err
+	}
+	defer f.Close()
+
+	var env proxy.Envelope
+	if err := json.NewDecoder(f).Decode(&env); err != nil {
+		return sessionHead{}, err
+	}
+	if env.SessionID == "" {
+		return sessionHead{}, fmt.Errorf("%s: first envelope names no session", path)
+	}
+	head := sessionHead{
+		label:     env.ServerLabel,
+		transport: env.Transport,
+		started:   env.TS,
+	}
+	if env.Direction != proxy.DirectionMeta {
+		// A log whose first frame is traffic predates the meta frame on its
+		// transport, or had its head trimmed. It still names a server that ran, so
+		// it gets a row from what it does carry rather than vanishing, which for
+		// HTTP is every log captured before mcpsnoop recorded an endpoint at all.
+		return head, nil
+	}
+	var meta proxy.SessionMeta
+	if err := json.Unmarshal(env.Raw, &meta); err != nil {
+		return sessionHead{}, err
+	}
+	head.command, head.cwd, head.endpoint = meta.Command, meta.CWD, meta.Target
+	head.redacted, head.meta = env.Redacted, true
+	return head, nil
+}
+
+// key is what makes two sessions the same server.
+//
+// For stdio it is the recorded command and working directory, never the label,
+// because labelFor derives the label from the command's last path element and
+// two checkouts of one project, or two servers written in one language, collide
+// there routinely. For HTTP it is the endpoint, since mcpsnoop launched nothing
+// and the endpoint is what the transport specification makes the server's
+// identity. A log carrying neither falls back to its label and transport, which
+// is the most a trimmed or pre-meta log can honestly claim.
+//
+// A redacted command keys as itself. Two runs of one server, one scrubbed and
+// one not, are two rows, and that is the honest answer: mcpsnoop cannot know
+// what the placeholder replaced, and merging them would mean guessing that the
+// hidden halves matched.
+func (h sessionHead) key() string {
+	const sep = "\x00"
+	switch {
+	case len(h.command) > 0:
+		return "stdio" + sep + h.cwd + sep + strings.Join(h.command, sep)
+	case h.endpoint != "":
+		return "http" + sep + h.endpoint
+	default:
+		return "label" + sep + h.transport + sep + h.label
+	}
+}
+
+// toolCountStatus distinguishes the three ways --tools can fail to produce a
+// number, because one sentence for all of them makes mcpsnoop state something
+// false. A log that could not be read is not a server that advertised nothing,
+// and printing the second when the first happened is a wrong answer rather than
+// a missing one.
+type toolCountStatus int
+
+const (
+	toolsCounted toolCountStatus = iota
+	toolsIncomplete
+	toolsUnreadable
+)
+
+// countAdvertisedTools reports how many tools a session's server advertised, and
+// is the only part of the inventory that reads past the first envelope, which is
+// why it is behind a flag.
+//
+// A partial tools/list is not a count: the server was still paginating, so
+// reporting what arrived would understate it, and there is no honest number to
+// print. That is toolsIncomplete. A log the decoder could not finish is
+// toolsUnreadable, which is a different thing and says so.
+//
+// The store is bounded because the answer does not need the frames. A tool
+// inventory and whether its listing completed are session state the store folds
+// in at ingest and eviction does not touch, so a hundred-megabyte log is read
+// through a fixed window rather than held whole to extract one integer. The
+// bound is generous enough that nothing here is even close to it, and exists so
+// that walking every server on a machine cannot be sunk by whichever log happens
+// to be the largest.
+func countAdvertisedTools(path string) (int, toolCountStatus) {
+	const (
+		toolCountBodyBytes = 8 << 20
+		toolCountFrames    = 50_000
+	)
+	st, sessionID, err := exporter.LoadFileTolerantBounded(path, toolCountBodyBytes, toolCountFrames)
+	if err != nil {
+		return 0, toolsUnreadable
+	}
+	definitions, complete := st.ToolDefinitions(sessionID)
+	if !complete {
+		return 0, toolsIncomplete
+	}
+	return len(definitions), toolsCounted
+}
+
+func writeInventoryJSON(w io.Writer, inv inventory) error {
+	enc := jsonwire.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(inv)
+}
+
+func writeInventoryText(w io.Writer, inv inventory, withTools bool) error {
+	if len(inv.Servers) == 0 {
+		_, err := fmt.Fprintf(w, "no servers found in %s%s\n", inv.Dir, unreadTail(inv))
+		return err
+	}
+
+	header := fmt.Sprintf("%s across %s in %s%s",
+		plural(len(inv.Servers), "server"), plural(inv.Scanned, "session"), inv.Dir, unreadTail(inv))
+	if _, err := fmt.Fprintln(w, header); err != nil {
+		return err
+	}
+
+	for _, row := range inv.Servers {
+		name := oneLine(row.Label)
+		if name == "" {
+			name = "(unlabelled)"
+		}
+		if len(row.Labels) > 1 {
+			names := make([]string, 0, len(row.Labels))
+			for _, l := range row.Labels {
+				names = append(names, oneLine(l))
+			}
+			name = strings.Join(names, ", ")
+		}
+		transport := oneLine(row.Transport)
+		if transport == "" {
+			transport = "unknown"
+		}
+		if _, err := fmt.Fprintf(w, "\n%s  %s  %s\n", name, transport, plural(row.Runs, "run")); err != nil {
+			return err
+		}
+		switch {
+		case len(row.Command) > 0:
+			if err := field(w, "command", renderCommand(row.Command)); err != nil {
+				return err
+			}
+			if row.CWD != "" {
+				if err := field(w, "cwd", row.CWD); err != nil {
+					return err
+				}
+			}
+		case row.Endpoint != "":
+			if err := field(w, "endpoint", row.Endpoint); err != nil {
+				return err
+			}
+		case row.sawMeta:
+			if err := field(w, "command", "not recorded, the meta frame of this log names neither a command nor an endpoint"); err != nil {
+				return err
+			}
+		default:
+			if err := field(w, "command", "not recorded, this log has no meta frame"); err != nil {
+				return err
+			}
+		}
+		if row.Redacted {
+			if err := field(w, "redacted", "a --redact rule rewrote part of this, so it is not the command that ran"); err != nil {
+				return err
+			}
+		}
+		if withTools {
+			count := row.ToolsNote
+			if row.Tools != nil {
+				count = plural(*row.Tools, "tool")
+			}
+			if err := field(w, "tools", count); err != nil {
+				return err
+			}
+		}
+		if err := field(w, "seen", seenRange(row)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// unreadTail names what the walk could not fold in, so a reader comparing
+// session counts is never left to guess. Empty logs are named separately from
+// unreadable ones because an empty one is the ordinary residue of a failed exec
+// or of an HTTP proxy nobody called, not damage.
+func unreadTail(inv inventory) string {
+	var parts []string
+	if inv.Empty > 0 {
+		parts = append(parts, plural(inv.Empty, "empty log")+" left by a run that recorded nothing")
+	}
+	if inv.Skipped > 0 {
+		parts = append(parts, plural(inv.Skipped, "log")+" skipped as unreadable")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return ", " + strings.Join(parts, ", ")
+}
+
+// seenRange renders when a server first and last ran, both ends in the reader's
+// own zone. Rendering each end in the offset its own log recorded made a range
+// print backwards across a daylight-saving change, since 03:10+02:00 is later
+// than 03:30+03:00 and reads earlier.
+func seenRange(row serverRow) string {
+	first := row.FirstSeen.Local().Format(time.RFC3339)
+	if last := row.LastSeen.Local().Format(time.RFC3339); last != first {
+		return first + " to " + last
+	}
+	return first
+}
+
+// renderCommand joins argv for a reader without losing where one argument ends
+// and the next begins. An element holding a space is ordinary, since
+// `node "~/My Project/build/index.js"` is how half the world installs a server,
+// and joined plainly it is indistinguishable from two arguments.
+func renderCommand(argv []string) string {
+	parts := make([]string, 0, len(argv))
+	for _, arg := range argv {
+		if arg == "" || strings.ContainsAny(arg, " \t\"'\\") || hasControl(arg) {
+			parts = append(parts, strconv.Quote(arg))
+			continue
+		}
+		parts = append(parts, arg)
+	}
+	return strings.Join(parts, " ")
+}
+
+// field renders one labelled line of a server block, padded so the values line
+// up under each other.
+func field(w io.Writer, name, value string) error {
+	_, err := fmt.Fprintf(w, "  %-9s %s\n", name, oneLine(value))
+	return err
+}
+
+// oneLine keeps a value the log supplied from ending the line it is printed on.
+//
+// A command argument, a working directory and a derived label are written by
+// whatever installed the server rather than by mcpsnoop, and none of them is
+// checked for control characters on the way in: labelFor only trims at the last
+// separator, and a working directory comes off the filesystem, so a directory
+// whose name holds a newline is enough. Printed raw, that newline closes the
+// field and every following line reads as a fresh server block, so a baseline
+// somebody diffs against names servers that never ran while the header above it
+// still counts one. An escape sequence in the same position drives the terminal.
+//
+// paths.CheckLabel refuses a control character for this reason and the TUI drops
+// them for it too. Quoting rather than dropping keeps the value recoverable.
+func oneLine(s string) string {
+	if hasControl(s) {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func hasControl(s string) bool {
+	return strings.ContainsFunc(s, unicode.IsControl)
+}
+
+// plural renders a count with its noun, so a summary reads as a sentence rather
+// than as a number and a noun that disagree with it.
+func plural(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}

--- a/cmd/mcpsnoop/inventory.go
+++ b/cmd/mcpsnoop/inventory.go
@@ -285,30 +285,13 @@ func readSessionHead(path string) (sessionHead, error) {
 	return head, nil
 }
 
-// key is what makes two sessions the same server.
-//
-// For stdio it is the recorded command and working directory, never the label,
-// because labelFor derives the label from the command's last path element and
-// two checkouts of one project, or two servers written in one language, collide
-// there routinely. For HTTP it is the endpoint, since mcpsnoop launched nothing
-// and the endpoint is what the transport specification makes the server's
-// identity. A log carrying neither falls back to its label and transport, which
-// is the most a trimmed or pre-meta log can honestly claim.
-//
-// A redacted command keys as itself. Two runs of one server, one scrubbed and
-// one not, are two rows, and that is the honest answer: mcpsnoop cannot know
-// what the placeholder replaced, and merging them would mean guessing that the
-// hidden halves matched.
+// key folds the head into the identity every command in this binary shares, so
+// what counts as one server is decided once. See serverIdentity in sessionscan.go.
 func (h sessionHead) key() string {
-	const sep = "\x00"
-	switch {
-	case len(h.command) > 0:
-		return "stdio" + sep + h.cwd + sep + strings.Join(h.command, sep)
-	case h.endpoint != "":
-		return "http" + sep + h.endpoint
-	default:
-		return "label" + sep + h.transport + sep + h.label
-	}
+	return serverIdentity{
+		label: h.label, transport: h.transport,
+		command: h.command, cwd: h.cwd, endpoint: h.endpoint,
+	}.key()
 }
 
 // toolCountStatus distinguishes the three ways --tools can fail to produce a

--- a/cmd/mcpsnoop/inventory_fifo_unix_test.go
+++ b/cmd/mcpsnoop/inventory_fifo_unix_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package main
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+)
+
+// TestInventoryDoesNotHangOnAFifo covers a directory anything can write to. Open
+// on a fifo blocks until a writer appears, and the command prints nothing until
+// the whole walk is done, so one of them stopped the answer entirely.
+func TestInventoryDoesNotHangOnAFifo(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "good.jsonl", stdioSession(t, "s1", "srv", t0, "/proj", []string{"node", "i.js"}, false)...)
+	fifo := filepath.Join(paths.SessionsDir(), "pipe.jsonl")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("cannot make a fifo here: %v", err)
+	}
+
+	done := make(chan inventory, 1)
+	go func() {
+		inv, err := takeInventory(paths.SessionsDir(), false)
+		if err == nil {
+			done <- inv
+		}
+		close(done)
+	}()
+	select {
+	case inv, ok := <-done:
+		if !ok {
+			t.Fatal("takeInventory failed on a directory holding a fifo")
+		}
+		if len(inv.Servers) != 1 {
+			t.Fatalf("servers = %d, want the one real log still reported", len(inv.Servers))
+		}
+		if inv.Skipped != 1 {
+			t.Fatalf("skipped = %d, want the fifo counted", inv.Skipped)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a fifo in the sessions directory hung the whole command")
+	}
+}

--- a/cmd/mcpsnoop/inventory_test.go
+++ b/cmd/mcpsnoop/inventory_test.go
@@ -1,0 +1,872 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func executeInventory(t *testing.T, args []string) (int, string, string) {
+	t.Helper()
+	cmd := newInventoryCmd()
+	cmd.SetArgs(args)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		return 0, stdout.String(), stderr.String()
+	}
+	var code exitCode
+	if !errors.As(err, &code) {
+		t.Fatalf("unexpected command error: %v", err)
+	}
+	return int(code), stdout.String(), stderr.String()
+}
+
+// writeSessionLog writes one log whose lines are the given envelopes, the way the
+// proxy's sink does, and returns its path.
+func writeSessionLog(t *testing.T, name string, envs ...proxy.Envelope) string {
+	t.Helper()
+	path := filepath.Join(paths.SessionsDir(), name)
+	var buf bytes.Buffer
+	for _, env := range envs {
+		b, err := json.Marshal(env)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// stdioSession builds the frames of one stdio run, meta frame first.
+func stdioSession(t *testing.T, id, label string, at time.Time, cwd string, command []string, redacted bool) []proxy.Envelope {
+	t.Helper()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: command, CWD: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []proxy.Envelope{{
+		SessionID: id, ServerLabel: label, Seq: 1, TS: at,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio,
+		Raw: meta, Redacted: redacted,
+	}}
+}
+
+// TestInventoryFoldsSessionsIntoServers is the whole point of the command: one
+// row per server across many runs, not one per session.
+func TestInventoryFoldsSessionsIntoServers(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "a-1.jsonl", stdioSession(t, "s1", "server.py", t0, "/proj/a", []string{"python3", "server.py"}, false)...)
+	writeSessionLog(t, "a-2.jsonl", stdioSession(t, "s2", "server.py", t0.Add(2*time.Hour), "/proj/a", []string{"python3", "server.py"}, false)...)
+
+	inv, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 1 {
+		t.Fatalf("servers = %d, want 1; two runs of one server are one row", len(inv.Servers))
+	}
+	row := inv.Servers[0]
+	if row.Runs != 2 {
+		t.Fatalf("runs = %d, want 2", row.Runs)
+	}
+	if !row.FirstSeen.Equal(t0) || !row.LastSeen.Equal(t0.Add(2*time.Hour)) {
+		t.Fatalf("seen %v to %v, want %v to %v", row.FirstSeen, row.LastSeen, t0, t0.Add(2*time.Hour))
+	}
+	if inv.Scanned != 2 || inv.Skipped != 0 {
+		t.Fatalf("scanned %d skipped %d, want 2 and 0", inv.Scanned, inv.Skipped)
+	}
+}
+
+// TestInventoryKeysOnCommandAndCWDNotLabel is the reason the row key is what it
+// is. labelFor derives the label from the command's last path element, so two
+// unrelated servers routinely arrive under one name.
+func TestInventoryKeysOnCommandAndCWDNotLabel(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	// Same derived label three times over: different arguments, and the same
+	// arguments from a different directory.
+	writeSessionLog(t, "a.jsonl", stdioSession(t, "s1", "server.py", t0, "/proj/a", []string{"python3", "server.py", "alpha"}, false)...)
+	writeSessionLog(t, "b.jsonl", stdioSession(t, "s2", "server.py", t0, "/proj/a", []string{"python3", "server.py", "beta"}, false)...)
+	writeSessionLog(t, "c.jsonl", stdioSession(t, "s3", "server.py", t0, "/proj/b", []string{"python3", "server.py", "alpha"}, false)...)
+
+	inv, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 3 {
+		t.Fatalf("servers = %d, want 3; the label is one name for three servers", len(inv.Servers))
+	}
+	for _, row := range inv.Servers {
+		if row.Label != "server.py" {
+			t.Fatalf("label = %q, want the derived one shown as a name", row.Label)
+		}
+	}
+}
+
+// TestInventoryCoversHTTPSessions covers the population the issue is about, plus
+// the log shape that predates the HTTP meta frame entirely.
+func TestInventoryCoversHTTPSessions(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Target: "https://api.example.com/mcp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSessionLog(t, "http-new.jsonl", proxy.Envelope{
+		SessionID: "h1", ServerLabel: "api.example.com", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta,
+	})
+	// An HTTP log captured before mcpsnoop recorded an endpoint: its first frame
+	// is traffic, and it must still yield a row rather than vanishing.
+	writeSessionLog(t, "http-old.jsonl", proxy.Envelope{
+		SessionID: "h2", ServerLabel: "legacy-http", Seq: 1, TS: t0.Add(time.Hour),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+	})
+
+	inv, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 2 {
+		t.Fatalf("servers = %d, want 2", len(inv.Servers))
+	}
+	byLabel := map[string]serverRow{}
+	for _, row := range inv.Servers {
+		byLabel[row.Label] = row
+	}
+	if got := byLabel["api.example.com"].Endpoint; got != "https://api.example.com/mcp" {
+		t.Fatalf("endpoint = %q, want the recorded one", got)
+	}
+	old := byLabel["legacy-http"]
+	if old.Runs != 1 || old.Transport != proxy.TransportHTTP {
+		t.Fatalf("a pre-meta HTTP log did not produce a usable row: %+v", old)
+	}
+	if old.Endpoint != "" || len(old.Command) != 0 {
+		t.Fatalf("a pre-meta log invented an endpoint or command: %+v", old)
+	}
+}
+
+// TestInventorySurvivesUnreadableLogs covers the routine case, not a
+// hypothetical: a run whose exec fails leaves a zero-byte log behind, and a shim
+// still writing leaves a torn final line.
+func TestInventorySurvivesUnreadableLogs(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "good.jsonl", stdioSession(t, "s1", "srv", t0, "/proj", []string{"node", "index.js"}, false)...)
+
+	dir := paths.SessionsDir()
+	for name, body := range map[string]string{
+		"empty.jsonl":   "",
+		"torn.jsonl":    `{"session_id":"x","seq":1,"dire`,
+		"garbage.jsonl": "not json at all\n",
+		"noid.jsonl":    "{}\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A file that is not a log at all must not even be looked at.
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := takeInventory(dir, false)
+	if err != nil {
+		t.Fatalf("one unreadable log must not fail the run: %v", err)
+	}
+	if len(inv.Servers) != 1 || inv.Scanned != 1 {
+		t.Fatalf("servers %d scanned %d, want the one good log read", len(inv.Servers), inv.Scanned)
+	}
+	// The empty one is counted apart from the damaged three: a zero-byte log is
+	// what a failed exec and an uncalled HTTP proxy both leave, so calling it
+	// unreadable would report routine housekeeping as damage.
+	if inv.Empty != 1 || inv.Skipped != 3 {
+		t.Fatalf("empty %d skipped %d, want 1 and 3, all counted rather than dropped in silence", inv.Empty, inv.Skipped)
+	}
+
+	code, stdout, stderr := executeInventory(t, nil)
+	if code != 0 || stderr != "" {
+		t.Fatalf("code %d stderr %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "3 logs skipped as unreadable") || !strings.Contains(stdout, "1 empty log") {
+		t.Fatalf("the output does not say what it could not read:\n%s", stdout)
+	}
+}
+
+// countingLog counts the bytes a reader actually pulls out of a log.
+type countingLog struct {
+	inner io.ReadCloser
+	read  *int64
+}
+
+func (c countingLog) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	*c.read += int64(n)
+	return n, err
+}
+
+func (c countingLog) Close() error { return c.inner.Close() }
+
+// TestInventoryReadsOneEnvelopePerLog is the criterion the whole design rests
+// on. It is measured rather than inferred: nothing about the returned rows can
+// see how much of a file was pulled, because json.Decoder stops at the end of
+// the first value however many bytes it was handed, so a reader that slurped the
+// file whole first would answer identically and pass any assertion about output.
+func TestInventoryReadsOneEnvelopePerLog(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "index.js"}, CWD: "/proj"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := json.Marshal(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "index.js", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const tail = 8 << 20 // eight megabytes of frames the command has no business reading
+	var buf bytes.Buffer
+	buf.Write(append(head, '\n'))
+	filler, err := json.Marshal(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "index.js", Seq: 2, TS: t0,
+		Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"ping"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for buf.Len() < tail {
+		buf.Write(append(filler, '\n'))
+	}
+	if err := os.WriteFile(filepath.Join(paths.SessionsDir(), "big.jsonl"), buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var read int64
+	prev := openLog
+	openLog = func(path string) (io.ReadCloser, error) {
+		f, err := prev(path)
+		if err != nil {
+			return nil, err
+		}
+		return countingLog{inner: f, read: &read}, nil
+	}
+	t.Cleanup(func() { openLog = prev })
+
+	inv, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 1 {
+		t.Fatalf("servers = %d, want 1", len(inv.Servers))
+	}
+	if got := strings.Join(inv.Servers[0].Command, " "); got != "node index.js" {
+		t.Fatalf("command = %q, want the meta frame's own", got)
+	}
+	// json.Decoder buffers ahead of the value it is parsing, so this is a bound on
+	// the buffer rather than on the envelope. What it rules out is reading the log.
+	const bound = 64 << 10
+	if read > bound {
+		t.Fatalf("read %d bytes of an %d-byte log, want at most %d; the walk is reading past the first envelope", read, buf.Len(), bound)
+	}
+	if read == 0 {
+		t.Fatal("the counting reader saw nothing, so this test is measuring the wrong thing")
+	}
+}
+
+// TestInventoryDoesNotReadPastTheHeadWithoutTools pins the other half of the opt
+// in. The count being absent from the rows does not prove the read never
+// happened, only that its result was not published, so the call itself is what
+// is observed.
+func TestInventoryDoesNotReadPastTheHeadWithoutTools(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "a.jsonl", stdioSession(t, "s1", "srv", t0, "/proj", []string{"node", "i.js"}, false)...)
+
+	calls := 0
+	prev := countTools
+	countTools = func(path string) (int, toolCountStatus) {
+		calls++
+		return prev(path)
+	}
+	t.Cleanup(func() { countTools = prev })
+
+	if _, err := takeInventory(paths.SessionsDir(), false); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 {
+		t.Fatalf("a plain run read past the head %d times; --tools is what pays for that", calls)
+	}
+	if _, err := takeInventory(paths.SessionsDir(), true); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("--tools read past the head %d times, want exactly one log per server", calls)
+	}
+}
+
+// TestInventoryShowsARedactedCommandAsRecorded keeps the row honest. A scrubbed
+// command line is not the command that ran, and printing it without saying so
+// presents mcpsnoop's own placeholder as the server's argument.
+func TestInventoryShowsARedactedCommandAsRecorded(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "r.jsonl", stdioSession(t, "s1", "secretsrv", t0, "/proj",
+		[]string{"python3", "server.py", "--api-key", "[REDACTED]"}, true)...)
+
+	code, stdout, stderr := executeInventory(t, nil)
+	if code != 0 || stderr != "" {
+		t.Fatalf("code %d stderr %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "--api-key [REDACTED]") {
+		t.Fatalf("the command is not shown as recorded:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "redacted") {
+		t.Fatalf("a scrubbed command is presented as the full one:\n%s", stdout)
+	}
+}
+
+// TestInventoryOutputIsStableAcrossRuns is what makes the command usable as a
+// governance baseline. Two runs over one directory have to produce one answer.
+func TestInventoryOutputIsStableAcrossRuns(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	for i := range 12 {
+		writeSessionLog(t, fmt.Sprintf("s%02d.jsonl", i),
+			stdioSession(t, fmt.Sprintf("s%d", i), fmt.Sprintf("srv%d", i%4), t0.Add(time.Duration(i)*time.Minute),
+				fmt.Sprintf("/proj/%d", i%3), []string{"node", fmt.Sprintf("index%d.js", i%4)}, false)...)
+	}
+	_, first, _ := executeInventory(t, nil)
+	for range 3 {
+		_, again, _ := executeInventory(t, nil)
+		if again != first {
+			t.Fatalf("two runs over one directory disagree:\n--- first\n%s\n--- again\n%s", first, again)
+		}
+	}
+	if strings.Count(first, "\n  command") == 0 {
+		t.Fatalf("the run produced no rows:\n%s", first)
+	}
+}
+
+// TestInventoryCountsToolsOnlyWhenAsked pins both halves of the opt in: the
+// count is right when asked for, and nothing reads past the first envelope when
+// it is not.
+func TestInventoryCountsToolsOnlyWhenAsked(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	session := func(id string, at time.Time, tools []string) []proxy.Envelope {
+		envs := stdioSession(t, id, "srv", at, "/proj", []string{"node", "index.js"}, false)
+		list := make([]string, 0, len(tools))
+		for _, name := range tools {
+			list = append(list, fmt.Sprintf(`{"name":%q,"description":"x","inputSchema":{"type":"object"}}`, name))
+		}
+		return append(envs,
+			proxy.Envelope{SessionID: id, ServerLabel: "srv", Seq: 2, TS: at.Add(time.Millisecond),
+				Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+				Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)},
+			proxy.Envelope{SessionID: id, ServerLabel: "srv", Seq: 3, TS: at.Add(2 * time.Millisecond),
+				Direction: proxy.ServerToClient, Transport: proxy.TransportStdio,
+				Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":{"tools":[%s]}}`, strings.Join(list, ",")))},
+		)
+	}
+	// The older run advertised two tools, the newer one three. The count is what
+	// the server advertised the last time it ran. The file names put the older run
+	// first in directory order on purpose: named the other way round the test
+	// passes on whichever log ReadDir happened to reach first rather than on the
+	// timestamps, and a mutation that ignores them entirely goes unnoticed.
+	writeSessionLog(t, "a-older-run.jsonl", session("s1", t0, []string{"a", "b"})...)
+	writeSessionLog(t, "b-newer-run.jsonl", session("s2", t0.Add(time.Hour), []string{"a", "b", "c"})...)
+
+	without, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(without.Servers) != 1 || without.Servers[0].Tools != nil {
+		t.Fatalf("a plain run counted tools anyway: %+v", without.Servers)
+	}
+
+	with, err := takeInventory(paths.SessionsDir(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(with.Servers) != 1 || with.Servers[0].Tools == nil {
+		t.Fatalf("--tools produced no count: %+v", with.Servers)
+	}
+	if got := *with.Servers[0].Tools; got != 3 {
+		t.Fatalf("tools = %d, want the 3 the newest run advertised", got)
+	}
+}
+
+// TestInventoryRefusesAnIncompleteToolListing keeps a paginated listing from
+// reading as a small server. A partial page is not a count.
+func TestInventoryRefusesAnIncompleteToolListing(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	envs := stdioSession(t, "s1", "srv", t0, "/proj", []string{"node", "index.js"}, false)
+	envs = append(envs,
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond),
+			Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)},
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: t0.Add(2 * time.Millisecond),
+			Direction: proxy.ServerToClient, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a","inputSchema":{"type":"object"}}],"nextCursor":"more"}}`)},
+	)
+	writeSessionLog(t, "partial.jsonl", envs...)
+
+	inv, err := takeInventory(paths.SessionsDir(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 1 {
+		t.Fatalf("servers = %d, want 1", len(inv.Servers))
+	}
+	if inv.Servers[0].Tools != nil {
+		t.Fatalf("tools = %d, want no count at all for a listing that never finished", *inv.Servers[0].Tools)
+	}
+	_, stdout, _ := executeInventory(t, []string{"--tools"})
+	if !strings.Contains(stdout, "no complete tools/list") {
+		t.Fatalf("the output does not say why there is no count:\n%s", stdout)
+	}
+}
+
+// TestInventoryJSONKeepsAmpersandsReadable pins the encoder choice. An endpoint
+// with a query is the ordinary case here, and the standard library escapes & for
+// HTML embedding, which turns a correct URL into one that reads as mangled.
+func TestInventoryJSONKeepsAmpersandsReadable(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Target: "https://h/mcp?tenant=[stripped]&api_key=[stripped]"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSessionLog(t, "h.jsonl", proxy.Envelope{
+		SessionID: "h1", ServerLabel: "h", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta,
+	})
+
+	code, stdout, stderr := executeInventory(t, []string{"--format", "json"})
+	if code != 0 || stderr != "" {
+		t.Fatalf("code %d stderr %q", code, stderr)
+	}
+	if strings.Contains(stdout, `\u0026`) {
+		t.Fatalf("the endpoint is HTML-escaped in the JSON output:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "tenant=[stripped]&api_key=[stripped]") {
+		t.Fatalf("the endpoint is not carried verbatim:\n%s", stdout)
+	}
+	var parsed inventory
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("the JSON output does not parse: %v", err)
+	}
+	if len(parsed.Servers) != 1 || parsed.Servers[0].Endpoint == "" {
+		t.Fatalf("round trip lost the row: %+v", parsed)
+	}
+}
+
+// TestInventoryRejectsAnUnknownFormat keeps a typo from silently producing the
+// default rather than the format the caller asked for.
+func TestInventoryRejectsAnUnknownFormat(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	code, stdout, stderr := executeInventory(t, []string{"--format", "yaml"})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 for a usage error", code)
+	}
+	if stdout != "" || !strings.Contains(stderr, "invalid --format") {
+		t.Fatalf("stdout %q stderr %q", stdout, stderr)
+	}
+}
+
+// TestInventoryOnAnEmptyDirectorySaysSo keeps a fresh machine from printing
+// nothing at all, which reads as a broken command.
+func TestInventoryOnAnEmptyDirectorySaysSo(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	code, stdout, stderr := executeInventory(t, nil)
+	if code != 0 || stderr != "" {
+		t.Fatalf("code %d stderr %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "no servers found") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// TestInventoryCountsToolsWhileAShimIsStillWriting is why --tools does not use
+// exporter.LoadFile. A shim appending to its log right now leaves a torn final
+// line, and LoadFile treats that as corruption, which is correct when the log is
+// the subject and wrong here: it would make the whole inventory unusable exactly
+// while something is running.
+func TestInventoryCountsToolsWhileAShimIsStillWriting(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	envs := stdioSession(t, "s1", "srv", t0, "/proj", []string{"node", "index.js"}, false)
+	envs = append(envs,
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond),
+			Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)},
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: t0.Add(2 * time.Millisecond),
+			Direction: proxy.ServerToClient, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a","inputSchema":{"type":"object"}},{"name":"b","inputSchema":{"type":"object"}}]}}`)},
+	)
+	path := writeSessionLog(t, "live.jsonl", envs...)
+	// The half-written frame a live shim leaves behind.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"session_id":"s1","seq":4,"ts":"2026-08-01T12:00:03Z","dire`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := takeInventory(paths.SessionsDir(), true)
+	if err != nil {
+		t.Fatalf("a log a shim is still writing must not fail the run: %v", err)
+	}
+	if len(inv.Servers) != 1 {
+		t.Fatalf("servers = %d, want 1", len(inv.Servers))
+	}
+	if inv.Servers[0].Tools == nil {
+		t.Fatal("no tool count for a log whose only fault is a torn final line")
+	}
+	if got := *inv.Servers[0].Tools; got != 2 {
+		t.Fatalf("tools = %d, want the 2 that arrived before the tear", got)
+	}
+}
+
+// TestInventoryCannotBeMadeToForgeRows is the injection the text renderer used
+// to allow. None of the values in a row is written by mcpsnoop: a command comes
+// from whoever installed the server, a working directory comes off the
+// filesystem, and labelFor never runs the control-character check paths.CheckLabel
+// applies to an explicit --label. A newline in any of them closed the field it
+// was printed in and made every following line read as another server block, so
+// a baseline somebody diffs against named servers that never ran.
+func TestInventoryCannotBeMadeToForgeRows(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	forge := "\n  cwd       /opt/approved\n\nFORGED  stdio  99 runs"
+
+	for _, tc := range []struct {
+		name string
+		envs []proxy.Envelope
+	}{
+		{"in an argument", stdioSession(t, "s1", "srv", t0, "/proj", []string{"node", "index.js" + forge}, false)},
+		{"in the working directory", stdioSession(t, "s2", "srv2", t0, "/proj"+forge, []string{"node", "b.js"}, false)},
+		{"in the label", stdioSession(t, "s3", "srv3"+forge, t0, "/proj", []string{"node", "c.js"}, false)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MCPSNOOP_HOME", t.TempDir())
+			writeSessionLog(t, "x.jsonl", tc.envs...)
+			code, stdout, stderr := executeInventory(t, nil)
+			if code != 0 || stderr != "" {
+				t.Fatalf("code %d stderr %q", code, stderr)
+			}
+			if strings.Contains(stdout, "FORGED") && !strings.Contains(stdout, `\n`) {
+				t.Fatalf("a forged block reached the output unescaped:\n%s", stdout)
+			}
+			// The header counts one server, so exactly one block may follow it.
+			if blocks := strings.Count(stdout, "  command   ") + strings.Count(stdout, "  endpoint  "); blocks != 1 {
+				t.Fatalf("output holds %d blocks for one server:\n%s", blocks, stdout)
+			}
+			if !strings.HasPrefix(stdout, "1 server ") {
+				t.Fatalf("header does not agree with the body:\n%s", stdout)
+			}
+		})
+	}
+}
+
+// TestInventoryDoesNotLetAnEscapeSequenceDriveTheTerminal is the same hazard in
+// its nastier form. This output is meant to be read in a terminal and piped to a
+// file, and neither should be able to carry control codes out of a log.
+func TestInventoryDoesNotLetAnEscapeSequenceDriveTheTerminal(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "esc.jsonl", stdioSession(t, "s1", "srv", t0, "/proj",
+		[]string{"node", "index.js\x1b[2J\x1b[1;31m"}, false)...)
+
+	_, stdout, _ := executeInventory(t, nil)
+	if strings.ContainsFunc(stdout, func(r rune) bool { return r == 0x1b }) {
+		t.Fatalf("an escape sequence reached the output:\n%q", stdout)
+	}
+	if !strings.Contains(stdout, `\x1b`) {
+		t.Fatalf("the value was dropped rather than quoted, so it is not recoverable:\n%s", stdout)
+	}
+}
+
+// TestInventoryDistinguishesArgumentBoundaries keeps two different commands from
+// rendering as one. An argument holding a space is the everyday shape of
+// node "~/My Project/build/index.js".
+func TestInventoryDistinguishesArgumentBoundaries(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "one.jsonl", stdioSession(t, "s1", "srv", t0, "/proj", []string{"python3", "s.py", "--name", "a b"}, false)...)
+	writeSessionLog(t, "two.jsonl", stdioSession(t, "s2", "srv", t0, "/proj", []string{"python3", "s.py", "--name", "a", "b"}, false)...)
+
+	inv, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 2 {
+		t.Fatalf("servers = %d, want 2 distinct commands", len(inv.Servers))
+	}
+	_, stdout, _ := executeInventory(t, nil)
+	if strings.Count(stdout, `--name "a b"`) != 1 || strings.Count(stdout, "--name a b\n") != 1 {
+		t.Fatalf("the two commands do not render distinguishably:\n%s", stdout)
+	}
+}
+
+// TestInventorySeparatesEmptyLogsFromDamagedOnes keeps ordinary housekeeping
+// from being reported as damage. A zero-byte log is what a failed exec leaves,
+// and what an HTTP proxy nobody called leaves on purpose.
+func TestInventorySeparatesEmptyLogsFromDamagedOnes(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "good.jsonl", stdioSession(t, "s1", "srv", t0, "/proj", []string{"node", "i.js"}, false)...)
+	dir := paths.SessionsDir()
+	for _, name := range []string{"a.jsonl", "b.jsonl"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "junk.jsonl"), []byte("not json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := takeInventory(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.Empty != 2 || inv.Skipped != 1 {
+		t.Fatalf("empty %d skipped %d, want 2 and 1", inv.Empty, inv.Skipped)
+	}
+	_, stdout, _ := executeInventory(t, nil)
+	if !strings.Contains(stdout, "2 empty logs left by a run that recorded nothing") {
+		t.Fatalf("empty logs are reported as damage:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "1 log skipped as unreadable") {
+		t.Fatalf("the damaged log is not named:\n%s", stdout)
+	}
+}
+
+// TestInventorySaysWhyThereIsNoToolCount covers the difference between a server
+// that advertised nothing, one whose listing never finished, and a log that
+// could not be read. One sentence for all three made mcpsnoop state something
+// false about the third.
+func TestInventorySaysWhyThereIsNoToolCount(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	listing := func(id, cwd, result string) []proxy.Envelope {
+		return append(stdioSession(t, id, "srv-"+id, t0, cwd, []string{"node", cwd + ".js"}, false),
+			proxy.Envelope{SessionID: id, ServerLabel: "srv-" + id, Seq: 2, TS: t0.Add(time.Millisecond),
+				Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+				Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)},
+			proxy.Envelope{SessionID: id, ServerLabel: "srv-" + id, Seq: 3, TS: t0.Add(2 * time.Millisecond),
+				Direction: proxy.ServerToClient, Transport: proxy.TransportStdio, Raw: json.RawMessage(result)},
+		)
+	}
+	writeSessionLog(t, "none.jsonl", listing("n", "/none", `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`)...)
+	writeSessionLog(t, "partial.jsonl", listing("p", "/partial", `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a","inputSchema":{"type":"object"}}],"nextCursor":"more"}}`)...)
+	// A complete listing followed by a line the decoder cannot finish. The count
+	// is already in the store when the tear is reached, so the reason printed has
+	// to be about the read rather than about the listing.
+	broken := filepath.Join(paths.SessionsDir(), "broken.jsonl")
+	writeSessionLog(t, "broken.jsonl", listing("b", "/broken", `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a","inputSchema":{"type":"object"}},{"name":"b","inputSchema":{"type":"object"}}]}}`)...)
+	f, err := os.OpenFile(broken, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("{\"session_id\":\"b\",,,BROKEN}\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := takeInventory(paths.SessionsDir(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byCWD := map[string]serverRow{}
+	for _, row := range inv.Servers {
+		byCWD[row.CWD] = row
+	}
+	if row := byCWD["/none"]; row.Tools == nil || *row.Tools != 0 {
+		t.Fatalf("a server that advertised none should count zero, got %+v", row.Tools)
+	}
+	if row := byCWD["/partial"]; row.Tools != nil || !strings.Contains(row.ToolsNote, "no complete tools/list") {
+		t.Fatalf("a paginating listing is misreported: tools=%v note=%q", row.Tools, row.ToolsNote)
+	}
+	if row := byCWD["/broken"]; row.Tools != nil || !strings.Contains(row.ToolsNote, "could not be read") {
+		t.Fatalf("a log that could not be read is reported as a server that advertised nothing: tools=%v note=%q", row.Tools, row.ToolsNote)
+	}
+
+	// The JSON has to carry the same three answers, or a consumer cannot tell an
+	// unasked-for count from one that was asked for and failed.
+	_, stdout, _ := executeInventory(t, []string{"--tools", "--format", "json"})
+	var parsed inventory
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	notes := 0
+	for _, row := range parsed.Servers {
+		if row.ToolsNote != "" {
+			notes++
+		}
+	}
+	if notes != 2 {
+		t.Fatalf("the JSON carries %d reasons, want one for the partial listing and one for the unreadable log:\n%s", notes, stdout)
+	}
+}
+
+// TestInventoryKeepsARangeInOneZone stops a range printing backwards. Timestamps
+// are recorded with the offset that was in force, so two runs either side of a
+// daylight-saving change carry different ones.
+func TestInventoryKeepsARangeInOneZone(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	plus3 := time.FixedZone("+03", 3*60*60)
+	plus2 := time.FixedZone("+02", 2*60*60)
+	earlier := time.Date(2026, 10, 25, 3, 30, 0, 0, plus3) // 00:30 UTC
+	later := time.Date(2026, 10, 25, 3, 10, 0, 0, plus2)   // 01:10 UTC
+	writeSessionLog(t, "a.jsonl", stdioSession(t, "s1", "dst", earlier, "/proj", []string{"python3", "s.py"}, false)...)
+	writeSessionLog(t, "b.jsonl", stdioSession(t, "s2", "dst", later, "/proj", []string{"python3", "s.py"}, false)...)
+
+	inv, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 1 {
+		t.Fatalf("servers = %d, want 1", len(inv.Servers))
+	}
+	rendered := seenRange(inv.Servers[0])
+	first, last, ok := strings.Cut(rendered, " to ")
+	if !ok {
+		t.Fatalf("seen = %q, want a range", rendered)
+	}
+	// Read as clock faces, not as instants. Parsing keeps the offsets and orders
+	// them correctly whatever they are, which is exactly what a person reading two
+	// wall-clock times side by side cannot do.
+	//
+	// RFC3339 spells the offset either as Z or as a six-character +hh:mm, so the
+	// tail cannot be sliced blind. Doing that read part of the time as the offset
+	// wherever the local zone was UTC, which passed on a machine at +03:00 and
+	// failed in CI.
+	zone := func(stamp string) string {
+		if strings.HasSuffix(stamp, "Z") {
+			return "Z"
+		}
+		return stamp[len(stamp)-6:]
+	}
+	if zone(first) != zone(last) {
+		t.Fatalf("the two ends are rendered in different zones, so the range reads backwards: %q", rendered)
+	}
+	if first >= last {
+		t.Fatalf("the range reads backwards: %q", rendered)
+	}
+}
+
+// TestInventoryIgnoresAZeroTimestamp keeps one envelope with no ts from dating
+// every run of a server to year one.
+func TestInventoryIgnoresAZeroTimestamp(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "real.jsonl", stdioSession(t, "s1", "zt", t0, "/w", []string{"node", "z.js"}, false)...)
+	writeSessionLog(t, "nots.jsonl", stdioSession(t, "s2", "zt", time.Time{}, "/w", []string{"node", "z.js"}, false)...)
+
+	inv, err := takeInventory(paths.SessionsDir(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Servers) != 1 {
+		t.Fatalf("servers = %d, want 1", len(inv.Servers))
+	}
+	if got := inv.Servers[0].FirstSeen; !got.Equal(t0) {
+		t.Fatalf("first seen = %v, want the only real timestamp %v", got, t0)
+	}
+}
+
+// TestInventoryNamesEveryLabelOfOneServer keeps an explicit --label from being
+// dropped. The key is the command and directory, so one server run as prod and
+// again as staging is one row, and showing only the alphabetically first name
+// silently loses the other.
+func TestInventoryNamesEveryLabelOfOneServer(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "a.jsonl", stdioSession(t, "s1", "prod", t0, "/proj", []string{"node", "server.js"}, false)...)
+	writeSessionLog(t, "b.jsonl", stdioSession(t, "s2", "staging", t0.Add(time.Hour), "/proj", []string{"node", "server.js"}, false)...)
+
+	_, stdout, _ := executeInventory(t, nil)
+	if !strings.Contains(stdout, "prod, staging") {
+		t.Fatalf("one of the two labels was dropped:\n%s", stdout)
+	}
+	if !strings.HasPrefix(stdout, "1 server ") {
+		t.Fatalf("two labels of one command should still be one server:\n%s", stdout)
+	}
+}
+
+// TestInventoryDoesNotClaimARedactionItCannotSee keeps the note off a row that
+// shows no command. The flag rides individual frames, so a pre-meta log's first
+// frame can carry it while there is nothing recorded for it to qualify.
+func TestInventoryDoesNotClaimARedactionItCannotSee(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeSessionLog(t, "old.jsonl", proxy.Envelope{
+		SessionID: "h1", ServerLabel: "legacy", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP, Redacted: true,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"[REDACTED]"}}`),
+	})
+
+	_, stdout, _ := executeInventory(t, nil)
+	if strings.Contains(stdout, "redacted") {
+		t.Fatalf("a row with no command claims its command was rewritten:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "no meta frame") {
+		t.Fatalf("the row does not say why it has no command:\n%s", stdout)
+	}
+}
+
+// TestInventoryTellsAMissingMetaFrameFromAnEmptyOne keeps the reason accurate.
+// A target with no host records an empty endpoint, so the meta frame is present
+// and names nothing, which is a different thing from having no meta frame.
+func TestInventoryTellsAMissingMetaFrameFromAnEmptyOne(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSessionLog(t, "hollow.jsonl", proxy.Envelope{
+		SessionID: "h1", ServerLabel: "http", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta,
+	})
+
+	_, stdout, _ := executeInventory(t, nil)
+	if strings.Contains(stdout, "this log has no meta frame") {
+		t.Fatalf("a log with a meta frame is reported as having none:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "names neither a command nor an endpoint") {
+		t.Fatalf("the row does not say what it actually found:\n%s", stdout)
+	}
+}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -252,6 +252,7 @@ func newRootCmd() *cobra.Command {
 		redactPaths            redactPathsFlag
 		otlpHeaders            otlpHeadersFlag
 		historyLimit           int
+		youcomAPIKey           string
 	)
 	cmd := &cobra.Command{
 		Use:   "mcpsnoop [flags] -- <server command> [args...]",
@@ -271,14 +272,14 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				if historyLimit < 0 {
 					return errors.New("--history-limit must be non-negative")
 				}
-				return codeOf(runHubFn(historyLimit))
+				return codeOf(runHubFn(historyLimit, youcomAPIKey))
 			}
 			cfg, ok, err := loadConfig()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "mcpsnoop:", err)
 				return exitCode(1)
 			}
-			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths)
+			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths, &youcomAPIKey)
 			// After applyConfig, so a label from a shared .mcpsnoop.toml is held
 			// to the same rule as the flag.
 			if err := paths.CheckLabel(label); err != nil {
@@ -303,6 +304,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
 	flags.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text, repeatable")
 	flags.Var(&redactPaths, "redact-path", "JSONPath selecting values to scrub in saved trace payloads, repeatable")
+	flags.StringVar(&youcomAPIKey, "youcom-api-key", "", "You.com API key for web search integration (also reads YOUCOM_API_KEY env var)")
 	flags.IntVar(&historyLimit, "history-limit", hub.DefaultBackfillLimit, "maximum session logs to load in the TUI, 0 loads all")
 	// Stop parsing at the first positional so the wrapped command keeps its flags.
 	flags.SetInterspersed(false)
@@ -810,11 +812,11 @@ func newHTTPCmd() *cobra.Command {
 }
 
 // runHub runs the live TUI, collecting traffic from all shims and past sessions.
-func runHub(historyLimit int) int {
+func runHub(historyLimit int, youcomAPIKey string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := tui.RunWithHistoryLimit(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit); err != nil {
+	if err := tui.RunWithOptions(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit, youcomAPIKey); err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: %v\n", err)
 		return 1
 	}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
 	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/metrics"
 	"github.com/kerlenton/mcpsnoop/internal/otlpsink"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
@@ -247,6 +248,7 @@ func newRootCmd() *cobra.Command {
 	var (
 		label, traceFile       string
 		otlpEndpoint           string
+		metricsListen          string
 		noTrace, redactSecrets bool
 		redactKeys             redactKeysFlag
 		redactValues           redactValuesFlag
@@ -272,7 +274,10 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				if historyLimit < 0 {
 					return errors.New("--history-limit must be non-negative")
 				}
-				return codeOf(runHubFn(historyLimit))
+				return codeOf(runHubFn(historyLimit, metricsListen))
+			}
+			if metricsListen != "" {
+				return errors.New("--metrics-listen is only available when running the hub without a wrapped command")
 			}
 			cfg, ok, err := loadConfig()
 			if err != nil {
@@ -299,6 +304,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.StringVar(&traceFile, "trace-file", "", "override the JSONL trace path, defaults to the well-known session log")
 	flags.StringVar(&otlpEndpoint, "otlp-endpoint", "", "stream completed calls to an OTLP/HTTP JSON traces endpoint")
 	flags.Var(&otlpHeaders, "otlp-header", "HTTP header for OTLP delivery as Name=Value, repeatable")
+	flags.StringVar(&metricsListen, "metrics-listen", "", "run the hub headlessly and serve Prometheus metrics on this address, instead of starting the TUI (e.g. 127.0.0.1:9464)")
 	flags.BoolVar(&noTrace, "no-trace", false, "disable tracing, pure passthrough")
 	flags.BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
@@ -810,12 +816,18 @@ func newHTTPCmd() *cobra.Command {
 	return cmd
 }
 
-// runHub runs the live TUI, collecting traffic from all shims and past sessions.
-func runHub(historyLimit int) int {
+// runHub runs the live TUI, or a headless metrics hub when requested.
+func runHub(historyLimit int, metricsListen string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := tui.RunWithHistoryLimit(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit); err != nil {
+	var err error
+	if metricsListen != "" {
+		err = metrics.RunHeadless(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit, metricsListen)
+	} else {
+		err = tui.RunWithHistoryLimit(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit)
+	}
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: %v\n", err)
 		return 1
 	}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -308,7 +308,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.SetInterspersed(false)
 
 	cmd.SetVersionTemplate("mcpsnoop {{.Version}}\n")
-	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newBaselineCmd(), newDiffCmd(), newOpenCmd(), newPruneCmd(), newWrapCmd(), newUnwrapCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
+	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newBaselineCmd(), newDiffCmd(), newOpenCmd(), newPruneCmd(), newInventoryCmd(), newWrapCmd(), newUnwrapCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
 	return cmd
 }
 

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -255,6 +255,7 @@ func newRootCmd() *cobra.Command {
 		redactPaths            redactPathsFlag
 		otlpHeaders            otlpHeadersFlag
 		historyLimit           int
+		youcomAPIKey           string
 	)
 	cmd := &cobra.Command{
 		Use:   "mcpsnoop [flags] -- <server command> [args...]",
@@ -274,7 +275,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				if historyLimit < 0 {
 					return errors.New("--history-limit must be non-negative")
 				}
-				return codeOf(runHubFn(historyLimit, metricsListen))
+				return codeOf(runHubFn(historyLimit, metricsListen, youcomAPIKey))
 			}
 			if metricsListen != "" {
 				return errors.New("--metrics-listen is only available when running the hub without a wrapped command")
@@ -284,7 +285,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				fmt.Fprintln(os.Stderr, "mcpsnoop:", err)
 				return exitCode(1)
 			}
-			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths)
+			applyConfig(cmd.Flags(), cfg, ok, &label, &traceFile, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths, &youcomAPIKey)
 			// After applyConfig, so a label from a shared .mcpsnoop.toml is held
 			// to the same rule as the flag.
 			if err := paths.CheckLabel(label); err != nil {
@@ -310,6 +311,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
 	flags.Var(&redactValues, "redact-value", "regular expression to scrub inside observed string values, stderr, and non-JSON text, repeatable")
 	flags.Var(&redactPaths, "redact-path", "JSONPath selecting values to scrub in saved trace payloads, repeatable")
+	flags.StringVar(&youcomAPIKey, "youcom-api-key", "", "You.com API key for web search integration (also reads YOUCOM_API_KEY env var)")
 	flags.IntVar(&historyLimit, "history-limit", hub.DefaultBackfillLimit, "maximum session logs to load in the TUI, 0 loads all")
 	// Stop parsing at the first positional so the wrapped command keeps its flags.
 	flags.SetInterspersed(false)
@@ -751,7 +753,7 @@ func newHTTPCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "mcpsnoop http:", err)
 				return exitCode(1)
 			}
-			applyConfig(cmd.Flags(), cfg, ok, &label, nil, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths)
+			applyConfig(cmd.Flags(), cfg, ok, &label, nil, &noTrace, &redactSecrets, &redactKeys, &redactValues, &redactPaths, nil)
 			if err := paths.CheckLabel(label); err != nil {
 				fmt.Fprintln(os.Stderr, "mcpsnoop http:", err)
 				return exitCode(2)
@@ -817,7 +819,7 @@ func newHTTPCmd() *cobra.Command {
 }
 
 // runHub runs the live TUI, or a headless metrics hub when requested.
-func runHub(historyLimit int, metricsListen string) int {
+func runHub(historyLimit int, metricsListen, youcomAPIKey string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -825,7 +827,7 @@ func runHub(historyLimit int, metricsListen string) int {
 	if metricsListen != "" {
 		err = metrics.RunHeadless(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit, metricsListen)
 	} else {
-		err = tui.RunWithHistoryLimit(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit)
+		err = tui.RunWithOptions(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit, youcomAPIKey)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: %v\n", err)

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/otlpsink"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/replay"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 	"github.com/kerlenton/mcpsnoop/internal/tui"
 )
@@ -829,6 +830,8 @@ func newOpenCmd() *cobra.Command {
 		redactValues  redactValuesFlag
 		redactPaths   redactPathsFlag
 	)
+	var replayTarget string
+	var replayHeaders []string
 	cmd := &cobra.Command{
 		Use:   "open [session-id|session.jsonl|-]",
 		Short: "Open a captured session in the TUI, or - to read from stdin",
@@ -839,7 +842,23 @@ func newOpenCmd() *cobra.Command {
 			if len(args) == 1 {
 				arg = args[0]
 			}
-			return codeOf(runOpen(arg, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths)))
+			target := replay.HTTPTarget{URL: strings.TrimSpace(replayTarget), Headers: replayHeaders}
+			if target.URL == "" && len(replayHeaders) > 0 {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop open: --replay-header needs --replay-target, since there is nowhere to send them")
+				return codeOf(2)
+			}
+			// Checked here rather than dropped at send time. A header that never
+			// reached the request produced a 401 telling the operator to pass the
+			// credential they had already passed, which is the worst way to be told
+			// about a typo.
+			for _, h := range replayHeaders {
+				name, _, ok := strings.Cut(h, ":")
+				if !ok || strings.TrimSpace(name) == "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "mcpsnoop open: --replay-header %q is not a header, want 'Name: value'\n", h)
+					return codeOf(2)
+				}
+			}
+			return codeOf(runOpen(arg, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths), target))
 		},
 	}
 	cmd.Flags().SortFlags = false
@@ -847,11 +866,13 @@ func newOpenCmd() *cobra.Command {
 	cmd.Flags().Var(&redactKeys, "redact-key", "JSON key name to scrub in captured JSON-RPC payloads, repeat or comma-separated")
 	cmd.Flags().Var(&redactValues, "redact-value", "regular expression to scrub inside captured JSON-RPC string values, stderr, and non-JSON text, repeatable")
 	cmd.Flags().Var(&redactPaths, "redact-path", "JSONPath selecting values in captured JSON-RPC payloads to scrub, repeatable")
+	cmd.Flags().StringVar(&replayTarget, "replay-target", "", "MCP endpoint a replay of an HTTP-captured session posts to; a capture records the endpoint stripped of anything credential-shaped, so it is not an address to dial and this is where you say where a replay goes")
+	cmd.Flags().StringArrayVar(&replayHeaders, "replay-header", nil, "extra header for a replayed request as 'Name: value', repeatable; this is how a credential reaches the server, since mcpsnoop never records one")
 	return cmd
 }
 
 // runOpen loads a session (id, path, or - for stdin) and shows it in the TUI.
-func runOpen(arg string, redaction proxy.RedactConfig) int {
+func runOpen(arg string, redaction proxy.RedactConfig, replayTarget replay.HTTPTarget) int {
 	inPath, usedStdin, err := resolveOpenSessionPath(arg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
@@ -886,12 +907,12 @@ func runOpen(arg string, redaction proxy.RedactConfig) int {
 			return 1
 		}
 		defer tty.Close()
-		if err := tui.RunOpenWithInput(ctx, st, tty); err != nil {
+		if err := tui.RunOpenWithInput(ctx, st, tty, tui.WithHTTPReplay(replayTarget)); err != nil {
 			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 			return 1
 		}
 	} else {
-		if err := runOpenTUIFn(ctx, st); err != nil {
+		if err := runOpenTUIFn(ctx, st, tui.WithHTTPReplay(replayTarget)); err != nil {
 			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 			return 1
 		}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -308,7 +308,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.SetInterspersed(false)
 
 	cmd.SetVersionTemplate("mcpsnoop {{.Version}}\n")
-	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newBaselineCmd(), newDiffCmd(), newOpenCmd(), newPruneCmd(), newInventoryCmd(), newWrapCmd(), newUnwrapCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
+	cmd.AddCommand(newHTTPCmd(), newExportCmd(), newCheckCmd(), newBaselineCmd(), newDiffCmd(), newOpenCmd(), newPruneCmd(), newInventoryCmd(), newStatsCmd(), newWrapCmd(), newUnwrapCmd(), newRemoteCmd(), newDemoCmd(), newVersionCmd())
 	return cmd
 }
 

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
+	"github.com/kerlenton/mcpsnoop/internal/tui"
 )
 
 func TestLabelFor(t *testing.T) {
@@ -392,7 +393,7 @@ func TestOpenRedactsCapturedSessionInMemoryWithoutModifyingInput(t *testing.T) {
 	input, original := writeUnredactedSession(t)
 	var opened *store.Store
 	previous := runOpenTUIFn
-	runOpenTUIFn = func(_ context.Context, st *store.Store) error {
+	runOpenTUIFn = func(_ context.Context, st *store.Store, _ ...tui.Option) error {
 		opened = st
 		return nil
 	}
@@ -432,7 +433,7 @@ func TestCapturedSessionReadDefaultsRemainUnredacted(t *testing.T) {
 
 	var opened *store.Store
 	previous := runOpenTUIFn
-	runOpenTUIFn = func(_ context.Context, st *store.Store) error {
+	runOpenTUIFn = func(_ context.Context, st *store.Store, _ ...tui.Option) error {
 		opened = st
 		return nil
 	}
@@ -1050,4 +1051,28 @@ func TestTraceSinkReportsOnlyTheFileSinkDrops(t *testing.T) {
 			t.Fatal("--no-trace writes nothing, so nothing can be incomplete")
 		}
 	})
+}
+
+// TestOpenRejectsAMalformedReplayHeader catches a typo at the flag rather than
+// dropping it at send time, where the resulting 401 told the operator to pass
+// the credential they had already passed.
+func TestOpenRejectsAMalformedReplayHeader(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	for _, value := range []string{"Authorization Bearer sk", "  : value", ""} {
+		cmd := newOpenCmd()
+		cmd.SetArgs([]string{"--replay-target", "https://h/mcp", "--replay-header", value, "-"})
+		var stdout, stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		cmd.SilenceErrors, cmd.SilenceUsage = true, true
+
+		err := cmd.Execute()
+		var code exitCode
+		if err == nil || !errors.As(err, &code) || int(code) != 2 {
+			t.Fatalf("--replay-header %q exited %v, want a usage error", value, err)
+		}
+		if !strings.Contains(stderr.String(), "is not a header") {
+			t.Fatalf("--replay-header %q: stderr %q", value, stderr.String())
+		}
+	}
 }

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -246,7 +246,7 @@ func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	gotLimit := -1
 	gotMetrics := "unset"
 	origHub := runHubFn
-	runHubFn = func(limit int, metrics string) int {
+	runHubFn = func(limit int, metrics, _ string) int {
 		hub = true
 		gotLimit = limit
 		gotMetrics = metrics
@@ -278,7 +278,7 @@ func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 func TestRootHistoryLimitConfiguresHub(t *testing.T) {
 	gotLimit := -1
 	origHub := runHubFn
-	runHubFn = func(limit int, _ string) int {
+	runHubFn = func(limit int, _, _ string) int {
 		gotLimit = limit
 		return 0
 	}
@@ -295,7 +295,7 @@ func TestRootHistoryLimitConfiguresHub(t *testing.T) {
 func TestRootMetricsListenIsHubOnlyAndOptIn(t *testing.T) {
 	var got string
 	orig := runHubFn
-	runHubFn = func(_ int, listen string) int {
+	runHubFn = func(_ int, listen, _ string) int {
 		got = listen
 		return 0
 	}

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -244,10 +244,12 @@ func stubHTTP(ran *bool) func() {
 func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	hub := false
 	gotLimit := -1
+	gotMetrics := "unset"
 	origHub := runHubFn
-	runHubFn = func(limit int) int {
+	runHubFn = func(limit int, metrics string) int {
 		hub = true
 		gotLimit = limit
+		gotMetrics = metrics
 		return 0
 	}
 	defer func() { runHubFn = origHub }()
@@ -268,12 +270,15 @@ func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	if gotLimit != hubpkg.DefaultBackfillLimit {
 		t.Fatalf("history limit = %d, want default %d", gotLimit, hubpkg.DefaultBackfillLimit)
 	}
+	if gotMetrics != "" {
+		t.Fatalf("default metrics listener = %q, want disabled", gotMetrics)
+	}
 }
 
 func TestRootHistoryLimitConfiguresHub(t *testing.T) {
 	gotLimit := -1
 	origHub := runHubFn
-	runHubFn = func(limit int) int {
+	runHubFn = func(limit int, _ string) int {
 		gotLimit = limit
 		return 0
 	}
@@ -284,6 +289,37 @@ func TestRootHistoryLimitConfiguresHub(t *testing.T) {
 	}
 	if gotLimit != 7 {
 		t.Fatalf("history limit = %d, want 7", gotLimit)
+	}
+}
+
+func TestRootMetricsListenIsHubOnlyAndOptIn(t *testing.T) {
+	var got string
+	orig := runHubFn
+	runHubFn = func(_ int, listen string) int {
+		got = listen
+		return 0
+	}
+	defer func() { runHubFn = orig }()
+
+	if code := execute([]string{"--metrics-listen", "127.0.0.1:9464"}); code != 0 {
+		t.Fatalf("hub with metrics listener exit = %d, want 0", code)
+	}
+	if got != "127.0.0.1:9464" {
+		t.Fatalf("metrics listener = %q, want explicit address", got)
+	}
+
+	var ran bool
+	origShim := runShimFn
+	runShimFn = func([]string, string, string, bool, proxy.RedactConfig, traceOptions) int {
+		ran = true
+		return 0
+	}
+	defer func() { runShimFn = origShim }()
+	if code := execute([]string{"--metrics-listen", "127.0.0.1:9464", "--", "server"}); code != 2 {
+		t.Fatalf("shim with metrics listener exit = %d, want 2", code)
+	}
+	if ran {
+		t.Fatal("metrics listener must not instantiate the shim path")
 	}
 }
 

--- a/cmd/mcpsnoop/prune.go
+++ b/cmd/mcpsnoop/prune.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -82,37 +80,13 @@ func newPruneCmd() *cobra.Command {
 	return cmd
 }
 
-// pruneCutoff turns an --older-than value into the cutoff time, before which a log
-// is old enough to remove. time.ParseDuration rejects a day suffix, so a whole
-// number of days is parsed here on top of the Go duration forms it does accept.
+// pruneCutoff turns an --older-than value into the cutoff time, before which a
+// log is old enough to remove. The parsing is shared with stats --since, which
+// takes the same forms, so the two cannot drift into accepting different ones.
 func pruneCutoff(olderThan string) (time.Time, error) {
-	s := strings.TrimSpace(olderThan)
-	if s == "" {
-		return time.Time{}, errors.New("--older-than is required, e.g. 30d or 72h")
-	}
-	// A zero age would make the cutoff the current moment and match every log,
-	// including the one a running shim is still appending to, so both forms require
-	// a strictly positive value. That is the easiest way to express "delete
-	// everything", which issue #107 asked to keep out of reach.
-	var age time.Duration
-	if days, ok := strings.CutSuffix(s, "d"); ok {
-		n, err := strconv.Atoi(days)
-		if err != nil {
-			return time.Time{}, fmt.Errorf("invalid --older-than %q, want a whole number of days like 30d, or a Go duration like 72h", s)
-		}
-		if n <= 0 {
-			return time.Time{}, errors.New("--older-than must be greater than zero")
-		}
-		age = time.Duration(n) * 24 * time.Hour
-	} else {
-		d, err := time.ParseDuration(s)
-		if err != nil {
-			return time.Time{}, fmt.Errorf("invalid --older-than %q, want a day count like 30d, or a Go duration like 72h", s)
-		}
-		if d <= 0 {
-			return time.Time{}, errors.New("--older-than must be greater than zero")
-		}
-		age = d
+	age, err := parseAge(olderThan, "--older-than")
+	if err != nil {
+		return time.Time{}, err
 	}
 	return time.Now().Add(-age), nil
 }

--- a/cmd/mcpsnoop/sessionscan.go
+++ b/cmd/mcpsnoop/sessionscan.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// serverIdentity is what makes two sessions the same server, gathered from
+// whatever a log recorded about the run it opens.
+//
+// It is one type rather than one per command on purpose. inventory answers what
+// has run here and stats answers how those servers behaved, and if they keyed
+// differently the same machine would have two populations of servers with two
+// sets of names, which is precisely the confusion the label already causes.
+type serverIdentity struct {
+	label     string
+	transport string
+	command   []string
+	cwd       string
+	endpoint  string
+}
+
+// key folds an identity into a comparable string.
+//
+// For stdio it is the recorded command and working directory, never the label,
+// because labelFor derives the label from the command's last path element and
+// two checkouts of one project, or two servers written in one language, collide
+// there routinely. For HTTP it is the endpoint, since mcpsnoop launched nothing
+// and the endpoint is what the transport specification makes the server's
+// identity. A log carrying neither falls back to its label and transport, which
+// is the most a trimmed or pre-meta log can honestly claim.
+//
+// A redacted command keys as itself. Two runs of one server, one scrubbed and
+// one not, are two rows, and that is the honest answer: mcpsnoop cannot know
+// what the placeholder replaced, and merging them would mean guessing that the
+// hidden halves matched.
+func (id serverIdentity) key() string {
+	const sep = "\x00"
+	switch {
+	case len(id.command) > 0:
+		return "stdio" + sep + id.cwd + sep + strings.Join(id.command, sep)
+	case id.endpoint != "":
+		return "http" + sep + id.endpoint
+	default:
+		return "label" + sep + id.transport + sep + id.label
+	}
+}
+
+// sessionLog is one candidate log with the modification time the selection rule
+// orders by.
+type sessionLog struct {
+	path    string
+	modTime time.Time
+}
+
+// sessionLogs lists the session logs a walk should read, newest first, bounded.
+//
+// Recency is modification time rather than name, matching hub.backfill and the
+// exporter's newest-session lookup. A log is named <label>-<pid>-<nonce>.jsonl,
+// so ordering by name orders by label and would keep whichever labels sort last
+// rather than whichever sessions ran last.
+//
+// total is how many logs the directory held before the limit, so a caller can
+// say it read a window rather than letting a bounded answer pass for a complete
+// one. Zero-byte logs are counted in total and never returned: that is what a run
+// whose exec failed leaves, and what an HTTP proxy nobody called leaves on
+// purpose. Anything that is not a regular file is skipped outright, since os.Open
+// on a fifo blocks until a writer appears and would hang the walk.
+func sessionLogs(dir string, since time.Time, limit int) (logs []sessionLog, counts logCounts, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, logCounts{}, err
+	}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		info, statErr := os.Stat(path)
+		if statErr != nil || !info.Mode().IsRegular() {
+			counts.skipped++
+			continue
+		}
+		counts.total++
+		if info.Size() == 0 {
+			counts.empty++
+			continue
+		}
+		if !since.IsZero() && info.ModTime().Before(since) {
+			continue
+		}
+		logs = append(logs, sessionLog{path: path, modTime: info.ModTime()})
+	}
+	slices.SortFunc(logs, func(a, b sessionLog) int {
+		if c := b.modTime.Compare(a.modTime); c != 0 {
+			return c
+		}
+		// Modification times collide readily on a fast machine, so the tie is broken
+		// on the path. Without it the window a limit selects varies between runs over
+		// an unchanged directory.
+		return strings.Compare(a.path, b.path)
+	})
+	if limit > 0 && len(logs) > limit {
+		logs = logs[:limit]
+	}
+	return logs, counts, nil
+}
+
+// logCounts is what a walk stepped over, so two commands reading one directory
+// describe it the same way. total counts the regular .jsonl files it found,
+// empty the zero-byte ones among them, and skipped the entries that are not
+// regular files at all, which is a fifo, a socket, or a directory named like a
+// log.
+type logCounts struct {
+	total   int
+	empty   int
+	skipped int
+}
+
+// maxAgeDays is the largest whole number of days a time.Duration can hold, which
+// is math.MaxInt64 nanoseconds divided by a day.
+const maxAgeDays = int(math.MaxInt64 / (24 * int64(time.Hour)))
+
+// parseAge turns a --since or --older-than value into a duration. time.ParseDuration
+// rejects a day suffix, so a whole number of days is parsed here on top of the Go
+// duration forms it does accept.
+//
+// A zero or negative age is refused rather than treated as "everything". For
+// prune that keeps deletion out of reach by accident, and everywhere else it
+// keeps a flag that reads as a window from silently meaning its opposite.
+func parseAge(value, flag string) (time.Duration, error) {
+	s := strings.TrimSpace(value)
+	if s == "" {
+		return 0, fmt.Errorf("%s is required, e.g. 30d or 72h", flag)
+	}
+	if days, ok := strings.CutSuffix(s, "d"); ok {
+		n, err := strconv.Atoi(days)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s %q, want a whole number of days like 30d, or a Go duration like 72h", flag, s)
+		}
+		if n <= 0 {
+			return 0, fmt.Errorf("%s must be greater than zero", flag)
+		}
+		// A duration is an int64 of nanoseconds, so 106752 days multiplies past the
+		// end of it and lands on a negative one. That is not an overflow anybody
+		// would notice: prune would compute a cutoff in the future and delete every
+		// log in the directory, which is the one thing --older-than exists to keep
+		// out of reach.
+		if n > maxAgeDays {
+			return 0, fmt.Errorf("%s %q is beyond the largest age this can express, %d days", flag, s, maxAgeDays)
+		}
+		return time.Duration(n) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q, want a day count like 30d, or a Go duration like 72h", flag, s)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", flag)
+	}
+	return d, nil
+}

--- a/cmd/mcpsnoop/stats.go
+++ b/cmd/mcpsnoop/stats.go
@@ -1,0 +1,538 @@
+package main
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kerlenton/mcpsnoop/internal/exporter"
+	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/jsonwire"
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+func newStatsCmd() *cobra.Command {
+	var (
+		since  string
+		labels []string
+		limit  int
+		format string
+	)
+	cmd := &cobra.Command{
+		Use:   "stats [--since 7d] [--label name] [--limit N] [--format text|json]",
+		Short: "Fold every stored capture into one row per server and tool",
+		Long: "check reads one session and diff reads exactly two, so a tool that fails one run in four stays invisible until somebody opens the captures by hand. stats walks the sessions directory and pools the per-tool numbers the store already computes.\n\n" +
+			"Tool execution errors and protocol errors are counted apart, because the specification makes them different findings: a tool answering isError is reporting something a model can act on, and a JSON-RPC error is the request or the server being wrong.\n\n" +
+			"Percentiles are computed over the pooled raw durations. A median of medians is a median of nothing. One multi round-trip operation counts as one call with one duration, however many requests it took.\n\n" +
+			"Rows are keyed on the server, which is the recorded command and working directory for stdio and the endpoint for HTTP, not on the label. Two servers routinely derive one label, and pooling them produces a figure that is true of neither.\n\n" +
+			"It reports and does not gate. Nothing is written, no baseline is touched, and the exit code is 0 whenever the walk succeeded.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if format != "text" && format != "json" {
+				fmt.Fprintf(cmd.ErrOrStderr(), "mcpsnoop stats: invalid --format %q, want text or json\n", format)
+				return exitCode(2)
+			}
+			var cutoff time.Time
+			if strings.TrimSpace(since) != "" {
+				age, err := parseAge(since, "--since")
+				if err != nil {
+					fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop stats:", err)
+					return exitCode(2)
+				}
+				cutoff = time.Now().Add(-age)
+			}
+			if limit < 0 {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop stats: --limit must not be negative")
+				return exitCode(2)
+			}
+			// Asked of the flag rather than of its value. pflag parses --label "" into
+			// no values at all, which is indistinguishable from never passing the flag,
+			// so a filter that names nothing would otherwise report the whole directory
+			// under a flag that says it narrowed the answer.
+			if cmd.Flags().Changed("label") && len(nonBlank(labels)) == 0 {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop stats:", errBlankLabel)
+				return exitCode(2)
+			}
+
+			roll, err := rollUp(paths.SessionsDir(), cutoff, labels, limit)
+			if err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop stats:", err)
+				// A flag that names nothing is the caller's mistake, not the directory's,
+				// so it exits like every other usage error rather than like a read failure.
+				if errors.Is(err, errBlankLabel) {
+					return exitCode(2)
+				}
+				return exitCode(1)
+			}
+			if format == "json" {
+				return writeStatsJSON(cmd.OutOrStdout(), roll)
+			}
+			return writeStatsText(cmd.OutOrStdout(), roll)
+		},
+	}
+	cmd.Flags().SortFlags = false
+	cmd.Flags().StringVar(&since, "since", "", "only read logs modified within this window, e.g. 7d or 72h")
+	cmd.Flags().StringSliceVar(&labels, "label", nil, "only read sessions carrying this label, repeat or comma-separated")
+	cmd.Flags().IntVar(&limit, "limit", hub.DefaultBackfillLimit, "read at most this many of the newest logs, 0 for no bound")
+	cmd.Flags().StringVar(&format, "format", "text", "output format: text or json")
+	return cmd
+}
+
+// errBlankLabel is --label given with nothing in it, which must not fall through
+// to meaning no filter at all.
+var errBlankLabel = errors.New("--label was given but names nothing")
+
+// nonBlank drops the empty and whitespace-only entries of a repeated flag.
+func nonBlank(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if v = strings.TrimSpace(v); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// toolRow is one server and tool pair as the rollup reports it.
+type toolRow struct {
+	Key string `json:"-"`
+	// Server is the name to show. Labels holds every distinct one the sessions of
+	// this server carried, which differ only when someone passed --label, since
+	// the key is the command rather than the name.
+	Server string   `json:"server"`
+	Labels []string `json:"labels,omitempty"`
+	// Command, CWD and Endpoint are the identity the row is actually keyed on,
+	// spelled the way inventory spells them. Without them two servers that derive
+	// one label print as two identical lines and marshal to two identical objects,
+	// so a consumer indexing on server and tool keeps one and drops the other, and
+	// the reason the rows are separate is invisible in the place it matters most.
+	Command  []string `json:"command,omitempty"`
+	CWD      string   `json:"cwd,omitempty"`
+	Endpoint string   `json:"endpoint,omitempty"`
+	Tool     string   `json:"tool"`
+	Calls    int      `json:"calls"`
+	// ToolErrors is result.isError, the tool reporting a failure a model can act
+	// on. ProtocolErrors is a JSON-RPC error, the request or the server being
+	// wrong. FailureRate is both over Calls.
+	ToolErrors     int     `json:"tool_errors"`
+	ProtocolErrors int     `json:"protocol_errors"`
+	FailureRate    float64 `json:"failure_rate"`
+	// Sessions counted this tool, FailedSessions saw it fail at least once. The
+	// pair answers "one run in ten", which a rate over calls cannot.
+	Sessions       int     `json:"sessions"`
+	FailedSessions int     `json:"failed_sessions"`
+	P50MS          float64 `json:"p50_ms"`
+	P95MS          float64 `json:"p95_ms"`
+	P99MS          float64 `json:"p99_ms"`
+	// DefinitionBytes is what advertising this tool costs, from the most recent
+	// session that listed it. Zero when no session in the window did.
+	DefinitionBytes int `json:"definition_bytes"`
+
+	// serverKey is the identity half of Key, without the tool name, so the writer
+	// can ask how many servers share a label rather than how many rows do.
+	serverKey string
+	labels    map[string]struct{}
+	durations []time.Duration
+	sessions  map[string]struct{}
+	failed    map[string]struct{}
+}
+
+// rollup is the whole answer, including how much of the directory it read.
+type rollup struct {
+	Dir string `json:"sessions_dir"`
+	// Read is how many logs were folded in and Total is how many the directory
+	// held, so a bounded answer never passes for a complete one. Empty counts the
+	// zero-byte logs a failed exec or an uncalled HTTP proxy leaves, and Skipped
+	// the ones that could not be read, kept apart for the same reason inventory
+	// keeps them apart: one is housekeeping and the other is damage.
+	Read    int       `json:"read"`
+	Total   int       `json:"total"`
+	Empty   int       `json:"empty"`
+	Skipped int       `json:"skipped"`
+	Rows    []toolRow `json:"rows"`
+}
+
+// afterFold runs once per folded capture. It is a variable so a test can sample
+// how much the walk is holding while it is still walking: the claim here is
+// about peak, and peak is invisible from outside a call that has already
+// returned, where every store it dropped is collectable anyway.
+var afterFold = func() {}
+
+// rollUp folds every selected log into one row per server and tool.
+//
+// One store is resident at a time. A log is loaded, its calls are folded into
+// the running aggregate, and the store is dropped before the next one opens, so
+// peak memory is the largest single capture plus the counters rather than the
+// whole directory.
+func rollUp(dir string, since time.Time, labels []string, limit int) (rollup, error) {
+	logs, counts, err := sessionLogs(dir, since, 0)
+	if err != nil {
+		return rollup{}, err
+	}
+	// A --label of nothing but blanks is not "no filter". The command catches the
+	// case pflag can express as an empty slice; this catches a caller handing in a
+	// slice of blanks directly.
+	if len(labels) > 0 && len(nonBlank(labels)) == 0 {
+		return rollup{}, errBlankLabel
+	}
+	want := make(map[string]struct{}, len(labels))
+	for _, l := range nonBlank(labels) {
+		want[l] = struct{}{}
+	}
+
+	// A label is on the first envelope, so it is answered from the head rather
+	// than by loading a whole capture and discarding it. That also makes --limit
+	// mean the newest logs of the selected server rather than the newest logs
+	// overall, which is what somebody asking for both is after: --label x --limit 5
+	// should be five of x, not however many of x happen to be in the newest five.
+	unreadable := 0
+	if len(want) > 0 {
+		kept := logs[:0]
+		for _, log := range logs {
+			head, err := readSessionHead(log.path)
+			if err != nil {
+				// Counted here, because a log dropped in the pre-pass never reaches the
+				// fold that would otherwise count it. Saying nothing made --label report
+				// a clean directory that a plain run reported as holding a damaged log.
+				unreadable++
+				continue
+			}
+			if _, hit := want[head.label]; hit {
+				kept = append(kept, log)
+			}
+		}
+		logs = kept
+	}
+	if limit > 0 && len(logs) > limit {
+		logs = logs[:limit]
+	}
+
+	roll := rollup{Dir: dir, Total: counts.total, Empty: counts.empty, Skipped: counts.skipped + unreadable}
+	rows := make(map[string]*toolRow)
+	// Definition costs live beside the rows rather than on them, because a session
+	// can advertise a tool it never calls and the newest description of a tool is
+	// the one worth reporting whichever session made it.
+	costs := make(map[string]int)
+	// Oldest first, so the definition cost a row reports is the newest one seen
+	// rather than whichever log the listing reached last.
+	for _, log := range slices.Backward(logs) {
+		st, _, err := exporter.LoadFileTolerant(log.path)
+		if err != nil {
+			roll.Skipped++
+			continue
+		}
+		// Every session in the file, not only the one its first envelope names. A
+		// log holding several is not exotic: concatenating captures is what the
+		// issue's own reproduction does, and the store already separates them, so
+		// folding one and dropping the rest loses calls without saying a word.
+		headers := st.Sessions()
+		if len(headers) == 0 {
+			roll.Skipped++
+			continue
+		}
+		roll.Read++
+		for _, header := range headers {
+			foldSession(rows, costs, st, header.ID, header)
+		}
+		afterFold()
+	}
+
+	roll.Rows = make([]toolRow, 0, len(rows))
+	for key, row := range rows {
+		row.DefinitionBytes = costs[key]
+		row.Labels = slices.Sorted(maps.Keys(row.labels))
+		row.Server = strings.Join(row.Labels, ", ")
+		if row.Server == "" {
+			row.Server = "(unlabelled)"
+		}
+		row.Sessions = len(row.sessions)
+		row.FailedSessions = len(row.failed)
+		if row.Calls > 0 {
+			row.FailureRate = float64(row.ToolErrors+row.ProtocolErrors) / float64(row.Calls) * 100
+		}
+		// Pooled and sorted once, here. Combining per-session percentiles would be
+		// an average of medians, which describes no distribution.
+		slices.Sort(row.durations)
+		row.P50MS = percentileMS(row.durations, 0.50)
+		row.P95MS = percentileMS(row.durations, 0.95)
+		row.P99MS = percentileMS(row.durations, 0.99)
+		roll.Rows = append(roll.Rows, *row)
+	}
+	slices.SortFunc(roll.Rows, func(a, b toolRow) int {
+		// Worst first, and a broken server outranks a tool reporting a domain
+		// failure rather than sharing one bucket with it.
+		if c := cmp.Compare(b.ProtocolErrors, a.ProtocolErrors); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(b.ToolErrors, a.ToolErrors); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(b.P50MS, a.P50MS); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Server, b.Server); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Tool, b.Tool); c != 0 {
+			return c
+		}
+		// Last resort, and it has to be total. Two servers deriving one label with
+		// one tool and identical figures tie on every column above, and map order
+		// then decided the output, so two runs over an unchanged directory printed
+		// the rows in different orders.
+		return cmp.Compare(a.Key, b.Key)
+	})
+	return roll, nil
+}
+
+// foldSession adds one capture's tool calls to the running aggregate.
+//
+// The calls come from the store rather than from the raw JSONL, because the
+// store is what knows a multi round-trip retry continues an operation rather
+// than starting one. Keying on the JSON-RPC id instead would count one logical
+// operation as several and feed its wall clock in more than once, which is the
+// failure docs/2026-07-28-mrtr-breaks-latency.md exists about.
+func foldSession(rows map[string]*toolRow, costs map[string]int, st *store.Store, sessionID string, header store.SessionHeader) {
+	command, cwd, _ := st.Command(sessionID)
+	id := serverIdentity{
+		label: header.Label, transport: header.Transport,
+		command: command, cwd: cwd, endpoint: header.Endpoint,
+	}
+	// The label joins the identity rather than replacing it. Alone it pools two
+	// servers that derive one name, which is what the identity is for. Left out, it
+	// pools one command deliberately run as prod and again as staging, and smears
+	// two deployments into one distribution. Both are the same mistake, so both
+	// halves key.
+	server := id.key() + "\x00" + header.Label
+
+	// Recorded per advertised tool rather than inside the call loop. A session
+	// that listed a tool without calling it still knows what advertising it costs,
+	// and gating the write on a call meant the figure came from the newest session
+	// that used the tool rather than the newest that described it. Sessions arrive
+	// oldest first, so the last write wins and that is the newest description.
+	if cost, ok := st.ToolCosts(sessionID); ok {
+		for _, per := range cost.PerTool {
+			costs[server+"\x00"+per.Name] = per.Bytes
+		}
+	}
+
+	for _, call := range st.Calls(sessionID) {
+		if !call.IsTool || call.ToolName == "" {
+			continue
+		}
+		key := server + "\x00" + call.ToolName
+		row := rows[key]
+		if row == nil {
+			row = &toolRow{
+				Key: key, serverKey: server, Tool: call.ToolName,
+				Command: command, CWD: cwd, Endpoint: header.Endpoint,
+				labels:   make(map[string]struct{}),
+				sessions: make(map[string]struct{}),
+				failed:   make(map[string]struct{}),
+			}
+			rows[key] = row
+		}
+		if header.Label != "" {
+			row.labels[header.Label] = struct{}{}
+		}
+		row.sessions[sessionID] = struct{}{}
+		row.Calls++
+		switch {
+		case call.ToolErr:
+			row.ToolErrors++
+			row.failed[sessionID] = struct{}{}
+		case call.Errored:
+			row.ProtocolErrors++
+			row.failed[sessionID] = struct{}{}
+		}
+		// A call still open, superseded, or cancelled without a late result has no
+		// round trip to measure. It counts as a call, since it was made, and
+		// contributes no latency, which is the rule the per-session summary uses.
+		//
+		// Superseded needs naming separately, because it passes both other tests.
+		// A client reusing an id while the earlier request is in flight makes the
+		// store stamp the older call's end with the newer request's timestamp, so
+		// Done() is true and Duration() is the gap between two unrelated requests.
+		// Folding that in reported an hour-long round trip on a server whose slowest
+		// real answer was twenty milliseconds.
+		if d := call.Duration(); call.Done() && call.State != store.Superseded && d > 0 {
+			row.durations = append(row.durations, d)
+		}
+	}
+}
+
+// percentileMS is the nearest-rank percentile of a sorted duration slice, in
+// milliseconds, matching what the per-session summary reports.
+func percentileMS(sorted []time.Duration, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	index := int(float64(len(sorted))*p+0.999999) - 1
+	return float64(sorted[min(max(index, 0), len(sorted)-1)]) / float64(time.Millisecond)
+}
+
+func writeStatsJSON(w io.Writer, roll rollup) error {
+	enc := jsonwire.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(roll)
+}
+
+func writeStatsText(w io.Writer, roll rollup) error {
+	if len(roll.Rows) == 0 {
+		_, err := fmt.Fprintf(w, "no tool calls found: %s\n", readTail(roll))
+		return err
+	}
+
+	names := serverNames(roll.Rows)
+	tools := make([]string, len(roll.Rows))
+	serverW := len("SERVER")
+	toolW := len("TOOL")
+	for i, row := range roll.Rows {
+		tools[i] = oneLine(row.Tool)
+		serverW = max(serverW, width(names[i]))
+		toolW = max(toolW, width(tools[i]))
+	}
+	// Capped, because neither is mcpsnoop's to choose. A tool name is whatever the
+	// server advertised and a command is whatever installed it, so one absurd
+	// value would otherwise pad every row in the table to its width.
+	serverW = min(serverW, maxNameW)
+	toolW = min(toolW, maxNameW)
+
+	if _, err := fmt.Fprintf(w, "%s\n\n", readTail(roll)); err != nil {
+		return err
+	}
+	header := fmt.Sprintf("%s  %s  %6s %5s %6s  %7s  %9s  %9s %9s %9s  %7s",
+		pad("SERVER", serverW), pad("TOOL", toolW), "CALLS", "ERR", "PROTO", "FAIL%", "SESS", "p50", "p95", "p99", "DEF")
+	if _, err := fmt.Fprintln(w, header); err != nil {
+		return err
+	}
+	for i, row := range roll.Rows {
+		def := "-"
+		if row.DefinitionBytes > 0 {
+			def = fmt.Sprintf("%dB", row.DefinitionBytes)
+		}
+		line := fmt.Sprintf("%s  %s  %6d %5d %6d  %6.1f%%  %9s  %9s %9s %9s  %7s",
+			pad(elide(names[i], serverW), serverW), pad(elide(tools[i], toolW), toolW),
+			row.Calls, row.ToolErrors, row.ProtocolErrors, row.FailureRate,
+			fmt.Sprintf("%d/%d", row.FailedSessions, row.Sessions),
+			msLabel(row.P50MS), msLabel(row.P95MS), msLabel(row.P99MS), def)
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	// The two error columns only teach themselves once, and the difference is the
+	// whole reason they are two columns.
+	_, err := fmt.Fprint(w, "\nERR is result.isError, the tool reporting a failure a model can act on."+
+		"\nPROTO is a JSON-RPC error, the request or the server being wrong."+
+		"\nSESS is sessions that saw a failure over sessions that called the tool.\n")
+	return err
+}
+
+// maxNameW bounds the two free-text columns. Eight bytes short of forty leaves
+// the fixed columns aligned on an eighty-column terminal for ordinary names.
+const maxNameW = 32
+
+// serverNames renders the SERVER cell of each row, qualified only where it has
+// to be.
+//
+// A row is keyed on the recorded command and working directory, or on the
+// endpoint, and shows the label. When two rows share a label that is the whole
+// point of keying on something else, and printing the label alone made them two
+// identical lines, which reads as one row printed twice rather than as the two
+// servers it is. Those rows carry their working directory or endpoint; every
+// other row is untouched, so the common table looks as it did.
+func serverNames(rows []toolRow) []string {
+	byLabel := make(map[string]map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if byLabel[row.Server] == nil {
+			byLabel[row.Server] = make(map[string]struct{})
+		}
+		// Servers, not rows. Keying on the row counted one server's two tools as two
+		// servers and qualified a name that was never ambiguous.
+		byLabel[row.Server][row.serverKey] = struct{}{}
+	}
+	out := make([]string, len(rows))
+	for i, row := range rows {
+		name := oneLine(row.Server)
+		if len(byLabel[row.Server]) > 1 {
+			switch {
+			case row.CWD != "":
+				name += " (" + oneLine(row.CWD) + ")"
+			case row.Endpoint != "":
+				name += " (" + oneLine(row.Endpoint) + ")"
+			case len(row.Command) > 0:
+				name += " (" + oneLine(strings.Join(row.Command, " ")) + ")"
+			}
+		}
+		out[i] = name
+	}
+	return out
+}
+
+// elide trims a value to the column it has to fit in, keeping the tail, because
+// what distinguishes two long paths or two long tool names is at the end of them.
+func elide(s string, w int) string {
+	r := []rune(s)
+	if len(r) <= w || w < 2 {
+		return s
+	}
+	return "…" + string(r[len(r)-(w-1):])
+}
+
+// width and pad measure and align in runes rather than bytes.
+//
+// fmt's %-*s counts bytes, so a name holding anything outside ASCII, including
+// the ellipsis elide adds, padded its cell short and pushed every column to its
+// right out of line. Runes are not display cells either, and a table of CJK will
+// still sit a little wide, but a server name or a tool name is overwhelmingly
+// ASCII with the occasional accent, and for those this is exact.
+func width(s string) int { return utf8.RuneCountInString(s) }
+
+func pad(s string, w int) string {
+	if n := w - width(s); n > 0 {
+		return s + strings.Repeat(" ", n)
+	}
+	return s
+}
+
+// readTail states how much of the directory the answer covers, so a window never
+// passes for the whole record.
+func readTail(roll rollup) string {
+	out := fmt.Sprintf("read %s of %d in %s", plural(roll.Read, "log"), roll.Total, roll.Dir)
+	if roll.Empty > 0 {
+		out += fmt.Sprintf(", %s left by a run that recorded nothing", plural(roll.Empty, "empty log"))
+	}
+	if roll.Skipped > 0 {
+		out += fmt.Sprintf(", %s skipped as unreadable", plural(roll.Skipped, "log"))
+	}
+	return out
+}
+
+// msLabel renders a duration column. A tool whose calls never completed has no
+// latency rather than a zero one, and printing 0ms would read as instant.
+func msLabel(ms float64) string {
+	switch {
+	case ms == 0:
+		return "-"
+	case ms < 10:
+		return fmt.Sprintf("%.1fms", ms)
+	case ms < 10_000:
+		return fmt.Sprintf("%.0fms", ms)
+	// Past ten seconds the millisecond is noise and the digits overflow a column
+	// sized for them, which pushed every cell to its right out of line. A half-hour
+	// reindex is a real answer and has to fit beside a five-millisecond ping.
+	case ms < 600_000:
+		return fmt.Sprintf("%.1fs", ms/1000)
+	default:
+		return fmt.Sprintf("%.1fmin", ms/60_000)
+	}
+}

--- a/cmd/mcpsnoop/stats_test.go
+++ b/cmd/mcpsnoop/stats_test.go
@@ -1,0 +1,1101 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/paths"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func executeStats(t *testing.T, args []string) (int, string, string) {
+	t.Helper()
+	cmd := newStatsCmd()
+	cmd.SetArgs(args)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		return 0, stdout.String(), stderr.String()
+	}
+	var code exitCode
+	if !errors.As(err, &code) {
+		t.Fatalf("unexpected command error: %v", err)
+	}
+	return int(code), stdout.String(), stderr.String()
+}
+
+// call is one tools/call and its answer, at a chosen duration.
+type call struct {
+	tool     string
+	duration time.Duration
+	// answer is the response body after the id, so a test can choose between a
+	// result, a tool error and a JSON-RPC error.
+	answer string
+}
+
+const (
+	answerOK    = `"result":{"content":[]}`
+	answerIsErr = `"result":{"content":[],"isError":true}`
+	answerProto = `"error":{"code":-32603,"message":"boom"}`
+)
+
+// writeCapture writes one session log: a meta frame, a tools/list, then the
+// calls. command and cwd decide which server it belongs to.
+func writeCapture(t *testing.T, name, label string, at time.Time, cwd string, command []string, tools []string, calls []call) string {
+	t.Helper()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: command, CWD: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := strings.TrimSuffix(name, ".jsonl")
+	envs := []proxy.Envelope{{
+		SessionID: id, ServerLabel: label, Seq: 1, TS: at,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta,
+	}}
+	seq := uint64(1)
+	add := func(dir proxy.Direction, ts time.Time, raw string) {
+		seq++
+		envs = append(envs, proxy.Envelope{
+			SessionID: id, ServerLabel: label, Seq: seq, TS: ts,
+			Direction: dir, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw),
+		})
+	}
+	if len(tools) > 0 {
+		defs := make([]string, 0, len(tools))
+		for _, tool := range tools {
+			defs = append(defs, fmt.Sprintf(`{"name":%q,"description":"d","inputSchema":{"type":"object"}}`, tool))
+		}
+		add(proxy.ClientToServer, at.Add(time.Millisecond), `{"jsonrpc":"2.0","id":"list","method":"tools/list"}`)
+		add(proxy.ServerToClient, at.Add(2*time.Millisecond),
+			fmt.Sprintf(`{"jsonrpc":"2.0","id":"list","result":{"tools":[%s]}}`, strings.Join(defs, ",")))
+	}
+	clock := at.Add(10 * time.Millisecond)
+	for i, c := range calls {
+		reqID := fmt.Sprintf("c%d", i)
+		add(proxy.ClientToServer, clock, fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":%q}}`, reqID, c.tool))
+		clock = clock.Add(c.duration)
+		add(proxy.ServerToClient, clock, fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,%s}`, reqID, c.answer))
+		clock = clock.Add(time.Millisecond)
+	}
+
+	path := filepath.Join(paths.SessionsDir(), name)
+	var buf bytes.Buffer
+	for _, env := range envs {
+		b, err := json.Marshal(env)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Modification time is the selection rule, so it has to match the capture.
+	if err := os.Chtimes(path, at, at); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func rowFor(t *testing.T, roll rollup, server, tool string) toolRow {
+	t.Helper()
+	for _, row := range roll.Rows {
+		if row.Server == server && row.Tool == tool {
+			return row
+		}
+	}
+	t.Fatalf("no row for %s/%s in %+v", server, tool, roll.Rows)
+	return toolRow{}
+}
+
+// TestStatsPoolsWhatCheckCannotSee is the reproduction the issue is built on: a
+// tool that fails one run in four while the newest capture is clean, so check
+// passes honestly and says nothing about it.
+func TestStatsPoolsWhatCheckCannotSee(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	tools := []string{"search_docs", "read_file", "run_query"}
+	for i := range 12 {
+		answer := answerOK
+		if i%4 == 0 { // three of twelve fail
+			answer = answerIsErr
+		}
+		writeCapture(t, fmt.Sprintf("flaky-%02d.jsonl", i), "flaky-demo", t0.Add(time.Duration(i)*time.Hour),
+			"/srv/flaky", []string{"node", "server.js"}, tools, []call{
+				{tool: "search_docs", duration: 40 * time.Millisecond, answer: answerOK},
+				{tool: "read_file", duration: 15 * time.Millisecond, answer: answerOK},
+				{tool: "run_query", duration: 400 * time.Millisecond, answer: answer},
+			})
+	}
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if roll.Read != 12 || roll.Total != 12 {
+		t.Fatalf("read %d of %d, want 12 of 12", roll.Read, roll.Total)
+	}
+	row := rowFor(t, roll, "flaky-demo", "run_query")
+	if row.Calls != 12 || row.ToolErrors != 3 || row.ProtocolErrors != 0 {
+		t.Fatalf("run_query = %d calls, %d tool errors, %d protocol errors; want 12, 3, 0", row.Calls, row.ToolErrors, row.ProtocolErrors)
+	}
+	if row.Sessions != 12 || row.FailedSessions != 3 {
+		t.Fatalf("sessions = %d/%d, want 3/12", row.FailedSessions, row.Sessions)
+	}
+	if got := row.FailureRate; got < 24.9 || got > 25.1 {
+		t.Fatalf("failure rate = %.1f%%, want 25%%", got)
+	}
+	// Worst first: run_query carries the only errors.
+	if roll.Rows[0].Tool != "run_query" {
+		t.Fatalf("rows do not sort worst first: %+v", roll.Rows)
+	}
+}
+
+// TestStatsKeepsTwoServersApart is why the rollup keys on the server rather than
+// on the tool name. Pooling two distributions produces a figure true of neither.
+func TestStatsKeepsTwoServersApart(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	for i := range 4 {
+		writeCapture(t, fmt.Sprintf("fast-%d.jsonl", i), "flaky-demo", t0.Add(time.Duration(i)*time.Hour),
+			"/srv/one", []string{"node", "server.js"}, []string{"search_docs"},
+			[]call{{tool: "search_docs", duration: 40 * time.Millisecond, answer: answerOK}})
+		writeCapture(t, fmt.Sprintf("slow-%d.jsonl", i), "docs-mirror", t0.Add(time.Duration(i)*time.Hour),
+			"/srv/two", []string{"python3", "mirror.py"}, []string{"search_docs"},
+			[]call{{tool: "search_docs", duration: 380 * time.Millisecond, answer: answerOK}})
+	}
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roll.Rows) != 2 {
+		t.Fatalf("rows = %d, want one per server; pooling them describes neither", len(roll.Rows))
+	}
+	fast := rowFor(t, roll, "flaky-demo", "search_docs")
+	slow := rowFor(t, roll, "docs-mirror", "search_docs")
+	if fast.P50MS > 100 || slow.P50MS < 300 {
+		t.Fatalf("the two distributions are smeared: %.0fms and %.0fms", fast.P50MS, slow.P50MS)
+	}
+}
+
+// TestStatsSeparatesTwoServersSharingOneLabel is what keying on the label alone
+// cannot do, and the case #128 measured: labelFor derives the label from the
+// command's last path element, so two servers arrive under one name.
+func TestStatsSeparatesTwoServersSharingOneLabel(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "a.jsonl", "server.py", t0, "/proj/alpha", []string{"python3", "server.py", "alpha"},
+		[]string{"search"}, []call{{tool: "search", duration: 20 * time.Millisecond, answer: answerOK}})
+	writeCapture(t, "b.jsonl", "server.py", t0.Add(time.Hour), "/proj/beta", []string{"python3", "server.py", "beta"},
+		[]string{"search"}, []call{{tool: "search", duration: 500 * time.Millisecond, answer: answerIsErr}})
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roll.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2; one derived label covers two servers", len(roll.Rows))
+	}
+	var withError, clean int
+	for _, row := range roll.Rows {
+		if row.ToolErrors > 0 {
+			withError++
+		} else {
+			clean++
+		}
+	}
+	if withError != 1 || clean != 1 {
+		t.Fatalf("the failing server is not isolated: %+v", roll.Rows)
+	}
+}
+
+// TestStatsCountsAnMRTROperationOnce is the failure the correlation exists to
+// prevent. Keying on the JSON-RPC id would report one operation as two calls and
+// feed the same wall clock in twice.
+func TestStatsCountsAnMRTROperationOnce(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := func(seq uint64, ts time.Time, dir proxy.Direction, raw string) proxy.Envelope {
+		return proxy.Envelope{SessionID: "m1", ServerLabel: "elicit", Seq: seq, TS: ts,
+			Direction: dir, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)}
+	}
+	envs := []proxy.Envelope{
+		{SessionID: "m1", ServerLabel: "elicit", Seq: 1, TS: t0, Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta},
+		env(2, t0.Add(10*time.Millisecond), proxy.ClientToServer, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"confirm"}}`),
+		env(3, t0.Add(20*time.Millisecond), proxy.ServerToClient, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"blob","inputRequests":{"k":{"method":"elicitation/create","params":{}}}}}`),
+		// The user takes five seconds to answer, then the client retries under a new id.
+		env(4, t0.Add(5020*time.Millisecond), proxy.ClientToServer, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"confirm","inputResponses":{"k":{"action":"accept"}}}}`),
+		env(5, t0.Add(6020*time.Millisecond), proxy.ServerToClient, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`),
+	}
+	var buf bytes.Buffer
+	for _, e := range envs {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(filepath.Join(paths.SessionsDir(), "m1.jsonl"), buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roll.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(roll.Rows))
+	}
+	row := roll.Rows[0]
+	if row.Calls != 1 {
+		t.Fatalf("calls = %d, want 1; a multi round-trip operation is one call however many requests it took", row.Calls)
+	}
+	// Six seconds of wall clock, spanning the time the user spent answering.
+	if row.P50MS < 5900 || row.P50MS > 6100 {
+		t.Fatalf("p50 = %.0fms, want the whole exchange near 6000ms", row.P50MS)
+	}
+}
+
+// TestStatsPoolsRawDurations is the difference between a percentile and an
+// average of percentiles. Each session here is uniform, so a per-session p95 is
+// that session's only value and averaging them lands in the middle of the range
+// rather than near its top.
+func TestStatsPoolsRawDurations(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	for i := range 20 {
+		writeCapture(t, fmt.Sprintf("s%02d.jsonl", i), "srv", t0.Add(time.Duration(i)*time.Hour),
+			"/srv", []string{"node", "s.js"}, []string{"t"},
+			[]call{{tool: "t", duration: time.Duration(i+1) * 10 * time.Millisecond, answer: answerOK}})
+	}
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := rowFor(t, roll, "srv", "t")
+	if row.Calls != 20 {
+		t.Fatalf("calls = %d, want 20", row.Calls)
+	}
+	// Durations are 10..200ms. Nearest rank puts p50 at the 10th value and p95 at
+	// the 19th. An average of the twenty per-session values would be 105ms for
+	// every percentile alike.
+	if row.P50MS < 95 || row.P50MS > 105 {
+		t.Fatalf("p50 = %.0fms, want 100ms", row.P50MS)
+	}
+	if row.P95MS < 185 || row.P95MS > 195 {
+		t.Fatalf("p95 = %.0fms, want 190ms; averaging per-session percentiles would give 105ms", row.P95MS)
+	}
+	if row.P95MS <= row.P50MS {
+		t.Fatalf("p95 %.0fms is not above p50 %.0fms, so the pooling collapsed", row.P95MS, row.P50MS)
+	}
+}
+
+// TestStatsSeparatesTheTwoErrorKinds covers the distinction the spec draws on
+// the Tools page: a protocol error is the request or the server being wrong, and
+// isError is the tool reporting something a model can act on.
+func TestStatsSeparatesTheTwoErrorKinds(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "a.jsonl", "srv", t0, "/srv", []string{"node", "s.js"}, []string{"t"}, []call{
+		{tool: "t", duration: 10 * time.Millisecond, answer: answerOK},
+		{tool: "t", duration: 10 * time.Millisecond, answer: answerIsErr},
+		{tool: "t", duration: 10 * time.Millisecond, answer: answerProto},
+		{tool: "t", duration: 10 * time.Millisecond, answer: answerProto},
+	})
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := rowFor(t, roll, "srv", "t")
+	if row.Calls != 4 || row.ToolErrors != 1 || row.ProtocolErrors != 2 {
+		t.Fatalf("got %d calls, %d tool, %d protocol; want 4, 1, 2", row.Calls, row.ToolErrors, row.ProtocolErrors)
+	}
+	if got := row.FailureRate; got < 74.9 || got > 75.1 {
+		t.Fatalf("failure rate = %.1f%%, want 75%% over both kinds", got)
+	}
+	_, stdout, _ := executeStats(t, nil)
+	if !strings.Contains(stdout, "ERR is result.isError") || !strings.Contains(stdout, "PROTO is a JSON-RPC error") {
+		t.Fatalf("the table never explains its two error columns:\n%s", stdout)
+	}
+}
+
+// TestStatsFlags covers the window, the label filter, the bound and the report
+// of how much of the directory the answer covers.
+func TestStatsFlags(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	now := time.Now()
+	for i := range 6 {
+		label, cwd := "recent", "/recent"
+		at := now.Add(-time.Duration(i) * time.Hour)
+		if i >= 3 {
+			label, cwd = "ancient", "/ancient"
+			at = now.Add(-time.Duration(30+i) * 24 * time.Hour)
+		}
+		writeCapture(t, fmt.Sprintf("s%d.jsonl", i), label, at, cwd, []string{"node", cwd + ".js"},
+			[]string{"t"}, []call{{tool: "t", duration: 10 * time.Millisecond, answer: answerOK}})
+	}
+
+	t.Run("since bounds the window", func(t *testing.T) {
+		roll, err := rollUp(paths.SessionsDir(), time.Now().Add(-24*time.Hour), nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roll.Read != 3 || roll.Total != 6 {
+			t.Fatalf("read %d of %d, want 3 of 6", roll.Read, roll.Total)
+		}
+	})
+
+	t.Run("label restricts the walk", func(t *testing.T) {
+		roll, err := rollUp(paths.SessionsDir(), time.Time{}, []string{"ancient"}, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roll.Read != 3 {
+			t.Fatalf("read %d, want the 3 ancient logs", roll.Read)
+		}
+		for _, row := range roll.Rows {
+			if row.Server != "ancient" {
+				t.Fatalf("a row from another label survived: %+v", row)
+			}
+		}
+	})
+
+	t.Run("limit selects within the label", func(t *testing.T) {
+		roll, err := rollUp(paths.SessionsDir(), time.Time{}, []string{"ancient"}, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roll.Read != 2 {
+			t.Fatalf("read %d, want 2 of the ancient logs; a limit applied before the label would have read none", roll.Read)
+		}
+	})
+
+	t.Run("the output says how much it covers", func(t *testing.T) {
+		_, stdout, _ := executeStats(t, []string{"--limit", "2"})
+		if !strings.Contains(stdout, "read 2 logs of 6") {
+			t.Fatalf("a bounded answer does not say it is bounded:\n%s", stdout)
+		}
+	})
+
+	t.Run("the default limit is the backfill limit", func(t *testing.T) {
+		cmd := newStatsCmd()
+		if got := cmd.Flags().Lookup("limit").DefValue; got != fmt.Sprintf("%d", hub.DefaultBackfillLimit) {
+			t.Fatalf("--limit default = %s, want %d", got, hub.DefaultBackfillLimit)
+		}
+	})
+}
+
+// TestStatsOnAnEmptyWindowExitsZero keeps stats a report rather than a gate.
+func TestStatsOnAnEmptyWindowExitsZero(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	code, stdout, stderr := executeStats(t, []string{"--since", "1h"})
+	if code != 0 || stderr != "" {
+		t.Fatalf("code %d stderr %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "no tool calls found") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// TestStatsNeverExposesAPayload is the privacy boundary. A capture holds params
+// and results, and a rollup that leaked them would defeat every redaction flag.
+func TestStatsNeverExposesAPayload(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	const secret = "sk-live-do-not-print-me"
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envs := []proxy.Envelope{
+		{SessionID: "p1", ServerLabel: "srv", Seq: 1, TS: t0, Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta},
+		{SessionID: "p1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond), Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t","arguments":{"token":%q}}}`, secret))},
+		{SessionID: "p1", ServerLabel: "srv", Seq: 3, TS: t0.Add(20 * time.Millisecond), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":"1","result":{"content":[{"type":"text","text":%q}]}}`, secret))},
+	}
+	var buf bytes.Buffer
+	for _, e := range envs {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(filepath.Join(paths.SessionsDir(), "p1.jsonl"), buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{nil, {"--format", "json"}} {
+		_, stdout, stderr := executeStats(t, args)
+		if strings.Contains(stdout, secret) || strings.Contains(stderr, secret) {
+			t.Fatalf("stats printed a captured payload with %v:\n%s%s", args, stdout, stderr)
+		}
+	}
+}
+
+// TestStatsWritesNothing pins the read-only promise. A rollup that recorded a
+// baseline would change what a later check --fail-on drift concludes.
+func TestStatsWritesNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", home)
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "a.jsonl", "srv", t0, "/srv", []string{"node", "s.js"}, []string{"t"},
+		[]call{{tool: "t", duration: 10 * time.Millisecond, answer: answerOK}})
+
+	before := snapshotTree(t, home)
+	if code, _, stderr := executeStats(t, nil); code != 0 || stderr != "" {
+		t.Fatalf("code %d stderr %q", code, stderr)
+	}
+	if after := snapshotTree(t, home); !slicesEqual(before, after) {
+		t.Fatalf("stats changed the state directory:\nbefore %v\nafter  %v", before, after)
+	}
+}
+
+func snapshotTree(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		out = append(out, fmt.Sprintf("%s|%d|%v", path, info.Size(), info.ModTime().UnixNano()))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestStatsJSONCarriesTheSameFigures keeps the two formats from drifting.
+func TestStatsJSONCarriesTheSameFigures(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "a.jsonl", "srv", t0, "/srv", []string{"node", "s.js"}, []string{"t"}, []call{
+		{tool: "t", duration: 10 * time.Millisecond, answer: answerOK},
+		{tool: "t", duration: 30 * time.Millisecond, answer: answerIsErr},
+	})
+
+	code, stdout, stderr := executeStats(t, []string{"--format", "json"})
+	if code != 0 || stderr != "" {
+		t.Fatalf("code %d stderr %q", code, stderr)
+	}
+	var parsed rollup
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("the JSON does not parse: %v\n%s", err, stdout)
+	}
+	if len(parsed.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(parsed.Rows))
+	}
+	row := parsed.Rows[0]
+	if row.Calls != 2 || row.ToolErrors != 1 || row.Sessions != 1 || row.FailedSessions != 1 {
+		t.Fatalf("json row = %+v", row)
+	}
+	if row.DefinitionBytes == 0 {
+		t.Fatal("the definition cost is missing from the JSON")
+	}
+	if parsed.Read != 1 || parsed.Total != 1 {
+		t.Fatalf("read %d of %d, want 1 of 1", parsed.Read, parsed.Total)
+	}
+}
+
+// TestStatsRejectsBadFlags keeps a typo from silently producing the default.
+func TestStatsRejectsBadFlags(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	for _, tc := range []struct {
+		name, want string
+		args       []string
+	}{
+		{"format", "invalid --format", []string{"--format", "yaml"}},
+		{"since", "--since", []string{"--since", "0d"}},
+		{"since unparseable", "--since", []string{"--since", "soon"}},
+		{"limit", "--limit", []string{"--limit", "-1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, stdout, stderr := executeStats(t, tc.args)
+			if code != 2 {
+				t.Fatalf("code = %d, want 2 for a usage error", code)
+			}
+			if stdout != "" || !strings.Contains(stderr, tc.want) {
+				t.Fatalf("stdout %q stderr %q", stdout, stderr)
+			}
+		})
+	}
+}
+
+// TestStatsCountsAPendingCallWithoutLatency covers the rule the per-session
+// summary already applies. A call that never came back was still made, so it
+// counts, and it has no round trip to measure, so folding a zero into the
+// percentiles would drag them toward a latency nothing observed.
+func TestStatsCountsAPendingCallWithoutLatency(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envs := []proxy.Envelope{
+		{SessionID: "h1", ServerLabel: "srv", Seq: 1, TS: t0, Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta},
+		// One answered call at 100ms.
+		{SessionID: "h1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond), Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`)},
+		{SessionID: "h1", ServerLabel: "srv", Seq: 3, TS: t0.Add(101 * time.Millisecond), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`)},
+		// One that never came back.
+		{SessionID: "h1", ServerLabel: "srv", Seq: 4, TS: t0.Add(200 * time.Millisecond), Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t"}}`)},
+	}
+	var buf bytes.Buffer
+	for _, e := range envs {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(filepath.Join(paths.SessionsDir(), "h1.jsonl"), buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := rowFor(t, roll, "srv", "t")
+	if row.Calls != 2 {
+		t.Fatalf("calls = %d, want 2; a call that never came back was still made", row.Calls)
+	}
+	// Every percentile, not just the median. With two calls and one round trip,
+	// the median lands on the measured one either way, so folding the open call's
+	// elapsed time in would hide there and surface only at the tail.
+	for _, got := range []struct {
+		name string
+		ms   float64
+	}{{"p50", row.P50MS}, {"p95", row.P95MS}, {"p99", row.P99MS}} {
+		if got.ms < 95 || got.ms > 105 {
+			t.Fatalf("%s = %.0fms, want the one measured round trip at 100ms; a call still open has no round trip to fold in", got.name, got.ms)
+		}
+	}
+	if row.ToolErrors != 0 || row.ProtocolErrors != 0 {
+		t.Fatalf("a pending call is not an error: %+v", row)
+	}
+}
+
+// TestStatsHoldsOneStoreAtATime is the memory bound the rollup promises. Each
+// capture carries a megabyte of result bodies, so holding them all would be
+// hundreds of megabytes; folding one at a time keeps the peak at one capture
+// plus the counters.
+func TestStatsHoldsOneStoreAtATime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("writes a few hundred logs")
+	}
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	const logs = 300
+	body := strings.Repeat("x", 64<<10) // 64 KiB per result, 300 of them
+	for i := range logs {
+		writeCaptureWithBody(t, fmt.Sprintf("s%03d.jsonl", i), t0.Add(time.Duration(i)*time.Minute), body)
+	}
+
+	// Sampled during the walk, not after it. Once rollUp returns, every store it
+	// held is collectable whether it dropped them as it went or kept them all, so
+	// measuring afterwards cannot tell the two apart.
+	var peak uint64
+	prev := afterFold
+	afterFold = func() {
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		peak = max(peak, m.HeapAlloc)
+	}
+	t.Cleanup(func() { afterFold = prev })
+
+	runtime.GC()
+	var start runtime.MemStats
+	runtime.ReadMemStats(&start)
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if roll.Read != logs {
+		t.Fatalf("read %d of %d logs", roll.Read, logs)
+	}
+	row := rowFor(t, roll, "srv", "t")
+	if row.Calls != logs {
+		t.Fatalf("calls = %d, want %d", row.Calls, logs)
+	}
+	// Everything the walk reads is 300 * 64 KiB, near twenty megabytes. What may
+	// be live at once is one capture plus the counters and one duration per call.
+	// The bound is loose on purpose: it is here to catch holding every store, not
+	// to police allocation.
+	grew := int64(peak) - int64(start.HeapAlloc)
+	const bound = 8 << 20
+	if grew > bound {
+		t.Fatalf("the walk grew the heap by %d bytes across %d logs of %d bytes each; it is holding stores rather than folding them",
+			grew, logs, len(body))
+	}
+	if peak == 0 {
+		t.Fatal("nothing was sampled, so this test is measuring the wrong thing")
+	}
+}
+
+// writeCaptureWithBody writes one capture whose single tool result carries body,
+// so a directory of them is large on disk and in any store that keeps them.
+func writeCaptureWithBody(t *testing.T, name string, at time.Time, body string) {
+	t.Helper()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := strings.TrimSuffix(name, ".jsonl")
+	result, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": "1",
+		"result": map[string]any{"content": []any{map[string]any{"type": "text", "text": body}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envs := []proxy.Envelope{
+		{SessionID: id, ServerLabel: "srv", Seq: 1, TS: at, Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta},
+		{SessionID: id, ServerLabel: "srv", Seq: 2, TS: at.Add(time.Millisecond), Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`)},
+		{SessionID: id, ServerLabel: "srv", Seq: 3, TS: at.Add(11 * time.Millisecond), Direction: proxy.ServerToClient, Raw: result},
+	}
+	var buf bytes.Buffer
+	for _, e := range envs {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	path := filepath.Join(paths.SessionsDir(), name)
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, at, at); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestStatsIgnoresASupersededCallsGap covers the criterion the pending test only
+// half covered. A client reusing an id while the earlier request is in flight
+// makes the store stamp the older call's end with the newer request's timestamp,
+// so the call reads as done with a duration that is the gap between two
+// unrelated requests. Folding that in reported a ten-minute round trip on a
+// server whose slowest real answer was twenty milliseconds.
+func TestStatsIgnoresASupersededCallsGap(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envs := []proxy.Envelope{{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta}}
+	seq := uint64(1)
+	at := t0.Add(10 * time.Millisecond)
+	add := func(dir proxy.Direction, ts time.Time, raw string) {
+		seq++
+		envs = append(envs, proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: seq, TS: ts,
+			Direction: dir, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)})
+	}
+	for i := range 10 { // ten honest 20ms round trips
+		id := fmt.Sprintf("%d", i)
+		add(proxy.ClientToServer, at, fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":"echo"}}`, id))
+		at = at.Add(20 * time.Millisecond)
+		add(proxy.ServerToClient, at, fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"result":{"content":[]}}`, id))
+		at = at.Add(5 * time.Millisecond)
+	}
+	// An id reused ten minutes later while the first was still in flight.
+	add(proxy.ClientToServer, at, `{"jsonrpc":"2.0","id":"99","method":"tools/call","params":{"name":"echo"}}`)
+	at = at.Add(10 * time.Minute)
+	add(proxy.ClientToServer, at, `{"jsonrpc":"2.0","id":"99","method":"tools/call","params":{"name":"echo"}}`)
+	add(proxy.ServerToClient, at.Add(20*time.Millisecond), `{"jsonrpc":"2.0","id":"99","result":{"content":[]}}`)
+
+	var buf bytes.Buffer
+	for _, e := range envs {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(filepath.Join(paths.SessionsDir(), "s1.jsonl"), buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := rowFor(t, roll, "srv", "echo")
+	if row.Calls != 12 {
+		t.Fatalf("calls = %d, want 12; a superseded call was still made", row.Calls)
+	}
+	for _, got := range []struct {
+		name string
+		ms   float64
+	}{{"p50", row.P50MS}, {"p95", row.P95MS}, {"p99", row.P99MS}} {
+		if got.ms > 100 {
+			t.Fatalf("%s = %.0fms, want the measured round trips near 20ms; the gap between two reused ids is not a latency", got.name, got.ms)
+		}
+	}
+}
+
+// TestStatsShowsWhichServerARowIsAbout is the other half of keying on the
+// command and working directory. Two servers that derive one label printed as
+// two identical lines, which reads as one row printed twice, and marshalled to
+// two identical objects, so a consumer indexing on server and tool kept one and
+// dropped the other.
+func TestStatsShowsWhichServerARowIsAbout(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	// Identical in every figure, so only the identity can tell them apart.
+	writeCapture(t, "a.jsonl", "server.py", t0, "/proj/alpha", []string{"python3", "server.py", "alpha"},
+		[]string{"search"}, []call{{tool: "search", duration: 20 * time.Millisecond, answer: answerOK}})
+	writeCapture(t, "b.jsonl", "server.py", t0.Add(time.Hour), "/proj/beta", []string{"python3", "server.py", "beta"},
+		[]string{"search"}, []call{{tool: "search", duration: 20 * time.Millisecond, answer: answerOK}})
+
+	_, stdout, _ := executeStats(t, nil)
+	if !strings.Contains(stdout, "/proj/alpha") || !strings.Contains(stdout, "/proj/beta") {
+		t.Fatalf("the two servers are indistinguishable in the table:\n%s", stdout)
+	}
+	var rowLines []string
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.Contains(line, "server.py") && !strings.Contains(line, "SERVER") {
+			rowLines = append(rowLines, line)
+		}
+	}
+	if len(rowLines) != 2 {
+		t.Fatalf("rows = %d, want 2:\n%s", len(rowLines), stdout)
+	}
+	if rowLines[0] == rowLines[1] {
+		t.Fatalf("the two rows render identically:\n%s", stdout)
+	}
+
+	_, jsonOut, _ := executeStats(t, []string{"--format", "json"})
+	var parsed rollup
+	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Rows) != 2 {
+		t.Fatalf("json rows = %d, want 2", len(parsed.Rows))
+	}
+	if parsed.Rows[0].CWD == parsed.Rows[1].CWD || parsed.Rows[0].CWD == "" {
+		t.Fatalf("the json rows do not carry the identity they are keyed on: %+v", parsed.Rows)
+	}
+}
+
+// TestStatsDoesNotQualifyAnUnambiguousName keeps the ordinary table unchanged.
+// One server with two tools is not two servers.
+func TestStatsDoesNotQualifyAnUnambiguousName(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "a.jsonl", "srv", t0, "/srv", []string{"node", "s.js"}, []string{"a", "b"}, []call{
+		{tool: "a", duration: 10 * time.Millisecond, answer: answerOK},
+		{tool: "b", duration: 20 * time.Millisecond, answer: answerOK},
+	})
+	_, stdout, _ := executeStats(t, nil)
+	if strings.Contains(stdout, "(/srv)") {
+		t.Fatalf("a name that was never ambiguous was qualified anyway:\n%s", stdout)
+	}
+}
+
+// TestStatsKeepsTwoLabelsOfOneCommandApart is the case the label half of the key
+// exists for. One command deliberately run as prod and again as staging is two
+// deployments, and pooling them smears two distributions into one.
+func TestStatsKeepsTwoLabelsOfOneCommandApart(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "p.jsonl", "prod", t0, "/srv", []string{"node", "server.js"},
+		[]string{"search"}, []call{{tool: "search", duration: 20 * time.Millisecond, answer: answerOK}})
+	writeCapture(t, "s.jsonl", "staging", t0.Add(time.Hour), "/srv", []string{"node", "server.js"},
+		[]string{"search"}, []call{{tool: "search", duration: 500 * time.Millisecond, answer: answerOK}})
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roll.Rows) != 2 {
+		t.Fatalf("rows = %d, want one per label; pooling them describes neither", len(roll.Rows))
+	}
+	fast := rowFor(t, roll, "prod", "search")
+	slow := rowFor(t, roll, "staging", "search")
+	if fast.P50MS > 100 || slow.P50MS < 300 {
+		t.Fatalf("the two deployments are smeared: %.0fms and %.0fms", fast.P50MS, slow.P50MS)
+	}
+}
+
+// TestStatsFoldsEverySessionInALog covers a file holding more than one session,
+// which is what concatenating captures produces and what the issue's own
+// reproduction does. Folding the first and dropping the rest lost calls silently.
+func TestStatsFoldsEverySessionInALog(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	a := writeCapture(t, "a.jsonl", "alpha", t0, "/a", []string{"node", "a.js"},
+		[]string{"t"}, []call{{tool: "t", duration: 20 * time.Millisecond, answer: answerOK}})
+	b := writeCapture(t, "b.jsonl", "beta", t0.Add(time.Hour), "/b", []string{"node", "b.js"},
+		[]string{"t"}, []call{{tool: "t", duration: 30 * time.Millisecond, answer: answerOK}})
+	joined, err := os.ReadFile(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tail, err := os.ReadFile(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(paths.SessionsDir(), "joined.jsonl"), append(joined, tail...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{a, b} {
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roll.Rows) != 2 {
+		t.Fatalf("rows = %d, want both sessions of the joined log: %+v", len(roll.Rows), roll.Rows)
+	}
+	if got := rowFor(t, roll, "beta", "t"); got.Calls != 1 {
+		t.Fatalf("the second session of the log contributed nothing: %+v", got)
+	}
+}
+
+// TestStatsDefinitionCostComesFromTheNewestListing keeps the figure attached to
+// the session that described the tool rather than the newest one that happened
+// to call it.
+func TestStatsDefinitionCostComesFromTheNewestListing(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	// The older run advertises a long description, the newer one a short one, and
+	// only the older one calls the tool.
+	writeCapture(t, "a-old.jsonl", "srv", t0, "/srv", []string{"node", "s.js"},
+		[]string{"searchsearchsearchsearchsearchsearch"},
+		[]call{{tool: "searchsearchsearchsearchsearchsearch", duration: 20 * time.Millisecond, answer: answerOK}})
+	writeCapture(t, "b-new.jsonl", "srv", t0.Add(time.Hour), "/srv", []string{"node", "s.js"},
+		[]string{"searchsearchsearchsearchsearchsearch", "extra"}, nil)
+
+	roll, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := rowFor(t, roll, "srv", "searchsearchsearchsearchsearchsearch")
+	if row.DefinitionBytes == 0 {
+		t.Fatal("no definition cost at all")
+	}
+	// Both sessions describe the tool identically here, so the assertion that
+	// matters is that a session which never called it still supplied the figure.
+	if roll.Read != 2 {
+		t.Fatalf("read %d logs, want both", roll.Read)
+	}
+}
+
+// TestStatsRefusesABlankLabel keeps a filter that names nothing from quietly
+// meaning no filter, which is the one wrong answer a filter can give.
+func TestStatsRefusesABlankLabel(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "a.jsonl", "srv", t0, "/srv", []string{"node", "s.js"}, []string{"t"},
+		[]call{{tool: "t", duration: 10 * time.Millisecond, answer: answerOK}})
+
+	for _, value := range []string{" ", "", ",", " , "} {
+		code, stdout, stderr := executeStats(t, []string{"--label", value})
+		if code != 2 {
+			t.Fatalf("--label %q exited %d, want 2", value, code)
+		}
+		if stdout != "" || !strings.Contains(stderr, "--label") {
+			t.Fatalf("--label %q: stdout %q stderr %q", value, stdout, stderr)
+		}
+	}
+}
+
+// TestStatsCountsAnUnreadableLogUnderALabelFilter keeps the coverage line honest
+// whichever flags are set. A log dropped in the label pre-pass never reaches the
+// fold that would otherwise count it.
+func TestStatsCountsAnUnreadableLogUnderALabelFilter(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "good.jsonl", "srv", t0, "/srv", []string{"node", "s.js"}, []string{"t"},
+		[]call{{tool: "t", duration: 10 * time.Millisecond, answer: answerOK}})
+	if err := os.WriteFile(filepath.Join(paths.SessionsDir(), "junk.jsonl"), []byte("not json at all\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plain, err := rollUp(paths.SessionsDir(), time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filtered, err := rollUp(paths.SessionsDir(), time.Time{}, []string{"srv"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain.Skipped != 1 {
+		t.Fatalf("a plain run reported %d skipped, want 1", plain.Skipped)
+	}
+	if filtered.Skipped != plain.Skipped {
+		t.Fatalf("--label reported %d skipped where a plain run reported %d; the same directory cannot be described two ways",
+			filtered.Skipped, plain.Skipped)
+	}
+}
+
+// TestStatsReportsEmptyLogsApartFromDamagedOnes keeps two commands reading one
+// directory from describing it differently.
+func TestStatsReportsEmptyLogsApartFromDamagedOnes(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writeCapture(t, "good.jsonl", "srv", t0, "/srv", []string{"node", "s.js"}, []string{"t"},
+		[]call{{tool: "t", duration: 10 * time.Millisecond, answer: answerOK}})
+	dir := paths.SessionsDir()
+	if err := os.WriteFile(filepath.Join(dir, "empty.jsonl"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "junk.jsonl"), []byte("nope\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	statsRoll, err := rollUp(dir, time.Time{}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv, err := takeInventory(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statsRoll.Empty != inv.Empty || statsRoll.Skipped != inv.Skipped {
+		t.Fatalf("stats says empty=%d skipped=%d and inventory says empty=%d skipped=%d for one directory",
+			statsRoll.Empty, statsRoll.Skipped, inv.Empty, inv.Skipped)
+	}
+	_, stdout, _ := executeStats(t, nil)
+	if !strings.Contains(stdout, "1 empty log") || !strings.Contains(stdout, "1 log skipped") {
+		t.Fatalf("the coverage line does not name both:\n%s", stdout)
+	}
+}
+
+// TestStatsTableStaysAligned covers the two ways a value the log supplied could
+// push the fixed columns out of line: a duration too wide for its cell, and a
+// name with no bound on its length.
+func TestStatsTableStaysAligned(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	long := strings.Repeat("x", 5000)
+	writeCapture(t, "a.jsonl", "batch", t0, "/srv", []string{"node", "s.js"}, []string{"reindex", long}, []call{
+		{tool: "reindex", duration: 30 * time.Minute, answer: answerOK},
+		{tool: long, duration: 5 * time.Millisecond, answer: answerOK},
+	})
+
+	_, stdout, _ := executeStats(t, nil)
+	var widths []int
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if strings.Contains(line, "CALLS") || strings.Contains(line, "batch") {
+			widths = append(widths, len([]rune(line)))
+		}
+	}
+	if len(widths) != 3 {
+		t.Fatalf("want a header and two rows, got %d lines:\n%s", len(widths), stdout)
+	}
+	for _, w := range widths[1:] {
+		if w != widths[0] {
+			t.Fatalf("rows are %v cells wide against a %d-cell header:\n%s", widths, widths[0], stdout)
+		}
+	}
+	if widths[0] > 140 {
+		t.Fatalf("one tool name widened the whole table to %d cells:\n%s", widths[0], stdout[:400])
+	}
+	if !strings.Contains(stdout, "min") {
+		t.Fatalf("a half-hour call is not rendered in a unit that fits:\n%s", stdout)
+	}
+}
+
+// TestStatsOrderIsTotal keeps two runs over an unchanged directory producing one
+// answer even when rows tie on every visible column.
+func TestStatsOrderIsTotal(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	for i := range 8 {
+		writeCapture(t, fmt.Sprintf("s%d.jsonl", i), "server.py", t0.Add(time.Duration(i)*time.Hour),
+			fmt.Sprintf("/proj/%d", i), []string{"python3", "server.py", fmt.Sprintf("%d", i)},
+			[]string{"search"}, []call{{tool: "search", duration: 20 * time.Millisecond, answer: answerOK}})
+	}
+	_, first, _ := executeStats(t, nil)
+	for range 5 {
+		_, again, _ := executeStats(t, nil)
+		if again != first {
+			t.Fatalf("two runs over one directory disagree:\n--- first\n%s\n--- again\n%s", first, again)
+		}
+	}
+}
+
+// TestParseAgeRefusesAnAgeItCannotHold is the overflow that reached prune. A
+// duration is an int64 of nanoseconds, so a large day count wraps to a negative
+// one, and prune would then compute a cutoff in the future and delete every log
+// in the directory, which is the one thing --older-than exists to prevent.
+func TestParseAgeRefusesAnAgeItCannotHold(t *testing.T) {
+	for _, value := range []string{"200000d", "9223372036854775807d"} {
+		if _, err := parseAge(value, "--older-than"); err == nil {
+			t.Fatalf("parseAge(%q) was accepted", value)
+		}
+	}
+	// The boundary itself still works, and one day past it does not.
+	if _, err := parseAge(fmt.Sprintf("%dd", maxAgeDays), "--older-than"); err != nil {
+		t.Fatalf("the largest expressible age was refused: %v", err)
+	}
+	if _, err := parseAge(fmt.Sprintf("%dd", maxAgeDays+1), "--older-than"); err == nil {
+		t.Fatal("one day past the largest expressible age was accepted")
+	}
+
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	kept := writePruneLog(t, "keepme.jsonl", time.Hour)
+	code, _, stderr := executePrune(t, []string{"--older-than", "200000d", "--yes"}, "")
+	if code == 0 {
+		t.Fatal("prune accepted an age it cannot express")
+	}
+	if !strings.Contains(stderr, "--older-than") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("prune deleted a log that is an hour old under a 200000-day cutoff: %v", err)
+	}
+}

--- a/cmd/npmpack/main.go
+++ b/cmd/npmpack/main.go
@@ -1,0 +1,55 @@
+// Command npmpack builds the npm packages for one mcpsnoop release.
+//
+// It is a release tool, not part of the mcpsnoop command. It reads the archives
+// a release publishes, checks them against the checksums file published beside
+// them, and writes the seven package trees that carry those same bytes to npm.
+//
+//	npmpack -version 0.19.0 -dist dist -out dist/npm
+//
+// With -print-order it writes nothing and lists the directories in the order
+// they have to be published in, one per line, and with -print-dist-tag it prints
+// the npm tag the release belongs under, so the release workflow does not have
+// to know either of those itself.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kerlenton/mcpsnoop/internal/npmpack"
+)
+
+func main() {
+	var (
+		version = flag.String("version", "", "the release being packaged, with or without a leading v")
+		dist    = flag.String("dist", "dist", "directory holding the released archives and checksums.txt")
+		source  = flag.String("source", filepath.Join("npm", "mcpsnoop"), "directory holding the checked-in root package")
+		out     = flag.String("out", filepath.Join("dist", "npm"), "directory to write the package trees to")
+		order   = flag.Bool("print-order", false, "write nothing and list the publish order instead")
+		tag     = flag.Bool("print-dist-tag", false, "write nothing and print the npm dist-tag for -version instead")
+	)
+	flag.Parse()
+
+	if *order {
+		for _, dir := range npmpack.PublishOrder() {
+			fmt.Println(dir)
+		}
+		return
+	}
+	if *tag {
+		fmt.Println(npmpack.DistTag(*version))
+		return
+	}
+
+	if err := npmpack.Build(npmpack.Options{
+		Version:   *version,
+		DistDir:   *dist,
+		SourceDir: *source,
+		OutDir:    *out,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/TRY_IT.md
+++ b/docs/TRY_IT.md
@@ -11,8 +11,11 @@ own native file tools and you would see only the handshake.
 Put mcpsnoop on your PATH.
 
 ```bash
-go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@latest
+npm i -g mcpsnoop
 ```
+
+Or `go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@latest` if you have a
+Go toolchain, or `brew install mcpsnoop`.
 
 Wrap the server with mcpsnoop in your client. For Claude Code, one command does
 it.
@@ -20,6 +23,10 @@ it.
 ```bash
 claude mcp add everything -- mcpsnoop -- npx -y @modelcontextprotocol/server-everything
 ```
+
+Nothing here needs mcpsnoop installed globally. `npx mcpsnoop -- <server>` works
+the same way, which is worth knowing when you paste a wrap into someone else's
+setup instructions.
 
 For Claude Desktop, add the server to your `claude_desktop_config.json` as usual,
 then let mcpsnoop make the same wrap for you.

--- a/docs/TRY_IT.md
+++ b/docs/TRY_IT.md
@@ -58,7 +58,7 @@ well. When you're done, `mcpsnoop unwrap everything` puts it back.
    > run its long-running operation.
 
 4. Drill into a frame with `enter`, filter with `/`, inspect capabilities with
-   `c`, and replay a call with `r`.
+   `c`, replay a call with `r`, or edit its params and replay with `R`.
 
 Frames stream in as the client works. The quick calls come back OK, and the long
 one sends progress notifications and shows a visibly higher latency.

--- a/docs/TRY_IT.md
+++ b/docs/TRY_IT.md
@@ -59,7 +59,9 @@ well. When you're done, `mcpsnoop unwrap everything` puts it back.
 
 4. Drill into a frame with `enter`, filter with `/`, inspect capabilities with
    `c`, see what servers asked the user for with `l`, replay a call with `r`,
-   or edit its params and replay with `R`.
+   or edit its params and replay with `R`. A session captured over HTTP needs
+   `mcpsnoop open --replay-target <url>` before `r` will send anywhere, since a
+   capture records the endpoint stripped of anything credential-shaped.
 
 Frames stream in as the client works. The quick calls come back OK, and the long
 one sends progress notifications and shows a visibly higher latency.

--- a/docs/TRY_IT.md
+++ b/docs/TRY_IT.md
@@ -58,7 +58,8 @@ well. When you're done, `mcpsnoop unwrap everything` puts it back.
    > run its long-running operation.
 
 4. Drill into a frame with `enter`, filter with `/`, inspect capabilities with
-   `c`, replay a call with `r`, or edit its params and replay with `R`.
+   `c`, see what servers asked the user for with `l`, replay a call with `r`,
+   or edit its params and replay with `R`.
 
 Frames stream in as the client works. The quick calls come back OK, and the long
 one sends progress notifications and shows a visibly higher latency.

--- a/docs/youcom-integration.md
+++ b/docs/youcom-integration.md
@@ -1,0 +1,94 @@
+# You.com Search Integration for mcpsnoop
+
+This enhancement adds optional You.com web search capability to mcpsnoop, allowing developers to search the web directly from the MCP debugging TUI when investigating issues, errors, or tool behaviors.
+
+## Features
+
+- **Optional Integration**: Web search is completely optional - mcpsnoop works normally without it
+- **Multiple Access Methods**: Search via keyboard shortcut `w`, command `:search <query>`, or command `:web <query>`
+- **Environment Variable Support**: Set `YOUCOM_API_KEY` or use `--youcom-api-key` flag  
+- **Configuration File Support**: Add `youcom-api-key = "your-key"` to `.mcpsnoop.toml`
+- **Overlay Display**: Search results appear in a scrollable overlay, consistent with other mcpsnoop overlays
+- **Error Handling**: Graceful fallback when API key is missing or requests fail
+
+## Setup
+
+### Option 1: Environment Variable (Recommended)
+```bash
+export YOUCOM_API_KEY="your-you.com-api-key"
+mcpsnoop
+```
+
+### Option 2: Command Line Flag
+```bash
+mcpsnoop --youcom-api-key="your-you.com-api-key"
+```
+
+### Option 3: Configuration File
+Create or edit `.mcpsnoop.toml` in your working directory:
+```toml
+youcom-api-key = "your-you.com-api-key"
+```
+
+## Usage
+
+Once configured, you have several ways to search:
+
+### Keyboard Shortcut
+- Press `w` in the TUI to get a search prompt
+- Enter your query and press Enter
+- Results appear in an overlay
+
+### Command Line
+- Press `:` to open the command prompt
+- Type `search <your query>` or `web <your query>`
+- Press Enter to execute
+
+### Examples
+```
+:search MCP server timeout error
+:web "JSON-RPC 2.0" specification
+:search python mcp client library
+```
+
+## Integration Points
+
+The search feature is most useful when:
+
+- **Debugging Errors**: Search for specific error messages or status codes you see in traces
+- **Learning About Tools**: Research MCP server capabilities, tool specifications, or protocols  
+- **Troubleshooting**: Look up common issues with specific MCP implementations
+- **Documentation**: Find official specs, examples, or community discussions
+
+## Implementation Details
+
+- **API Endpoint**: Uses You.com search API for web search
+- **Result Limit**: Returns top 5 results for clean TUI display
+- **Timeout**: 10-second timeout on search requests
+- **Privacy**: Search queries are sent to You.com; no local data is shared
+- **Performance**: Asynchronous search doesn't block the TUI
+
+## Help Text
+
+The integration adds search to the help overlay (`?` key):
+
+```
+FRAME ACTIONS
+w          search the web (You.com integration)
+```
+
+And to the hints bar when viewing MCP sessions.
+
+## Error Handling
+
+- **No API Key**: Shows helpful message about configuration
+- **Network Issues**: Displays error message in TUI flash bar
+- **API Errors**: Shows HTTP error details for debugging
+- **Empty Results**: Indicates when no results are found
+
+## Security Notes
+
+- API keys are handled securely (not logged or traced)
+- Search queries are transmitted to You.com over HTTPS
+- No MCP session data is included in search requests
+- You.com's privacy policy governs search data handling

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/kerlenton/mcpsnoop/internal/jsonwire"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
@@ -42,6 +43,55 @@ type SessionExport struct {
 	Capabilities *CapabilitiesExport `json:"capabilities,omitempty"`
 	Calls        []CallExport        `json:"calls"`
 	Events       []EventExport       `json:"events"`
+	// Elicitations is the ledger of what servers asked the user for and what they
+	// answered. Absent from a session that saw none, so an ordinary export is
+	// unchanged.
+	Elicitations []ElicitationExport `json:"elicitations,omitempty"`
+}
+
+// ElicitationExport is one question a server put to the user through the client.
+//
+// It carries the shape of the question and never its content. The submitted
+// values stay in the log, so this document is safe to pass around whatever the
+// capture was redacted with, which matters most in url mode, where the
+// specification puts credentials on purpose.
+type ElicitationExport struct {
+	// CallIndex points into Calls, and is absent when the call it names is not in
+	// this document, which a bounded live store can produce by dropping the frame
+	// that opened it. A pointer rather than a sentinel: -1 is a number, and jq and
+	// Python both resolve calls[-1] to the last call rather than to nothing.
+	// CallID, Method and ToolName name the operation regardless.
+	CallIndex *int   `json:"call_index,omitempty"`
+	CallID    string `json:"call_id"`
+	Method    string `json:"method"`
+	ToolName  string `json:"tool_name,omitempty"`
+	// Key is the inputRequests entry the question was filed under, and what paired
+	// it with its answer.
+	Key string `json:"key"`
+	// Mode is form or url. A request naming neither is form, which is what the
+	// specification tells a client to assume.
+	Mode    string `json:"mode"`
+	Message string `json:"message,omitempty"`
+	// Fields are the form mode requestedSchema properties. A type is absent when
+	// the schema declared none, which includes a subschema redaction replaced with
+	// its placeholder.
+	Fields []ElicitFieldExport `json:"fields,omitempty"`
+	// URL is the url mode target in full, since the specification makes a client
+	// show it whole, and Host is the part it is told to highlight.
+	URL  string `json:"url,omitempty"`
+	Host string `json:"host,omitempty"`
+	// Action is what the user did. Absent means no retry ever answered, which
+	// Pending states outright so a consumer does not have to infer it.
+	Action     string     `json:"action,omitempty"`
+	Pending    bool       `json:"pending,omitempty"`
+	AskedAt    time.Time  `json:"asked_at"`
+	AnsweredAt *time.Time `json:"answered_at,omitempty"`
+	ElapsedMS  *float64   `json:"elapsed_ms,omitempty"`
+}
+
+type ElicitFieldExport struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
 }
 
 type ToolSummaryExport struct {
@@ -489,6 +539,29 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 		outEvents = append(outEvents, exportEvent(ev, callIndex))
 	}
 
+	elicitations := st.Elicitations(sessionID)
+	outElicitations := make([]ElicitationExport, 0, len(elicitations))
+	for _, e := range elicitations {
+		row := ElicitationExport{
+			CallID: e.CallID, Method: e.Method, ToolName: e.ToolName,
+			Key: e.Key, Mode: e.Mode, Message: e.Message,
+			URL: e.URL, Host: e.Host,
+			Action: e.Action, Pending: e.Pending(), AskedAt: e.Asked,
+		}
+		if idx, ok := callIndex[strconv.FormatUint(e.CallSeq, 10)]; ok {
+			row.CallIndex = &idx
+		}
+		for _, f := range e.Fields {
+			row.Fields = append(row.Fields, ElicitFieldExport{Name: f.Name, Type: f.Type})
+		}
+		if !e.Answered.IsZero() {
+			answered := e.Answered
+			elapsed := durationMS(e.Elapsed)
+			row.AnsweredAt, row.ElapsedMS = &answered, &elapsed
+		}
+		outElicitations = append(outElicitations, row)
+	}
+
 	out := SessionExport{
 		GeneratedAt: time.Now().UTC(),
 		Session: SessionSummary{
@@ -507,8 +580,9 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 			MissingFrames:    header.MissingFrames,
 			RetiredExchanges: header.RetiredExchanges,
 		},
-		Calls:  outCalls,
-		Events: outEvents,
+		Calls:        outCalls,
+		Events:       outEvents,
+		Elicitations: outElicitations,
 	}
 	if summary, ok := st.ToolSummary(sessionID); ok {
 		out.Summary = exportToolSummary(summary)
@@ -1037,6 +1111,31 @@ func writeText(w io.Writer, data SessionExport) error {
 	if err != nil {
 		return err
 	}
+	if len(data.Elicitations) > 0 {
+		if _, err := fmt.Fprintln(w, "elicitations:"); err != nil {
+			return err
+		}
+		for _, e := range data.Elicitations {
+			if _, err := fmt.Fprintf(w, "  %s\n", elicitationLine(e)); err != nil {
+				return err
+			}
+			// The message is what the server wrote for a human to read, so it is on
+			// every row rather than standing in for the fields when there are none.
+			if e.Message != "" {
+				if _, err := fmt.Fprintf(w, "    %s\n", oneLine(e.Message)); err != nil {
+					return err
+				}
+			}
+			if detail := elicitationDetail(e); detail != "" {
+				if _, err := fmt.Fprintf(w, "    %s\n", detail); err != nil {
+					return err
+				}
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
 	if data.Summary.Definitions != nil && len(data.Summary.Definitions.PerTool) > 0 {
 		hasFindings := false
 		for _, tool := range data.Summary.Definitions.PerTool {
@@ -1200,4 +1299,61 @@ func safeFileName(s string) string {
 
 func errPathNotFound(path string) error {
 	return fmt.Errorf("session log %q not found", path)
+}
+
+// elicitationLine is the headline of one ledger row: who asked, in which mode,
+// what the user did and how long they took.
+func elicitationLine(e ElicitationExport) string {
+	who := e.Method
+	if e.ToolName != "" {
+		who = e.Method + " " + e.ToolName
+	}
+	answer := "pending, no retry ever answered"
+	if !e.Pending {
+		answer = e.Action
+		if e.ElapsedMS != nil {
+			answer += fmt.Sprintf(" after %s", time.Duration(*e.ElapsedMS*float64(time.Millisecond)).Round(time.Millisecond))
+		}
+	}
+	return fmt.Sprintf("%s [%s] %s: %s", oneLine(who), oneLine(e.Mode), oneLine(e.Key), answer)
+}
+
+// elicitationDetail is what was asked for. A form names its fields and their
+// declared types, a url names the address whole and the host to look at, since
+// the specification tells a client to show one and highlight the other.
+func elicitationDetail(e ElicitationExport) string {
+	switch {
+	case e.URL != "":
+		out := oneLine(e.URL)
+		if e.Host != "" {
+			out += " (host " + oneLine(e.Host) + ")"
+		}
+		return out
+	case len(e.Fields) > 0:
+		parts := make([]string, 0, len(e.Fields))
+		for _, f := range e.Fields {
+			typ := f.Type
+			if typ == "" {
+				typ = "unknown"
+			}
+			parts = append(parts, oneLine(f.Name)+" "+oneLine(typ))
+		}
+		return strings.Join(parts, ", ")
+	default:
+		return ""
+	}
+}
+
+// oneLine keeps a value the wire supplied from ending the line it is printed on.
+//
+// A key, a message, a field name and a url are all written by the server, and a
+// newline in one of them closes the line it lands in, so the lines after it read
+// as more ledger rows in a document somebody diffs. Quoting rather than dropping
+// keeps the value recoverable, and matches what inventory and stats already do
+// with the values they print.
+func oneLine(s string) string {
+	if strings.ContainsFunc(s, unicode.IsControl) {
+		return strconv.Quote(s)
+	}
+	return s
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -47,6 +47,50 @@ type SessionExport struct {
 	// answered. Absent from a session that saw none, so an ordinary export is
 	// unchanged.
 	Elicitations []ElicitationExport `json:"elicitations,omitempty"`
+	// Interactions is one entry per logical operation, with the per-hop breakdown
+	// of a multi round-trip chain. A call with no retry is a one hop interaction,
+	// so this describes every operation uniformly.
+	Interactions []InteractionExport `json:"interactions,omitempty"`
+}
+
+// InteractionExport is one logical operation, however many requests it took.
+type InteractionExport struct {
+	CallIndex *int   `json:"call_index,omitempty"`
+	CallID    string `json:"call_id"`
+	Method    string `json:"method"`
+	ToolName  string `json:"tool_name,omitempty"`
+	State     string `json:"state"`
+	// RoundTrips is how many requests the operation took. ServerTimeMS is how long
+	// the server held it across all of them and ClientTurnaroundMS is the rest,
+	// mostly a person deciding. The two sum to DurationMS by construction.
+	RoundTrips         int       `json:"round_trips"`
+	ServerTimeMS       float64   `json:"server_time_ms"`
+	ClientTurnaroundMS float64   `json:"client_turnaround_ms"`
+	DurationMS         float64   `json:"duration_ms"`
+	StartedAt          time.Time `json:"started_at"`
+	// Hops is the per-hop breakdown. HopsComplete is false when the store no
+	// longer holds every frame, which a live one does to stay inside its budget,
+	// so a partial breakdown is never read as the whole operation.
+	Hops         []HopExport `json:"hops,omitempty"`
+	HopsComplete bool        `json:"hops_complete"`
+}
+
+// HopExport is one request and its answer inside an interaction.
+type HopExport struct {
+	RequestID  string     `json:"request_id"`
+	RequestAt  time.Time  `json:"request_at"`
+	ResponseAt *time.Time `json:"response_at,omitempty"`
+	// ServerTimeMS is this hop alone and ClientTurnaroundMS the wait before it,
+	// zero on the first since nothing preceded it.
+	ServerTimeMS       float64 `json:"server_time_ms"`
+	ClientTurnaroundMS float64 `json:"client_turnaround_ms"`
+	// Asked names what this hop's answer asked the client for, sorted, and is
+	// absent on a hop that finished the operation. AskedUnknown separates that from
+	// a hop whose answer is no longer readable, which a live store produces by
+	// releasing frame bodies.
+	Asked        []string `json:"asked,omitempty"`
+	AskedUnknown bool     `json:"asked_unknown,omitempty"`
+	Pending      bool     `json:"pending,omitempty"`
 }
 
 // ElicitationExport is one question a server put to the user through the client.
@@ -202,6 +246,13 @@ type CallExport struct {
 	CancelReason string          `json:"cancel_reason,omitempty"`
 	LateResult   bool            `json:"late_result,omitempty"`
 	DurationMS   *float64        `json:"duration_ms,omitempty"`
+	// RoundTrips is how many requests this operation took, and ServerTimeMS the
+	// share of DurationMS the server held it for. Under multi round-trip requests
+	// one call is several requests and the time a person spent answering sits
+	// inside the duration, so a record carrying only the total implies the server
+	// was busy for all of it. Absent on an operation with no measured hops.
+	RoundTrips   int             `json:"round_trips,omitempty"`
+	ServerTimeMS *float64        `json:"server_time_ms,omitempty"`
 	Params       json.RawMessage `json:"params,omitempty"`
 	Result       json.RawMessage `json:"result,omitempty"`
 	Error        *proxy.RPCError `json:"error,omitempty"`
@@ -539,6 +590,50 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 		outEvents = append(outEvents, exportEvent(ev, callIndex))
 	}
 
+	interactions := st.Interactions(sessionID)
+	// Indexed by the call each one belongs to, so a per-call record can say how
+	// many requests it took and how much of its duration was the server.
+	byCall := make(map[uint64]store.InteractionView, len(interactions))
+	outInteractions := make([]InteractionExport, 0, len(interactions))
+	for _, in := range interactions {
+		byCall[in.CallSeq] = in
+		row := InteractionExport{
+			CallID: in.CallID, Method: in.Method, ToolName: in.ToolName,
+			State:        in.State.String(),
+			RoundTrips:   in.RoundTrips,
+			ServerTimeMS: durationMS(in.ServerTime), ClientTurnaroundMS: durationMS(in.ClientTurnaround),
+			DurationMS: durationMS(in.Duration), StartedAt: in.Start,
+			HopsComplete: in.HopsComplete,
+		}
+		if idx, ok := callIndex[strconv.FormatUint(in.CallSeq, 10)]; ok {
+			row.CallIndex = &idx
+		}
+		for _, h := range in.Hops {
+			hop := HopExport{
+				RequestID: h.RequestID, RequestAt: h.RequestAt,
+				ServerTimeMS: durationMS(h.ServerTime), ClientTurnaroundMS: durationMS(h.ClientTurnaround),
+				Asked: h.Asked, AskedUnknown: h.AskedUnknown, Pending: h.Pending,
+			}
+			if !h.ResponseAt.IsZero() {
+				at := h.ResponseAt
+				hop.ResponseAt = &at
+			}
+			row.Hops = append(row.Hops, hop)
+		}
+		outInteractions = append(outInteractions, row)
+	}
+	for i := range outCalls {
+		in, ok := byCall[calls[i].RequestSeq]
+		if !ok {
+			continue
+		}
+		outCalls[i].RoundTrips = in.RoundTrips
+		if in.ServerTime > 0 || in.RoundTrips > 1 {
+			ms := durationMS(in.ServerTime)
+			outCalls[i].ServerTimeMS = &ms
+		}
+	}
+
 	elicitations := st.Elicitations(sessionID)
 	outElicitations := make([]ElicitationExport, 0, len(elicitations))
 	for _, e := range elicitations {
@@ -583,6 +678,7 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 		Calls:        outCalls,
 		Events:       outEvents,
 		Elicitations: outElicitations,
+		Interactions: outInteractions,
 	}
 	if summary, ok := st.ToolSummary(sessionID); ok {
 		out.Summary = exportToolSummary(summary)
@@ -1111,6 +1207,63 @@ func writeText(w io.Writer, data SessionExport) error {
 	if err != nil {
 		return err
 	}
+	if len(data.Interactions) > 0 {
+		chained := 0
+		for _, in := range data.Interactions {
+			if in.RoundTrips > 1 {
+				chained++
+			}
+		}
+		if chained > 0 {
+			if _, err := fmt.Fprintln(w, "interactions:"); err != nil {
+				return err
+			}
+			for _, in := range data.Interactions {
+				if in.RoundTrips <= 1 {
+					continue // an ordinary call is already a line above
+				}
+				who := in.Method
+				if in.ToolName != "" {
+					who = in.Method + " " + in.ToolName
+				}
+				if _, err := fmt.Fprintf(w, "  %s: %d round trips, %s total, %s server, %s client\n",
+					oneLine(who), in.RoundTrips,
+					msDuration(in.DurationMS), msDuration(in.ServerTimeMS), msDuration(in.ClientTurnaroundMS)); err != nil {
+					return err
+				}
+				for i, hop := range in.Hops {
+					asked := ""
+					if len(hop.Asked) > 0 {
+						asked = "  asked " + oneLine(strings.Join(hop.Asked, ", "))
+					}
+					state := ""
+					if hop.Pending {
+						state = "  (no answer)"
+					}
+					if _, err := fmt.Fprintf(w, "    hop %d id=%s  %s server", i+1, oneLine(hop.RequestID), msDuration(hop.ServerTimeMS)); err != nil {
+						return err
+					}
+					if hop.ClientTurnaroundMS > 0 {
+						if _, err := fmt.Fprintf(w, ", %s waiting on the client", msDuration(hop.ClientTurnaroundMS)); err != nil {
+							return err
+						}
+					}
+					if _, err := fmt.Fprintf(w, "%s%s\n", asked, state); err != nil {
+						return err
+					}
+				}
+				if !in.HopsComplete {
+					if _, err := fmt.Fprintf(w, "    (%d of %d hops still held, the rest were released to stay inside the memory budget)\n",
+						len(in.Hops), in.RoundTrips); err != nil {
+						return err
+					}
+				}
+			}
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+	}
 	if len(data.Elicitations) > 0 {
 		if _, err := fmt.Fprintln(w, "elicitations:"); err != nil {
 			return err
@@ -1356,4 +1509,10 @@ func oneLine(s string) string {
 		return strconv.Quote(s)
 	}
 	return s
+}
+
+// msDuration renders a millisecond figure the way the rest of the text export
+// renders a duration, so a reader is not comparing two spellings.
+func msDuration(ms float64) string {
+	return time.Duration(ms * float64(time.Millisecond)).Round(time.Millisecond).String()
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -71,13 +71,19 @@ type ToolCostExport struct {
 }
 
 type ToolStatsExport struct {
-	Name    string  `json:"name"`
-	Calls   int     `json:"calls"`
-	Errors  int     `json:"errors"`
-	Pending int     `json:"pending"`
-	P50MS   float64 `json:"p50_ms"`
-	P95MS   float64 `json:"p95_ms"`
-	P99MS   float64 `json:"p99_ms"`
+	Name  string `json:"name"`
+	Calls int    `json:"calls"`
+	// Errors is the total, and the two below split it. A tool answering isError
+	// is reporting a domain outcome, a server returning a JSON-RPC error is
+	// broken, and a consumer that gates on one of those should not have to guess
+	// which it is looking at. They always sum to Errors.
+	Errors         int     `json:"errors"`
+	ProtocolErrors int     `json:"protocol_errors"`
+	ToolErrors     int     `json:"tool_errors"`
+	Pending        int     `json:"pending"`
+	P50MS          float64 `json:"p50_ms"`
+	P95MS          float64 `json:"p95_ms"`
+	P99MS          float64 `json:"p99_ms"`
 	// ResultBytes and MaxResultBytes are the per-call half of the context cost.
 	ResultBytes    int64 `json:"result_bytes"`
 	MaxResultBytes int   `json:"max_result_bytes"`
@@ -92,8 +98,15 @@ type SlowCallExport struct {
 }
 
 type SessionSummary struct {
-	ID            string    `json:"id"`
-	Label         string    `json:"label"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	// Transport and Endpoint say what was captured. The label alone cannot: on
+	// HTTP it defaults to the target host, so two proxies pointed at two paths of
+	// one host export under the same name. Endpoint is the MCP endpoint with
+	// userinfo, query values and the fragment already removed, empty on stdio and
+	// on an HTTP log captured before mcpsnoop recorded it.
+	Transport     string    `json:"transport,omitempty"`
+	Endpoint      string    `json:"endpoint,omitempty"`
 	First         time.Time `json:"first"`
 	Last          time.Time `json:"last"`
 	Requests      int       `json:"requests"`
@@ -105,6 +118,10 @@ type SessionSummary struct {
 	// MissingFrames counts envelopes dropped upstream, inferred from Seq gaps.
 	// A non-zero value means the capture is incomplete.
 	MissingFrames uint64 `json:"missing_frames"`
+	// RetiredExchanges counts multi round-trip operations dropped at the parking
+	// cap while still open. A non-zero value means a retry for one of them could
+	// no longer be linked, so an operation may be reported here as two calls.
+	RetiredExchanges int `json:"retired_exchanges,omitempty"`
 }
 
 type CapabilitiesExport struct {
@@ -421,17 +438,20 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 	out := SessionExport{
 		GeneratedAt: time.Now().UTC(),
 		Session: SessionSummary{
-			ID:            header.ID,
-			Label:         header.Label,
-			First:         header.First,
-			Last:          header.Last,
-			Requests:      header.Requests,
-			Responses:     header.Responses,
-			Notifications: header.Notifications,
-			Errors:        header.Errors,
-			Pending:       header.Pending,
-			LateResults:   header.LateResults,
-			MissingFrames: header.MissingFrames,
+			ID:               header.ID,
+			Label:            header.Label,
+			Transport:        header.Transport,
+			Endpoint:         header.Endpoint,
+			First:            header.First,
+			Last:             header.Last,
+			Requests:         header.Requests,
+			Responses:        header.Responses,
+			Notifications:    header.Notifications,
+			Errors:           header.Errors,
+			Pending:          header.Pending,
+			LateResults:      header.LateResults,
+			MissingFrames:    header.MissingFrames,
+			RetiredExchanges: header.RetiredExchanges,
 		},
 		Calls:  outCalls,
 		Events: outEvents,
@@ -465,7 +485,8 @@ func exportToolSummary(summary store.SessionToolSummary) ToolSummaryExport {
 	}
 	for _, tool := range summary.Tools {
 		out.Tools = append(out.Tools, ToolStatsExport{
-			Name: tool.Name, Calls: tool.Calls, Errors: tool.Errors, Pending: tool.Pending,
+			Name: tool.Name, Calls: tool.Calls, Errors: tool.Errors,
+			ProtocolErrors: tool.ProtocolErrors, ToolErrors: tool.ToolErrors, Pending: tool.Pending,
 			P50MS: durationMS(tool.P50), P95MS: durationMS(tool.P95), P99MS: durationMS(tool.P99),
 			ResultBytes: tool.ResultBytes, MaxResultBytes: tool.MaxResultBytes,
 		})

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -281,6 +281,60 @@ func LoadFile(path string) (*store.Store, string, error) {
 	return Load(f, path)
 }
 
+// LoadFileTolerant is LoadFile for a caller reading many logs at once, where one
+// of them being live must not fail the run.
+//
+// The two differ on exactly one thing, a truncated final envelope. LoadFile
+// treats it as corruption and returns an error, which is right for check and
+// export: they were pointed at one capture, and a capture that ends mid-frame is
+// itself the finding. A shim appending to its log right now leaves that same
+// torn tail every time, so a command walking the sessions directory would fail
+// whenever anything was running, which is the moment its answer matters most.
+// This one stops at the tear and reports what came before it, the way
+// proxy.Decode does for the live path.
+//
+// Reach for LoadFile whenever the log is the subject. Reach for this one only
+// when it is one of many and the others still have to be read.
+func LoadFileTolerant(path string) (*store.Store, string, error) {
+	return loadFileTolerant(path, store.New())
+}
+
+// LoadFileTolerantBounded is LoadFileTolerant into a store that releases frame
+// bodies and old frames as it reads, so peak memory is the bound rather than the
+// size of the log.
+//
+// What survives eviction is session state, which the store folds in at ingest:
+// the negotiated capabilities, the tool inventory and whether its listing
+// completed, the counters, the drift verdict. What does not is the timeline and
+// the call list, since those are the frames themselves. Reach for this only when
+// the answer is one of the former. A caller that will read Timeline or Calls
+// wants LoadFileTolerant, or it will silently read a window instead of a log.
+func LoadFileTolerantBounded(path string, bodyBytes, frames int) (*store.Store, string, error) {
+	return loadFileTolerant(path, store.NewBounded(bodyBytes, frames))
+}
+
+func loadFileTolerant(path string, st *store.Store) (*store.Store, string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer f.Close()
+
+	var firstSession string
+	if err := proxy.Decode(f, func(env proxy.Envelope) {
+		if firstSession == "" {
+			firstSession = env.SessionID
+		}
+		st.Ingest(env)
+	}); err != nil {
+		return nil, "", fmt.Errorf("%s: invalid JSONL envelope: %w", path, err)
+	}
+	if firstSession == "" {
+		return nil, "", fmt.Errorf("%s: no envelopes found", path)
+	}
+	return st, firstSession, nil
+}
+
 // LoadFileLines is LoadFile plus the log line every envelope was decoded from,
 // for a caller that has to point a reader at one specific frame of the file.
 func LoadFileLines(path string) (*store.Store, string, FrameLines, error) {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1586,3 +1586,231 @@ func TestACleanExportOmitsRetiredExchanges(t *testing.T) {
 		t.Fatalf("a clean export carries the field:\n%s", buf.String())
 	}
 }
+
+// writeElicitCapture writes a capture holding one form exchange, one url
+// exchange and one nobody ever answered. The submitted value is deliberately
+// distinctive so a test can prove it never reaches the ledger.
+func writeElicitCapture(t *testing.T, path, submitted string) {
+	t.Helper()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq := uint64(0)
+	env := func(dir proxy.Direction, off time.Duration, raw string) proxy.Envelope {
+		seq++
+		return proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(off),
+			Direction: dir, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)}
+	}
+	seq++
+	envs := []proxy.Envelope{{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta}}
+	envs = append(envs,
+		env(proxy.ClientToServer, time.Second, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"create_account"}}`),
+		env(proxy.ServerToClient, 2*time.Second, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"profile":{"method":"elicitation/create","params":{"mode":"form","message":"contact information","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}}}}}}}}`),
+		env(proxy.ClientToServer, 11*time.Second, fmt.Sprintf(`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"create_account","inputResponses":{"profile":{"action":"accept","content":{"name":%q}}},"requestState":"st-1"}}`, submitted)),
+		env(proxy.ServerToClient, 12*time.Second, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`),
+		env(proxy.ClientToServer, 20*time.Second, `{"jsonrpc":"2.0","id":"3","method":"tools/call","params":{"name":"sync_calendar"}}`),
+		env(proxy.ServerToClient, 21*time.Second, `{"jsonrpc":"2.0","id":"3","result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"auth":{"method":"elicitation/create","params":{"mode":"url","url":"https://mcp.example.com/ui/set_api_key","message":"api key"}}}}}`),
+		env(proxy.ClientToServer, 50*time.Second, `{"jsonrpc":"2.0","id":"4","method":"tools/call","params":{"name":"sync_calendar","inputResponses":{"auth":{"action":"accept"}},"requestState":"st-2"}}`),
+		env(proxy.ServerToClient, 51*time.Second, `{"jsonrpc":"2.0","id":"4","result":{"content":[]}}`),
+		env(proxy.ClientToServer, 60*time.Second, `{"jsonrpc":"2.0","id":"5","method":"tools/call","params":{"name":"abandoned"}}`),
+		env(proxy.ServerToClient, 61*time.Second, `{"jsonrpc":"2.0","id":"5","result":{"resultType":"input_required","requestState":"st-3","inputRequests":{"q":{"method":"elicitation/create","params":{"message":"still there","requestedSchema":{"type":"object","properties":{"ok":{"type":"boolean"}}}}}}}}`),
+	)
+	var buf bytes.Buffer
+	for _, e := range envs {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestExportCarriesTheElicitationLedger covers the surfaces the ledger has to
+// reach, and the boundary it must not cross.
+func TestExportCarriesTheElicitationLedger(t *testing.T) {
+	const submitted = "hunter2-do-not-repeat-me"
+	path := filepath.Join(t.TempDir(), "elicit.jsonl")
+	writeElicitCapture(t, path, submitted)
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data.Elicitations) != 3 {
+		t.Fatalf("rows = %d, want 3: %+v", len(data.Elicitations), data.Elicitations)
+	}
+
+	byKey := map[string]ElicitationExport{}
+	for _, e := range data.Elicitations {
+		byKey[e.Key] = e
+	}
+	form := byKey["profile"]
+	if form.Mode != "form" || form.Action != "accept" || form.ElapsedMS == nil || *form.ElapsedMS != 9000 {
+		t.Fatalf("form row = %+v", form)
+	}
+	if len(form.Fields) != 1 || form.Fields[0].Name != "name" || form.Fields[0].Type != "string" {
+		t.Fatalf("form fields = %+v", form.Fields)
+	}
+	if form.CallIndex == nil || data.Calls[*form.CallIndex].ID != form.CallID {
+		t.Fatalf("call_index %v does not point at call %q", form.CallIndex, form.CallID)
+	}
+	url := byKey["auth"]
+	if url.URL != "https://mcp.example.com/ui/set_api_key" || url.Host != "mcp.example.com" {
+		t.Fatalf("url row = %+v", url)
+	}
+	pending := byKey["q"]
+	if !pending.Pending || pending.Action != "" || pending.AnsweredAt != nil || pending.ElapsedMS != nil {
+		t.Fatalf("pending row = %+v", pending)
+	}
+
+	for _, format := range []Format{FormatJSON, FormatText, FormatHTML} {
+		var buf bytes.Buffer
+		if err := Write(&buf, data, Options{Format: format}); err != nil {
+			t.Fatalf("%s: %v", format, err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "profile") || !strings.Contains(out, "mcp.example.com") {
+			t.Fatalf("%s does not carry the ledger:\n%s", format, out[:min(len(out), 1500)])
+		}
+	}
+
+	// The submitted value belongs to the capture and to nothing else. It rides the
+	// raw frames legitimately, so the assertion is about the ledger itself.
+	ledger, err := json.Marshal(data.Elicitations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(ledger), submitted) {
+		t.Fatalf("a submitted value reached the ledger: %s", ledger)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, submitted) && !strings.Contains(line, `"name"`) {
+			t.Fatalf("the text export repeats a submitted value outside the raw frame: %q", line)
+		}
+	}
+}
+
+// TestExportWithoutElicitationOmitsTheLedger keeps an ordinary export byte
+// identical to what it was.
+func TestExportWithoutElicitationOmitsTheLedger(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plain.jsonl")
+	writeEnv(t, path, proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: time.Now(),
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+	})
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data.Elicitations) != 0 {
+		t.Fatalf("elicitations = %+v, want none", data.Elicitations)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "elicitations") {
+		t.Fatalf("a session with none carries the key anyway:\n%s", buf.String())
+	}
+	if err := Write(&buf, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "elicitations:") {
+		t.Fatal("the text export gained an empty section")
+	}
+}
+
+// TestElicitationTextExportCannotForgeRows keeps a value the wire supplied from
+// ending the line it is printed on. A key, a message and a field name are all
+// written by the server, and a newline in one made the lines after it read as
+// more ledger rows.
+func TestElicitationTextExportCannotForgeRows(t *testing.T) {
+	data := SessionExport{Elicitations: []ElicitationExport{{
+		CallID: "1", Method: "tools/call", ToolName: "login",
+		Key:     "creds\nelicitations:",
+		Mode:    "form",
+		Message: "m\n  FORGED [form] x: accept after 99s",
+		Fields:  []ElicitFieldExport{{Name: "pass\nword", Type: "string"}},
+		Action:  "decline",
+	}}}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "\nFORGED") || strings.Contains(out, "\n  FORGED") {
+		t.Fatalf("a forged row reached the output:\n%s", out)
+	}
+	if !strings.Contains(out, `\n`) {
+		t.Fatalf("the control character was dropped rather than quoted, so it is not recoverable:\n%s", out)
+	}
+	// One question, one headline line, one message line, one detail line.
+	rows := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "tools/call login") {
+			rows++
+		}
+	}
+	if rows != 1 {
+		t.Fatalf("the ledger printed %d headline rows for one question:\n%s", rows, out)
+	}
+}
+
+// TestElicitationTextExportKeepsTheMessage covers the line the switch used to
+// swallow. The message is what the server wrote for a human, so it is on every
+// row rather than standing in for the fields when there are none.
+func TestElicitationTextExportKeepsTheMessage(t *testing.T) {
+	data := SessionExport{Elicitations: []ElicitationExport{{
+		CallID: "1", Method: "tools/call", Key: "k", Mode: "form",
+		Message: "Enter your admin password to continue",
+		Fields:  []ElicitFieldExport{{Name: "password", Type: "string"}},
+		Action:  "decline",
+	}}}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Enter your admin password to continue") {
+		t.Fatalf("the message a human was shown is missing:\n%s", out)
+	}
+	if !strings.Contains(out, "password string") {
+		t.Fatalf("the fields are missing:\n%s", out)
+	}
+}
+
+// TestElicitationCallIndexIsAbsentRatherThanNegative keeps a sentinel out of a
+// document other tools read. jq and Python both resolve calls[-1] to the last
+// call, so -1 would silently point a consumer at the wrong one.
+func TestElicitationCallIndexIsAbsentRatherThanNegative(t *testing.T) {
+	data := SessionExport{Elicitations: []ElicitationExport{{
+		CallID: "1", Method: "tools/call", Key: "k", Mode: "form", Pending: true,
+	}}}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "-1") {
+		t.Fatalf("a negative index reached the document:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), "call_index") {
+		t.Fatalf("an unresolved index is present rather than absent:\n%s", buf.String())
+	}
+}

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1814,3 +1814,291 @@ func TestElicitationCallIndexIsAbsentRatherThanNegative(t *testing.T) {
 		t.Fatalf("an unresolved index is present rather than absent:\n%s", buf.String())
 	}
 }
+
+// writeMRTRCapture writes the capture from issue #201: a three hop book_flight
+// chain where the server works 1.2s and the user takes 37s, plus one ordinary
+// call for contrast.
+func writeMRTRCapture(t *testing.T, path string) {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	var buf bytes.Buffer
+	for i, f := range frames {
+		b, err := json.Marshal(proxy.Envelope{SessionID: "demo", ServerLabel: "booking", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestExportCarriesTheInteractions covers the json shape and the two fields the
+// per-call record gains, so a consumer stops reading the whole duration as
+// server work.
+func TestExportCarriesTheInteractions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mrtr.jsonl")
+	writeMRTRCapture(t, path)
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data.Interactions) != 2 {
+		t.Fatalf("interactions = %d, want one per operation: %+v", len(data.Interactions), data.Interactions)
+	}
+	var book InteractionExport
+	for _, in := range data.Interactions {
+		if in.ToolName == "book_flight" {
+			book = in
+		}
+	}
+	if book.RoundTrips != 3 || book.ServerTimeMS != 1200 || book.ClientTurnaroundMS != 37000 || book.DurationMS != 38200 {
+		t.Fatalf("book_flight = %+v", book)
+	}
+	if book.ServerTimeMS+book.ClientTurnaroundMS != book.DurationMS {
+		t.Fatalf("the two shares do not add up: %+v", book)
+	}
+	if len(book.Hops) != 3 || !book.HopsComplete {
+		t.Fatalf("hops = %d complete=%v", len(book.Hops), book.HopsComplete)
+	}
+	if book.Hops[1].ClientTurnaroundMS != 12000 || book.Hops[1].ServerTimeMS != 300 {
+		t.Fatalf("hop 2 = %+v", book.Hops[1])
+	}
+	if book.CallIndex == nil || data.Calls[*book.CallIndex].ID != book.CallID {
+		t.Fatalf("call_index %v does not point at call %q", book.CallIndex, book.CallID)
+	}
+
+	for _, c := range data.Calls {
+		if c.ToolName != "book_flight" {
+			continue
+		}
+		if c.RoundTrips != 3 || c.ServerTimeMS == nil || *c.ServerTimeMS != 1200 {
+			t.Fatalf("the call record does not carry its share: %+v", c)
+		}
+		if c.DurationMS == nil || *c.DurationMS != 38200 {
+			t.Fatalf("the wall clock changed: %+v", c.DurationMS)
+		}
+	}
+
+	for _, format := range []Format{FormatJSON, FormatText, FormatHTML} {
+		var buf bytes.Buffer
+		if err := Write(&buf, data, Options{Format: format}); err != nil {
+			t.Fatalf("%s: %v", format, err)
+		}
+		if !strings.Contains(buf.String(), "book_flight") {
+			t.Fatalf("%s does not name the chained operation", format)
+		}
+	}
+	var text bytes.Buffer
+	if err := Write(&text, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text.String(), "3 round trips, 38.2s total, 1.2s server, 37s client") {
+		t.Fatalf("the text export does not split the total:\n%s", text.String())
+	}
+}
+
+// TestHARSplitsWaitFromBlocked stops a viewer drawing a server that was busy for
+// the whole interaction. HAR keeps wait for the server and blocked for time the
+// entry spent waiting on something else, which here is a person answering.
+func TestHARSplitsWaitFromBlocked(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mrtr.jsonl")
+	writeMRTRCapture(t, path)
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := WriteHAR(&buf, data); err != nil {
+		t.Fatal(err)
+	}
+	var har struct {
+		Log struct {
+			Entries []struct {
+				Time    float64 `json:"time"`
+				Request struct {
+					URL string `json:"url"`
+				} `json:"request"`
+				Timings struct {
+					Blocked float64 `json:"blocked"`
+					Send    float64 `json:"send"`
+					Wait    float64 `json:"wait"`
+					Receive float64 `json:"receive"`
+				} `json:"timings"`
+			} `json:"entries"`
+		} `json:"log"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &har); err != nil {
+		t.Fatalf("the HAR does not parse: %v", err)
+	}
+	if len(har.Log.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(har.Log.Entries))
+	}
+	for _, e := range har.Log.Entries {
+		sum := e.Timings.Send + e.Timings.Wait + e.Timings.Receive
+		if e.Timings.Blocked > 0 {
+			sum += e.Timings.Blocked
+		}
+		if sum != e.Time {
+			t.Fatalf("%s: timings sum to %v against a time of %v", e.Request.URL, sum, e.Time)
+		}
+		if !strings.Contains(e.Request.URL, "book_flight") {
+			continue
+		}
+		if e.Timings.Wait != 1200 {
+			t.Fatalf("wait = %v, want the 1.2s the server held it", e.Timings.Wait)
+		}
+		if e.Timings.Blocked != 37000 {
+			t.Fatalf("blocked = %v, want the 37s the client took", e.Timings.Blocked)
+		}
+	}
+}
+
+// TestAnOrdinaryExportGainsNoInteractionsSection keeps a capture with no chain
+// unchanged, since every operation there is already one line.
+func TestAnOrdinaryExportGainsNoInteractionsSection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plain.jsonl")
+	writeEnv(t, path, proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: time.Now(),
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"t"}}`)})
+	writeEnv(t, path, proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: time.Now().Add(time.Millisecond),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`)})
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "interactions:") {
+		t.Fatalf("a capture with no chain gained a section:\n%s", buf.String())
+	}
+	if len(data.Interactions) != 1 || data.Interactions[0].RoundTrips != 1 {
+		t.Fatalf("an ordinary call is still a one hop interaction: %+v", data.Interactions)
+	}
+}
+
+// TestHARNeverEmitsAnIllegalBlocked covers the entries HAR 1.2 constrains most.
+// An operation with no exportable duration used to report a negative blocked,
+// which is not the -1 sentinel and is the one negative the format forbids
+// elsewhere.
+func TestHARNeverEmitsAnIllegalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	full := filepath.Join(dir, "full.jsonl")
+	writeMRTRCapture(t, full)
+	// The same capture cut while the user is still answering, which MRTR makes an
+	// ordinary outcome rather than damage.
+	body, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.SplitN(string(body), "\n", 5)
+	abandoned := filepath.Join(dir, "abandoned.jsonl")
+	if err := os.WriteFile(abandoned, []byte(strings.Join(lines[:4], "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{full, abandoned} {
+		st, id, err := LoadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := Build(st, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		if err := WriteHAR(&buf, data); err != nil {
+			t.Fatal(err)
+		}
+		var har struct {
+			Log struct {
+				Entries []struct {
+					Time    float64 `json:"time"`
+					Timings struct {
+						Blocked float64 `json:"blocked"`
+						Send    float64 `json:"send"`
+						Wait    float64 `json:"wait"`
+						Receive float64 `json:"receive"`
+					} `json:"timings"`
+				} `json:"entries"`
+			} `json:"log"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &har); err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range har.Log.Entries {
+			tm := e.Timings
+			if tm.Blocked < 0 && tm.Blocked != -1 {
+				t.Fatalf("%s: blocked = %v, and the only negative HAR allows is -1", filepath.Base(path), tm.Blocked)
+			}
+			for name, v := range map[string]float64{"send": tm.Send, "wait": tm.Wait, "receive": tm.Receive} {
+				if v < 0 {
+					t.Fatalf("%s: %s = %v, which HAR never allows to be negative", filepath.Base(path), name, v)
+				}
+			}
+			if tm.Wait > e.Time {
+				t.Fatalf("%s: wait %v is larger than the entry time %v", filepath.Base(path), tm.Wait, e.Time)
+			}
+		}
+	}
+}
+
+// TestHopsCarryWhetherAnAnswerWasReadable keeps an unreadable hop apart from one
+// that asked for nothing, which is what a released frame body produces.
+func TestHopsCarryWhetherAnAnswerWasReadable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mrtr.jsonl")
+	writeMRTRCapture(t, path)
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	// A batch read holds every body, so nothing is unknown and the key stays out.
+	if strings.Contains(buf.String(), "asked_unknown") {
+		t.Fatalf("a complete capture reports an unreadable hop:\n%s", buf.String()[:600])
+	}
+	for _, in := range data.Interactions {
+		for _, h := range in.Hops {
+			if h.AskedUnknown {
+				t.Fatalf("hop %s is marked unreadable in a batch read", h.RequestID)
+			}
+		}
+	}
+}

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1419,3 +1419,170 @@ func TestNewlineCounterDropsOffsetsItHasWalkedPast(t *testing.T) {
 		t.Fatalf("offsets = %d after walking %d lines, want only what is still ahead", got, lines)
 	}
 }
+
+// TestExportSaysWhatItCaptured checks that an exported document identifies its
+// own server. Two proxies pointed at two paths of one host share a default label,
+// so without the endpoint the two exports are indistinguishable.
+func TestExportSaysWhatItCaptured(t *testing.T) {
+	base := time.Unix(0, 0).UTC()
+	meta, err := json.Marshal(proxy.SessionMeta{Target: "https://api.example.com/tenant-a/mcp?key=[stripped]"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "api.example.com", Seq: 1, TS: base, Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta})
+	st.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "api.example.com", Seq: 2, TS: base.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+	})
+
+	data, err := Build(st, "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := data.Session.Endpoint, "https://api.example.com/tenant-a/mcp?key=[stripped]"; got != want {
+		t.Fatalf("Session.Endpoint = %q, want %q", got, want)
+	}
+	if got := data.Session.Transport; got != proxy.TransportHTTP {
+		t.Fatalf("Session.Transport = %q, want %q", got, proxy.TransportHTTP)
+	}
+
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"endpoint": "https://api.example.com/tenant-a/mcp?key=[stripped]"`) {
+		t.Fatalf("the JSON export does not name the endpoint:\n%s", buf.String())
+	}
+}
+
+// TestAStdioExportOmitsTheEndpointKey pins the omitempty rather than assuming it.
+// A stdio export that carries an empty endpoint invites a reader to conclude the
+// endpoint was unknown rather than inapplicable.
+func TestAStdioExportOmitsTheEndpointKey(t *testing.T) {
+	base := time.Unix(0, 0).UTC()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "server.js"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: base, Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+	st.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: base.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`),
+	})
+
+	data, err := Build(st, "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), `"endpoint"`) {
+		t.Fatalf("a stdio export carries an endpoint key:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"transport": "stdio"`) {
+		t.Fatalf("the export does not name the transport:\n%s", buf.String())
+	}
+}
+
+// TestExportSplitsTheTwoKindsOfToolError keeps a consumer from having to guess
+// which failure a number describes. Both new fields always add up to errors.
+func TestExportSplitsTheTwoKindsOfToolError(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	seq := uint64(0)
+	call := func(tool, response string) {
+		seq++
+		id := fmt.Sprintf("%d", seq)
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ClientToServer, Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":%q}}`, id, tool))})
+		seq++
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ServerToClient, Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,%s}`, id, response))})
+	}
+	call("search", `"result":{"content":[],"isError":true}`)
+	call("search", `"error":{"code":-32603,"message":"boom"}`)
+
+	data, err := Build(st, "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data.Summary.Tools) != 1 {
+		t.Fatalf("tools = %d, want 1", len(data.Summary.Tools))
+	}
+	tool := data.Summary.Tools[0]
+	if tool.Errors != 2 || tool.ProtocolErrors != 1 || tool.ToolErrors != 1 {
+		t.Fatalf("errors = %d (%d protocol, %d tool), want 2 (1, 1)", tool.Errors, tool.ProtocolErrors, tool.ToolErrors)
+	}
+
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"protocol_errors": 1`, `"tool_errors": 1`, `"errors": 2`} {
+		if !strings.Contains(buf.String(), want) {
+			t.Fatalf("the export is missing %s:\n%s", want, buf.String())
+		}
+	}
+}
+
+// TestExportReportsRetiredExchanges keeps the parking cap from being silent in a
+// document somebody reads without the TUI. A capture where the cap fired may
+// report one operation as two calls, and the reader needs that stated.
+func TestExportReportsRetiredExchanges(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	var seq uint64
+	// Enough abandoned exchanges that the store's parking cap has to drop some.
+	for i := range 200 {
+		seq++
+		id := fmt.Sprintf("%d", i)
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ClientToServer, Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":"ask"}}`, id))})
+		seq++
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ServerToClient, Raw: json.RawMessage(fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%q,"result":{"resultType":"input_required","requestState":"s-%d","inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}}`, id, i))})
+	}
+
+	data, err := Build(st, "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data.Session.RetiredExchanges == 0 {
+		t.Fatal("200 abandoned exchanges and the export reports none retired")
+	}
+
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"retired_exchanges"`) {
+		t.Fatalf("the export does not name the retired exchanges:\n%s", buf.String()[:2000])
+	}
+}
+
+// TestACleanExportOmitsRetiredExchanges pins the omitempty. A zero on every
+// ordinary capture would train a reader to ignore the field.
+func TestACleanExportOmitsRetiredExchanges(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)})
+	data, err := Build(st, "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), `"retired_exchanges"`) {
+		t.Fatalf("a clean export carries the field:\n%s", buf.String())
+	}
+}

--- a/internal/exporter/har.go
+++ b/internal/exporter/har.go
@@ -77,6 +77,13 @@ type harResponse struct {
 type harCache struct{}
 
 type harTimings struct {
+	// Blocked is time the entry spent waiting on something other than the server.
+	// Under multi round-trip requests that is the client gathering an answer from
+	// a person, which is what the field is for, and putting it in wait drew a
+	// server that had been busy for the whole interaction. A one hop call reports
+	// zero, since nothing blocked it, and -1, which HAR 1.2 reserves for a timing
+	// that does not apply, is used only when there is no split to report at all.
+	Blocked float64 `json:"blocked"`
 	Send    float64 `json:"send"`
 	Wait    float64 `json:"wait"`
 	Receive float64 `json:"receive"`
@@ -128,11 +135,28 @@ func WriteHAR(w io.Writer, data SessionExport) error {
 	for _, call := range data.Calls {
 		status, statusText := harStatus(call.Status)
 
-		// Only the total round trip is known, so it all lands in wait, and time is
-		// the sum of the three. An unanswered call has no round trip, so it stays 0.
+		// time is the whole interaction, split between the server and whatever the
+		// client was doing between hops. An unanswered call has no round trip, so it
+		// stays 0.
 		var durationMS float64
 		if call.DurationMS != nil {
 			durationMS = *call.DurationMS
+		}
+		// wait is the server's share and blocked is the rest. Without the split a
+		// viewer drew a thirty-eight second server wait for an operation the server
+		// spent one second on, with the other thirty-seven belonging to a person
+		// answering an elicitation. An operation with no measured share reports -1,
+		// which is how HAR 1.2 spells a timing that does not apply.
+		// The split needs a duration large enough to contain the server's share. An
+		// operation with no exportable duration, which is every pending, superseded
+		// and cancelled one, has zero here, so subtracting a server share that is
+		// real produced a negative blocked. HAR 1.2 allows exactly one negative,
+		// the -1 that means the timing does not apply, so that is what such an entry
+		// reports.
+		wait, blocked := durationMS, float64(-1)
+		if call.ServerTimeMS != nil && *call.ServerTimeMS <= durationMS {
+			wait = *call.ServerTimeMS
+			blocked = durationMS - wait
 		}
 
 		request := harRequest{
@@ -166,7 +190,7 @@ func WriteHAR(w io.Writer, data SessionExport) error {
 				BodySize:    len(body),
 			},
 			Cache:   harCache{},
-			Timings: harTimings{Send: 0, Wait: durationMS, Receive: 0},
+			Timings: harTimings{Blocked: blocked, Send: 0, Wait: wait, Receive: 0},
 		})
 	}
 

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -94,6 +94,35 @@ document.getElementById("summary").innerHTML = [
   ["Late results", data.session.late_results],
   ["Protocol", data.capabilities?.protocol_version || ""]
 ].map(([k,v]) => "<div class=\"pill\">" + esc(k) + "<br><b>" + esc(v) + "</b></div>").join("");
+const chained = (data.interactions || []).filter(i => i.round_trips > 1);
+if (chained.length) {
+  const block = document.createElement("div");
+  block.innerHTML = "<div class=\"section-title\">Interactions</div>" +
+    "<div class=\"dim\">Operations that took more than one request. Under multi round-trip requests " +
+    "the time a person spent answering sits inside the total, so the server's own share is separated out.</div>";
+  const list = document.createElement("div");
+  list.className = "grid";
+  const ms = (v) => v >= 1000 ? (v / 1000).toFixed(1) + "s" : Math.round(v) + "ms";
+  for (const i of chained) {
+    const who = esc(i.tool_name ? i.method + " " + i.tool_name : i.method);
+    const hops = (i.hops || []).map((h, n) =>
+      "hop " + (n + 1) + " <span class=\"dim\">id " + esc(h.request_id) + "</span> " + ms(h.server_time_ms) + " server" +
+      (h.client_turnaround_ms > 0 ? ", " + ms(h.client_turnaround_ms) + " waiting on the client" : "") +
+      ((h.asked || []).length ? " <span class=\"dim\">asked " + esc(h.asked.join(", ")) + "</span>" : "") +
+      (h.pending ? " <span class=\"dim\">(no answer)</span>" : "")).join("<br>");
+    const card = document.createElement("div");
+    card.className = "pill";
+    card.innerHTML = who + " <span class=\"dim\">" + i.round_trips + " round trips</span><br>" +
+      "<b>" + ms(i.duration_ms) + "</b> total, " + ms(i.server_time_ms) + " server, " +
+      ms(i.client_turnaround_ms) + " client" +
+      (hops ? "<br>" + hops : "") +
+      (i.hops_complete === false ? "<br><span class=\"dim\">" + (i.hops || []).length + " of " +
+        i.round_trips + " hops still held</span>" : "");
+    list.appendChild(card);
+  }
+  block.appendChild(list);
+  document.getElementById("summary").after(block);
+}
 if ((data.elicitations || []).length) {
   const block = document.createElement("div");
   block.innerHTML = "<div class=\"section-title\">Elicitations</div>" +

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -23,6 +23,8 @@ h1 { margin:0 0 10px; font-size:22px; letter-spacing:0; }
 .toolbar { margin-top:14px; display:flex; gap:10px; align-items:center; }
 input { width:min(680px, 100%); padding:9px 11px; border:1px solid var(--line); border-radius:6px; background:var(--panel); color:var(--fg); font:inherit; }
 main { padding:18px 24px 40px; max-width:1180px; margin:0 auto; }
+.dim { color:var(--muted); }
+.elicit-url { word-break:break-all; overflow-wrap:anywhere; }
 .section-title { margin:22px 0 10px; color:var(--muted); font-size:12px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
 .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:10px; }
 .pill { padding:10px 12px; border:1px solid var(--line); border-radius:6px; background:var(--panel); }
@@ -92,6 +94,33 @@ document.getElementById("summary").innerHTML = [
   ["Late results", data.session.late_results],
   ["Protocol", data.capabilities?.protocol_version || ""]
 ].map(([k,v]) => "<div class=\"pill\">" + esc(k) + "<br><b>" + esc(v) + "</b></div>").join("");
+if ((data.elicitations || []).length) {
+  const block = document.createElement("div");
+  block.innerHTML = "<div class=\"section-title\">Elicitations</div>" +
+    "<div class=\"dim\">What each server asked the user for, and what they answered. " +
+    "The submitted values are not here by design; they stay in the capture.</div>";
+  const list = document.createElement("div");
+  list.className = "grid";
+  for (const e of data.elicitations) {
+    const who = esc(e.tool_name ? e.method + " " + e.tool_name : e.method);
+    const answer = e.pending ? "pending" : esc(e.action) +
+      (e.elapsed_ms != null ? " after " + Math.round(e.elapsed_ms) + "ms" : "");
+    let detail = "";
+    if (e.url) {
+      detail = "<span class=\"elicit-url\">" + esc(e.url) + "</span>" + (e.host ? " <b>" + esc(e.host) + "</b>" : "");
+    } else if ((e.fields || []).length) {
+      detail = e.fields.map(f => esc(f.name) + " <span class=\"dim\">" + esc(f.type || "unknown") + "</span>").join(", ");
+    }
+    const card = document.createElement("div");
+    card.className = "pill";
+    card.innerHTML = who + " <span class=\"dim\">[" + esc(e.mode) + "] " + esc(e.key) + "</span><br>" +
+      "<b>" + answer + "</b>" + (e.message ? "<br><span class=\"dim\">" + esc(e.message) + "</span>" : "") +
+      (detail ? "<br>" + detail : "");
+    list.appendChild(card);
+  }
+  block.appendChild(list);
+  document.getElementById("summary").after(block);
+}
 if (data.summary?.definitions?.per_tool?.length) {
   const withFindings = data.summary.definitions.per_tool.filter(t => (t.findings || []).length);
   if (withFindings.length) {

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -78,6 +78,7 @@ document.title = "mcpsnoop " + (data.session.label || data.session.id);
 document.getElementById("title").textContent = data.session.label || data.session.id;
 document.getElementById("meta").innerHTML = [
   "<span><b>" + esc(data.session.id) + "</b></span>",
+  data.session.endpoint ? "<span>" + esc(data.session.endpoint) + "</span>" : "",
   "<span>" + esc(fmtTime(data.session.first)) + "</span>",
   "<span>" + data.events.length + " frames</span>",
   "<span>" + data.calls.length + " calls</span>"

--- a/internal/exporter/html_test.go
+++ b/internal/exporter/html_test.go
@@ -193,3 +193,37 @@ func TestWriteHTMLStillEscapesMarkup(t *testing.T) {
 		t.Fatal("expected the markup to stay escaped in the HTML export")
 	}
 }
+
+// TestHTMLNamesTheEndpoint covers the human-facing half of a self-describing
+// capture. The heading falls back to the label, which on HTTP defaults to the
+// target host alone, so the endpoint is what tells two paths of one host apart.
+func TestHTMLNamesTheEndpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "http.jsonl")
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Target: "https://api.example.com/tenant-a/mcp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeEnv(t, path, proxy.Envelope{SessionID: "s1", ServerLabel: "api.example.com", Seq: 1, TS: t0, Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta})
+	writeEnv(t, path, proxy.Envelope{SessionID: "s1", ServerLabel: "api.example.com", Seq: 2, TS: t0.Add(time.Millisecond), Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)})
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, out, Options{Format: FormatHTML}); err != nil {
+		t.Fatal(err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, `"endpoint":"https://api.example.com/tenant-a/mcp"`) {
+		t.Fatal("the embedded data does not carry the endpoint")
+	}
+	if !strings.Contains(html, "data.session.endpoint") {
+		t.Fatal("the page never renders the endpoint it was given")
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -31,14 +31,17 @@ type Handler func(proxy.Envelope)
 
 // Hub collects envelopes from shims (socket) and past sessions (files).
 type Hub struct {
-	socketPath    string
-	sessionsDir   string
-	handler       Handler
-	backfillLimit int
-	onBackfill    func(BackfillReport)
+	socketPath         string
+	sessionsDir        string
+	handler            Handler
+	backfillLimit      int
+	onBackfill         func(BackfillReport)
+	onBackfillEnvelope Handler
+	onLive             Handler
 
-	mu   sync.Mutex
-	seen map[string]seenEntry // session id -> dedup high-water mark, with last touch
+	mu          sync.Mutex
+	seen        map[string]seenEntry // session id -> dedup high-water mark, with last touch
+	lastTouched time.Time
 }
 
 // seenEntry is one session's dedup high-water mark plus the last time it was
@@ -59,6 +62,14 @@ const seenCap = 10 * DefaultBackfillLimit
 type Options struct {
 	BackfillLimit int
 	OnBackfill    func(BackfillReport)
+	// OnBackfillEnvelope receives each unique envelope replayed from a session
+	// log. It is separate from OnLive so a consumer can prime state without
+	// treating historical traffic as new activity.
+	OnBackfillEnvelope Handler
+	// OnLive receives each unique envelope arriving from a connected shim. It is
+	// deliberately separate from handler so startup replay cannot look like new
+	// traffic to consumers such as live metrics.
+	OnLive Handler
 }
 
 // BackfillReport describes how much saved history was replayed at startup.
@@ -77,12 +88,14 @@ func New(socketPath, sessionsDir string, handler Handler) *Hub {
 // NewWithOptions creates a hub with explicit startup behavior.
 func NewWithOptions(socketPath, sessionsDir string, handler Handler, opts Options) *Hub {
 	return &Hub{
-		socketPath:    socketPath,
-		sessionsDir:   sessionsDir,
-		handler:       handler,
-		backfillLimit: opts.BackfillLimit,
-		onBackfill:    opts.OnBackfill,
-		seen:          make(map[string]seenEntry),
+		socketPath:         socketPath,
+		sessionsDir:        sessionsDir,
+		handler:            handler,
+		backfillLimit:      opts.BackfillLimit,
+		onBackfill:         opts.OnBackfill,
+		onBackfillEnvelope: opts.OnBackfillEnvelope,
+		onLive:             opts.OnLive,
+		seen:               make(map[string]seenEntry),
 	}
 }
 
@@ -107,10 +120,28 @@ func (h *Hub) Run(ctx context.Context) error {
 		h.onBackfill(report)
 	}
 
-	// Stop accepting when the context is done.
+	// Stop accepting when the context is done, and hang up on whoever is already
+	// connected.
+	//
+	// Closing the listener alone is not enough. handleConn parks in Decode until
+	// its shim disconnects, so wg.Wait below would sit there for as long as the
+	// shim lives, which is forever for a shim wrapping a long-running server. The
+	// TUI never noticed because it does not wait for Run to return, but a
+	// headless hub is a process somebody sends SIGTERM to and expects to stop.
+	var (
+		connMu sync.Mutex
+		conns  = map[net.Conn]struct{}{}
+		closed bool
+	)
 	go func() {
 		<-ctx.Done()
 		ln.Close()
+		connMu.Lock()
+		closed = true
+		for conn := range conns {
+			conn.Close()
+		}
+		connMu.Unlock()
 	}()
 
 	var wg sync.WaitGroup
@@ -122,9 +153,24 @@ func (h *Hub) Run(ctx context.Context) error {
 			}
 			continue
 		}
+		connMu.Lock()
+		if closed {
+			// Cancellation landed between Accept and here, so nobody is left to
+			// close this one.
+			connMu.Unlock()
+			conn.Close()
+			break
+		}
+		conns[conn] = struct{}{}
+		connMu.Unlock()
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() {
+				connMu.Lock()
+				delete(conns, conn)
+				connMu.Unlock()
+			}()
 			h.handleConn(conn)
 		}()
 	}
@@ -161,7 +207,7 @@ func (h *Hub) handleConn(conn net.Conn) {
 			}
 			return // malformed stream, drop the connection
 		}
-		h.emit(env)
+		h.emitLive(env)
 	}
 }
 
@@ -233,17 +279,37 @@ func (h *Hub) replayFile(path string) {
 // second would restart at Seq 1 and be discarded whole, which is why the shim
 // mints a unique id per run rather than trusting the PID to be unique.
 func (h *Hub) emit(env proxy.Envelope) {
+	h.emitFrom(env, false)
+}
+
+func (h *Hub) emitLive(env proxy.Envelope) {
+	h.emitFrom(env, true)
+}
+
+func (h *Hub) emitFrom(env proxy.Envelope, live bool) {
 	h.mu.Lock()
 	if env.Seq <= h.seen[env.SessionID].seq {
 		h.mu.Unlock()
 		return
 	}
-	h.seen[env.SessionID] = seenEntry{seq: env.Seq, touched: time.Now()}
+	touched := time.Now()
+	if !touched.After(h.lastTouched) {
+		touched = h.lastTouched.Add(time.Nanosecond)
+	}
+	h.lastTouched = touched
+	h.seen[env.SessionID] = seenEntry{seq: env.Seq, touched: touched}
 	if len(h.seen) > seenCap {
 		h.sweepSeen()
 	}
 	h.mu.Unlock()
 	h.handler(env)
+	if live {
+		if h.onLive != nil {
+			h.onLive(env)
+		}
+	} else if h.onBackfillEnvelope != nil {
+		h.onBackfillEnvelope(env)
+	}
 }
 
 // sweepSeen drops the least-recently-touched quarter of the dedup map, keeping it

--- a/internal/hub/hub_metrics_test.go
+++ b/internal/hub/hub_metrics_test.go
@@ -1,0 +1,114 @@
+package hub_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/metrics"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func writeMetricMetaLog(t *testing.T, dir, session string, command []string) {
+	t.Helper()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: command, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Create(filepath.Join(dir, session+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewEncoder(file).Encode(proxy.Envelope{
+		SessionID: session, ServerLabel: "same", Seq: 1, TS: time.Unix(1_700_000_000, 0),
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta,
+	}); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBackfillPrimesMetricsIdentityForLiveReconnect(t *testing.T) {
+	sessionsDir := t.TempDir()
+	writeMetricMetaLog(t, sessionsDir, "s0", []string{"node", "alpha.js"})
+	writeMetricMetaLog(t, sessionsDir, "s1", []string{"node", "beta.js"})
+
+	socket := filepath.Join(os.TempDir(), fmt.Sprintf("mcpsnoop-metrics-%d.sock", os.Getpid()))
+	defer os.Remove(socket)
+	probe, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Skipf("unix sockets unavailable: %v", err)
+	}
+	probe.Close()
+	os.Remove(socket)
+	collector := metrics.New()
+	h := hub.NewWithOptions(socket, sessionsDir, func(proxy.Envelope) {}, hub.Options{
+		BackfillLimit:      0,
+		OnBackfillEnvelope: collector.Prime,
+		OnLive:             collector.Observe,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hubErr := make(chan error, 1)
+	go func() { hubErr <- h.Run(ctx) }()
+	for range 50 {
+		if _, err := os.Stat(socket); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(socket); err != nil {
+		cancel()
+		t.Fatalf("hub socket did not start: %v", err)
+	}
+
+	sink := proxy.NewSocketSink(socket, 0)
+	defer sink.Close()
+	for i := range 2 {
+		session := fmt.Sprintf("s%d", i)
+		at := time.Unix(1_700_000_000+int64(i), 0)
+		sink.Emit(proxy.Envelope{
+			SessionID: session, ServerLabel: "same", Seq: 2, TS: at,
+			Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"echo"}}`),
+		})
+		sink.Emit(proxy.Envelope{
+			SessionID: session, ServerLabel: "same", Seq: 3, TS: at.Add(time.Millisecond),
+			Direction: proxy.ServerToClient, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`),
+		})
+	}
+
+	var out strings.Builder
+	for range 100 {
+		out.Reset()
+		if err := collector.Write(&out); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out.String(), `mcpsnoop_tool_calls_total{server="same"`) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if err := <-hubErr; err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(out.String(), `mcpsnoop_tool_calls_total{server="same"`); got != 2 {
+		t.Fatalf("backfill did not prime distinct reconnect identities, got %d series:\n%s", got, out.String())
+	}
+}

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -100,6 +100,40 @@ func TestHubBackfillLiveDedup(t *testing.T) {
 	}
 }
 
+func TestHubOnLiveExcludesBackfill(t *testing.T) {
+	sessionsDir := t.TempDir()
+	historyRequest := env("s1", 1, "tools/call")
+	historyRequest.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"echo"}}`)
+	historyResponse := env("s1", 2, "response")
+	historyResponse.Direction = proxy.ServerToClient
+	historyResponse.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`)
+	writeLog(t, sessionsDir, "s1", historyRequest, historyResponse)
+
+	var live []proxy.Envelope
+	backfilled := 0
+	h := NewWithOptions("", sessionsDir, func(proxy.Envelope) {}, Options{
+		OnBackfillEnvelope: func(proxy.Envelope) { backfilled++ },
+		OnLive: func(e proxy.Envelope) {
+			live = append(live, e)
+		},
+	})
+	h.backfill(context.Background())
+	liveRequest := env("s1", 3, "tools/call")
+	liveRequest.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"echo"}}`)
+	liveResponse := env("s1", 4, "response")
+	liveResponse.Direction = proxy.ServerToClient
+	liveResponse.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`)
+	h.emitLive(liveRequest)
+	h.emitLive(liveResponse)
+
+	if backfilled != 2 {
+		t.Fatalf("backfill callback count = %d, want 2", backfilled)
+	}
+	if len(live) != 2 || live[0].Seq != 3 || live[1].Seq != 4 {
+		t.Fatalf("live callback = %+v, want only seq 3 and 4", live)
+	}
+}
+
 // touchLog writes a session log and stamps it, so recency is set by the
 // modification time rather than by the file name.
 func touchLog(t *testing.T, dir, session string, modTime time.Time, envs ...proxy.Envelope) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,596 @@
+// Package metrics aggregates live tool calls and exposes Prometheus text
+// exposition without adding a runtime telemetry dependency.
+package metrics
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+const (
+	toolCallsMetric    = "mcpsnoop_tool_calls_total"
+	toolErrorsMetric   = "mcpsnoop_tool_errors_total"
+	toolDurationMetric = "mcpsnoop_tool_call_duration_seconds"
+	// transportErrorsMetric counts failures that never became a JSON-RPC message,
+	// so they can never be attributed to a tool.
+	//
+	// A gateway answering 502, or a 401 challenge, arrives as a status and a body
+	// that is not JSON-RPC. The store counts it against the session and attaches
+	// no call, deliberately, because nothing in the response says which request
+	// it answered: the connection id is the client's address, and a client may
+	// have several requests in flight on it. Without this series a gateway outage
+	// showed as a fall in mcpsnoop_tool_calls_total and a flat error line, which
+	// reads like traffic stopping rather than traffic failing, while a default
+	// `mcpsnoop check` run over the same capture failed.
+	transportErrorsMetric = "mcpsnoop_transport_errors_total"
+)
+
+// Buckets are the conventional Prometheus defaults, expressed in seconds.
+var buckets = [...]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+const (
+	// maxLabelBytes bounds a label value taken off the wire.
+	//
+	// A tool label is whatever a peer put in params.name, and Write repeats it on
+	// seventeen lines per series. A frame may carry 16 MiB of it, so one request
+	// measured out at a 71 MB scrape body from a 4 MiB name, which Prometheus
+	// drops whole against body_size_limit, taking every real series for that
+	// target with it. Truncating happens before the cardinality cap below, so a
+	// thousand long names that share a prefix fold into one series rather than
+	// each minting its own.
+	maxLabelBytes = 128
+	// labelElision marks a value this cut. It is longer than it needs to be so
+	// that a reader who meets it in a dashboard is not left guessing.
+	labelElision = "...(truncated by mcpsnoop)"
+	// maxSeries bounds distinct series, which is the other half of the same
+	// problem. Nothing on the wire constrains how many tool names a peer uses,
+	// and neither peer has to cooperate: a server writing unsolicited tools/call
+	// lines on its own stdout mints one series each. Past the cap, calls are
+	// still counted, under overflowTool, so the totals stay right and the flood
+	// is visible rather than fatal.
+	//
+	// Folding rather than evicting is deliberate. Evicting a series resets a
+	// counter, and Prometheus reads a counter that went backwards as a target
+	// restart, which fabricates traffic that never happened.
+	maxSeries = 2000
+	// overflowTool is where everything past the cap is counted. A real tool of
+	// this name would land in the same bucket, which is a collision folding
+	// makes possible and cannot avoid, since folding is lossy by construction.
+	overflowTool = "(over-series-cap)"
+)
+
+// clampLabel bounds one wire-supplied label value.
+func clampLabel(value string) string {
+	if len(value) <= maxLabelBytes {
+		return value
+	}
+	// Cut on a rune boundary so the result is still valid UTF-8, which the
+	// exposition format requires of a label value.
+	cut := maxLabelBytes - len(labelElision)
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return value[:cut] + labelElision
+}
+
+// Collector is the hub-side live metrics aggregate. Its small bounded store is
+// only a correlator: counters and histogram observations are retained here,
+// while frame bodies and the timeline are not.
+type Collector struct {
+	mu         sync.RWMutex
+	store      *store.Store
+	series     map[seriesKey]*toolSeries
+	transport  map[transportKey]uint64
+	operations map[operationKey]*operation
+	inflight   map[requestKey]operationKey
+	cancelled  []operationKey
+	// identities memoises the labels for a session. Deriving them walks every
+	// session the store has ever seen, allocating a full header for each, and it
+	// ran once per observed envelope while the write lock was held. A session's
+	// identity is fixed once its first frames land, so the walk only has to
+	// happen the first time one is seen.
+	identities map[string]serverIdentityLabels
+}
+
+type seriesKey struct {
+	server   string
+	serverID string
+	tool     string
+}
+
+// transportKey is a failure with no tool to hang it on. status is bounded by
+// what an HTTP status line can hold, so unlike a tool name it needs no cap.
+type transportKey struct {
+	server   string
+	serverID string
+	status   int
+}
+
+type operationKey struct {
+	session string
+	seq     uint64
+}
+
+type requestKey struct {
+	session string
+	// dir, for the reason store.callKey carries it. JSON-RPC scopes id
+	// uniqueness to the sender, so a server-initiated request may legally reuse
+	// the id of a tool call that is still in flight. Without it, the supersede
+	// branch in Observe treats that as a retry and finishes the live call, and
+	// its error and its latency are never recorded.
+	dir  proxy.Direction
+	id   string
+	conn string
+}
+
+type operation struct {
+	series    seriesKey
+	dir       proxy.Direction
+	id        string
+	conn      string
+	cancelled bool
+}
+
+type toolSeries struct {
+	calls  uint64
+	errors [2]uint64
+	bucket [len(buckets) + 1]uint64
+	sum    float64
+	count  uint64
+}
+
+// New creates an empty live collector. It deliberately uses a one-frame
+// bounded Store so Store remains the sole owner of JSON-RPC and MRTR
+// correlation without retaining a second copy of the live capture.
+func New() *Collector {
+	return &Collector{
+		store:      store.NewBounded(1, 1),
+		series:     make(map[seriesKey]*toolSeries),
+		transport:  make(map[transportKey]uint64),
+		operations: make(map[operationKey]*operation),
+		inflight:   make(map[requestKey]operationKey),
+		identities: make(map[string]serverIdentityLabels),
+	}
+}
+
+// Prime adds historical state without producing live metrics. It is used during
+// hub startup so a reconnect can retain the session identity and correlation
+// context learned from the log.
+func (c *Collector) Prime(env proxy.Envelope) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store.Ingest(env)
+}
+
+// Observe adds one deduplicated live envelope. It does no network or disk work.
+func (c *Collector) Observe(env proxy.Envelope) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	event := c.store.Ingest(env)
+	header, ok := sessionHeader(c.store, env.SessionID)
+	if !ok {
+		return
+	}
+	server, known := c.identities[env.SessionID]
+	if !known {
+		server = labelsForSession(c.store, env.SessionID, header)
+		c.identities[env.SessionID] = server
+	}
+
+	if event.Kind == store.EventTransport && event.Errored {
+		c.transport[transportKey{server: server.label, serverID: server.id, status: event.HTTPStatus}]++
+	}
+
+	if event.Kind == store.EventRequest && event.Call != nil && event.MRTRRoot == "" {
+		key := operationKey{session: env.SessionID, seq: event.Call.RequestSeq}
+		request := requestKey{session: env.SessionID, dir: env.Direction, id: event.Call.ID, conn: env.ConnID}
+		if previous, exists := c.inflight[request]; exists && previous != key {
+			if op := c.operations[previous]; op != nil {
+				c.finish(previous, op)
+			} else {
+				delete(c.inflight, request)
+			}
+		}
+		if event.Call.IsTool && event.Call.ToolName != "" {
+			if _, exists := c.operations[key]; !exists {
+				series := seriesKey{server: server.label, serverID: server.id, tool: clampLabel(event.Call.ToolName)}
+				c.operations[key] = &operation{series: series, dir: env.Direction, id: event.Call.ID, conn: env.ConnID}
+				c.inflight[request] = key
+				c.seriesFor(series).calls++
+			}
+		}
+	}
+
+	call := event.Call
+	if event.TaskCall != nil && event.TaskCall.IsTool {
+		call = event.TaskCall
+	}
+	if call == nil || !call.IsTool || call.ToolName == "" || !call.Done() {
+		return
+	}
+	key := operationKey{session: env.SessionID, seq: call.RequestSeq}
+	op := c.operations[key]
+	if op == nil {
+		return
+	}
+	if call.State == store.Cancelled && !call.LateResult {
+		if !op.cancelled {
+			op.cancelled = true
+			c.cancelled = append(c.cancelled, key)
+			c.trimCancelled()
+		}
+		return
+	}
+
+	series := c.seriesFor(op.series)
+	if call.Errored {
+		if call.ToolErr {
+			series.errors[0]++
+		} else {
+			series.errors[1]++
+		}
+	}
+	if call.State != store.Superseded && !(call.State == store.Cancelled && !call.LateResult) &&
+		!(call.TaskStatus == "cancelled" && !call.Errored) {
+		duration := call.Duration()
+		if duration >= 0 {
+			seconds := duration.Seconds()
+			series.sum += seconds
+			series.count++
+			for i, bound := range buckets {
+				if seconds <= bound {
+					series.bucket[i]++
+				}
+			}
+			series.bucket[len(buckets)]++
+		}
+	}
+	c.finish(key, op)
+}
+
+func (c *Collector) finish(key operationKey, op *operation) {
+	delete(c.operations, key)
+	request := requestKey{session: key.session, dir: op.dir, id: op.id, conn: op.conn}
+	if current, ok := c.inflight[request]; ok && current == key {
+		delete(c.inflight, request)
+	}
+}
+
+func (c *Collector) trimCancelled() {
+	const maxCancelled = 1024
+	if len(c.cancelled) <= maxCancelled {
+		return
+	}
+	key := c.cancelled[0]
+	if op := c.operations[key]; op != nil {
+		c.finish(key, op)
+	}
+	c.cancelled = c.cancelled[1:]
+}
+
+// seriesFor returns the series for key, creating it while there is room. Past
+// the cap the call is counted against overflowTool for the same server, so a
+// flood of names costs one series rather than one each and the totals still add
+// up. Caller holds c.mu for writing.
+func (c *Collector) seriesFor(key seriesKey) *toolSeries {
+	if series := c.series[key]; series != nil {
+		return series
+	}
+	if len(c.series) >= maxSeries {
+		overflow := seriesKey{server: key.server, serverID: key.serverID, tool: overflowTool}
+		if series := c.series[overflow]; series != nil {
+			return series
+		}
+		// The overflow series itself must always fit, or the cap would silently
+		// discard the calls it is meant to keep counting.
+		series := &toolSeries{}
+		c.series[overflow] = series
+		return series
+	}
+	series := &toolSeries{}
+	c.series[key] = series
+	return series
+}
+
+type serverIdentityLabels struct {
+	label string
+	id    string
+}
+
+func sessionHeader(st *store.Store, sessionID string) (store.SessionHeader, bool) {
+	for _, header := range st.Sessions() {
+		if header.ID == sessionID {
+			return header, true
+		}
+	}
+	return store.SessionHeader{}, false
+}
+
+// labelsForSession follows the identity split used by inventory and stats. The
+// friendly label is paired with a stable fingerprint of the recorded command
+// and cwd (stdio), endpoint (HTTP), or label/transport fallback. Raw commands,
+// paths, endpoints, and session ids never become Prometheus label values.
+func labelsForSession(st *store.Store, sessionID string, header store.SessionHeader) serverIdentityLabels {
+	command, cwd, _ := st.Command(sessionID)
+	const sep = "\x00"
+	var identity string
+	switch {
+	case len(command) > 0:
+		identity = "stdio" + sep + cwd + sep + strings.Join(command, sep)
+	case header.Endpoint != "":
+		identity = "http" + sep + header.Endpoint
+	default:
+		identity = "label" + sep + header.Transport + sep + header.Label
+	}
+	identity += sep + header.Label
+	digest := sha256.Sum256([]byte(identity))
+	label := header.Label
+	if label == "" {
+		label = "(unlabelled)"
+	}
+	return serverIdentityLabels{label: label, id: hex.EncodeToString(digest[:8])}
+}
+
+// Write renders the current aggregate in deterministic Prometheus text format.
+func (c *Collector) Write(w io.Writer) error {
+	c.mu.RLock()
+	seriesByKey := make(map[seriesKey]toolSeries, len(c.series))
+	keys := make([]seriesKey, 0, len(c.series))
+	for key, series := range c.series {
+		seriesByKey[key] = *series
+		keys = append(keys, key)
+	}
+	transportByKey := make(map[transportKey]uint64, len(c.transport))
+	transportKeys := make([]transportKey, 0, len(c.transport))
+	for key, count := range c.transport {
+		transportByKey[key] = count
+		transportKeys = append(transportKeys, key)
+	}
+	c.mu.RUnlock()
+	slices.SortFunc(transportKeys, func(a, b transportKey) int {
+		if c := strings.Compare(a.server, b.server); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.serverID, b.serverID); c != 0 {
+			return c
+		}
+		return a.status - b.status
+	})
+	slices.SortFunc(keys, func(a, b seriesKey) int {
+		if c := strings.Compare(a.server, b.server); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.serverID, b.serverID); c != 0 {
+			return c
+		}
+		return strings.Compare(a.tool, b.tool)
+	})
+
+	if _, err := fmt.Fprintln(w, "# HELP "+toolCallsMetric+" Total number of observed MCP tool calls."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+toolCallsMetric+" counter"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# HELP "+toolErrorsMetric+" Total number of observed MCP tool call errors by error type."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+toolErrorsMetric+" counter"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# HELP "+toolDurationMetric+" Request-to-response duration of observed MCP tool calls in seconds."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+toolDurationMetric+" histogram"); err != nil {
+		return err
+	}
+	for _, key := range keys {
+		series := seriesByKey[key]
+		labels := baseLabels(key)
+		if _, err := fmt.Fprintf(w, "%s{%s} %d\n", toolCallsMetric, labels, series.calls); err != nil {
+			return err
+		}
+		for i, kind := range []string{"tool", "protocol"} {
+			if _, err := fmt.Fprintf(w, "%s{%s,error_type=\"%s\"} %d\n", toolErrorsMetric, labels, kind, series.errors[i]); err != nil {
+				return err
+			}
+		}
+		for i, bound := range buckets {
+			if _, err := fmt.Fprintf(w, "%s_bucket{%s,le=\"%s\"} %d\n", toolDurationMetric, labels, formatFloat(bound), series.bucket[i]); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "%s_bucket{%s,le=\"+Inf\"} %d\n", toolDurationMetric, labels, series.bucket[len(buckets)]); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "%s_sum{%s} %s\n", toolDurationMetric, labels, formatFloat(series.sum)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "%s_count{%s} %d\n", toolDurationMetric, labels, series.count); err != nil {
+			return err
+		}
+	}
+
+	// Emitted whether or not anything failed, so a dashboard that graphs it does
+	// not go blank on a healthy hub and leave the reader wondering which of the
+	// two it is looking at.
+	if _, err := fmt.Fprintln(w, "# HELP "+transportErrorsMetric+" Total number of observed transport failures that carried no JSON-RPC message."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+transportErrorsMetric+" counter"); err != nil {
+		return err
+	}
+	for _, key := range transportKeys {
+		if _, err := fmt.Fprintf(w, "%s{server=\"%s\",server_id=\"%s\",status=\"%d\"} %d\n",
+			transportErrorsMetric, escapeLabel(key.server), escapeLabel(key.serverID), key.status,
+			transportByKey[key]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func baseLabels(key seriesKey) string {
+	return `server="` + escapeLabel(key.server) + `",server_id="` + escapeLabel(key.serverID) + `",tool="` + escapeLabel(key.tool) + `"`
+}
+
+func escapeLabel(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`).Replace(value)
+}
+
+func formatFloat(value float64) string {
+	return fmt.Sprintf("%g", value)
+}
+
+// ServeHTTP serves only /metrics. A separate server/listener is used by the
+// CLI, so this handler can never shadow an MCP proxy path.
+func (c *Collector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/metrics" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	if r.Method == http.MethodHead {
+		return
+	}
+	if err := c.Write(w); err != nil {
+		return
+	}
+}
+
+// Server is the opt-in Prometheus HTTP listener.
+type Server struct {
+	listener net.Listener
+	server   *http.Server
+}
+
+// NewServer binds an independent TCP listener for metrics.
+func NewServer(addr string, collector *Collector) (*Server, error) {
+	if collector == nil {
+		return nil, errors.New("metrics: nil collector")
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		listener: listener,
+		server: &http.Server{
+			Handler:           collector,
+			ReadHeaderTimeout: 5 * time.Second,
+		},
+	}, nil
+}
+
+// Addr returns the bound address, useful when the listener requested port 0.
+func (s *Server) Addr() net.Addr { return s.listener.Addr() }
+
+// Serve runs the metrics listener until it is closed.
+func (s *Server) Serve() error {
+	err := s.server.Serve(s.listener)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// Close stops the metrics listener and waits for in-flight requests to finish.
+func (s *Server) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if err := s.server.Shutdown(ctx); err != nil {
+		// Shutdown leaves active handlers alone after the deadline. Close the
+		// connections so a blocked scrape cannot hold up hub shutdown forever.
+		_ = s.server.Close()
+		return err
+	}
+	return nil
+}
+
+// RunHeadless runs the hub and metrics listener without starting a TUI. History
+// primes the collector's correlation store, but only envelopes received after
+// backfill are observed as live metrics.
+func RunHeadless(ctx context.Context, socketPath, sessionsDir string, historyLimit int, listen string) error {
+	if listen == "" {
+		return errors.New("metrics: empty listen address")
+	}
+	collector := New()
+	server, err := NewServer(listen, collector)
+	if err != nil {
+		return err
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve() }()
+
+	h := hub.NewWithOptions(socketPath, sessionsDir, func(proxy.Envelope) {}, hub.Options{
+		BackfillLimit:      historyLimit,
+		OnBackfillEnvelope: collector.Prime,
+		OnLive:             collector.Observe,
+	})
+	hubErr := make(chan error, 1)
+	go func() { hubErr <- h.Run(runCtx) }()
+
+	select {
+	case err := <-hubErr:
+		closeErr := server.Close()
+		metricsErr := <-serveErr
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
+		}
+		return metricsErr
+	case err := <-serveErr:
+		cancel()
+		<-hubErr
+		if err != nil {
+			return fmt.Errorf("metrics listener stopped: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		cancel()
+		// The hub first, and its error before the listener's. A scrape in flight
+		// keeps Shutdown polling to its deadline, so on an ordinary SIGTERM
+		// during a scrape the listener reports a timeout it already recovered
+		// from by closing the connections, and reporting that would exit 1 on a
+		// clean stop and hide whatever the hub had to say.
+		hubErr := <-hubErr
+		closeErr := server.Close()
+		metricsErr := <-serveErr
+		if hubErr != nil {
+			return hubErr
+		}
+		if metricsErr != nil {
+			return metricsErr
+		}
+		if closeErr != nil && !errors.Is(closeErr, context.DeadlineExceeded) {
+			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
+		}
+		return nil
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,552 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func envelope(session, label string, seq uint64, at time.Time, direction proxy.Direction, raw string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID: session, ServerLabel: label, Seq: seq, TS: at,
+		Direction: direction, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw),
+	}
+}
+
+func toolRequest(session, label string, seq uint64, at time.Time, id, tool string) proxy.Envelope {
+	return envelope(session, label, seq, at, proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":`+strconv.Quote(id)+`,"method":"tools/call","params":{"name":`+strconv.Quote(tool)+`}}`)
+}
+
+func toolResponse(session, label string, seq uint64, at time.Time, id, answer string) proxy.Envelope {
+	return envelope(session, label, seq, at, proxy.ServerToClient,
+		`{"jsonrpc":"2.0","id":`+strconv.Quote(id)+`,`+answer+`}`)
+}
+
+func toolRequestOnConn(session, label string, seq uint64, at time.Time, conn, id, tool string) proxy.Envelope {
+	e := toolRequest(session, label, seq, at, id, tool)
+	e.Transport = proxy.TransportHTTP
+	e.ConnID = conn
+	return e
+}
+
+func toolResponseOnConn(session, label string, seq uint64, at time.Time, conn, id, answer string) proxy.Envelope {
+	e := toolResponse(session, label, seq, at, id, answer)
+	e.Transport = proxy.TransportHTTP
+	e.ConnID = conn
+	return e
+}
+
+func TestCollectorWritesCountersHistogramAndEscapedLabels(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	label := "srv\"\\\n"
+	tool := "echo\"\\\n"
+	c.Observe(toolRequest("s1", label, 1, start, "1", tool))
+	c.Observe(toolResponse("s1", label, 2, start.Add(20*time.Millisecond), "1", `"result":{"content":[]}`))
+	c.Observe(toolRequest("s1", label, 3, start.Add(time.Second), "2", tool))
+	c.Observe(toolResponse("s1", label, 4, start.Add(2*time.Second), "2", `"result":{"content":[],"isError":true}`))
+	c.Observe(toolRequest("s1", label, 5, start.Add(3*time.Second), "3", tool))
+	c.Observe(toolResponse("s1", label, 6, start.Add(4*time.Second), "3", `"error":{"code":-32603,"message":"boom"}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `# TYPE mcpsnoop_tool_calls_total counter`) {
+		t.Fatal("missing calls counter type")
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_calls_total{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n"} 3`) {
+		t.Fatalf("escaped counter labels or value missing:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_errors_total{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n",error_type="tool"} 1`) {
+		t.Fatalf("tool error counter missing:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_errors_total{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n",error_type="protocol"} 1`) {
+		t.Fatalf("protocol error counter missing:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_call_duration_seconds_bucket{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n",le="0.025"} 1`) {
+		t.Fatalf("cumulative 25ms bucket missing:\n%s", got)
+	}
+	if !strings.Contains(got, `",tool="echo\"\\\n",le="+Inf"} 3`) || !strings.Contains(got, `mcpsnoop_tool_call_duration_seconds_count{server="srv\"\\\n",server_id="`) {
+		t.Fatalf("histogram count missing:\n%s", got)
+	}
+}
+
+func TestCollectorCountsMRTRAsOneCallAndOneObservation(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "1", "confirm"))
+	c.Observe(envelope("s1", "server", 2, start.Add(time.Second), proxy.ServerToClient,
+		`{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"state","inputRequests":{"answer":{"method":"elicitation/create"}}}}`))
+	c.Observe(envelope("s1", "server", 3, start.Add(5*time.Second), proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"confirm","requestState":"state","inputResponses":{"answer":{"action":"accept"}}}}`))
+	c.Observe(toolResponse("s1", "server", 4, start.Add(6*time.Second), "2", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_calls_total{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="confirm"} 1`) {
+		t.Fatalf("MRTR operation counted more than once:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="confirm"} 1`) {
+		t.Fatalf("MRTR duration observed more than once:\n%s", out.String())
+	}
+}
+
+func TestCollectorSkipsCancelledTaskLatency(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "1", "slow"))
+	c.Observe(toolResponse("s1", "server", 2, start.Add(time.Millisecond), "1", `"result":{"resultType":"task","taskId":"task-1","status":"working"}`))
+	c.Observe(envelope("s1", "server", 3, start.Add(time.Second), proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":"2","method":"tasks/get","params":{"taskId":"task-1"}}`))
+	c.Observe(envelope("s1", "server", 4, start.Add(5*time.Second), proxy.ServerToClient,
+		`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"task-1","status":"cancelled"}}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `",tool="slow"} 1`) {
+		t.Fatalf("cancelled task call missing:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="slow"} 0`) {
+		t.Fatalf("cancelled task must not create a latency observation:\n%s", out.String())
+	}
+}
+
+func TestCollectorDropsSupersededOperationState(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "same", "echo"))
+	c.Observe(toolRequest("s1", "server", 2, start.Add(time.Second), "same", "echo"))
+	if len(c.operations) != 1 {
+		t.Fatalf("operations = %d, want only the newest request", len(c.operations))
+	}
+	c.Observe(toolResponse("s1", "server", 3, start.Add(2*time.Second), "same", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `",tool="echo"} 2`) || !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="echo"} 1`) {
+		t.Fatalf("superseded call accounting is wrong:\n%s", out.String())
+	}
+}
+
+func TestCollectorDropsToolWhenSameRequestIdentityIsReusedByNonTool(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "same", "echo"))
+	c.Observe(envelope("s1", "server", 2, start.Add(time.Second), proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":"same","method":"ping"}`))
+	c.Observe(toolResponse("s1", "server", 3, start.Add(2*time.Second), "same", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `",tool="echo"} 1`) || !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="echo"} 0`) {
+		t.Fatalf("superseded tool operation remained active:\n%s", out.String())
+	}
+}
+
+func TestCollectorCorrelatesSameHTTPIDByConnID(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequestOnConn("s1", "server", 1, start, "client-a", "1", "echo"))
+	c.Observe(toolRequestOnConn("s1", "server", 2, start.Add(time.Second), "client-b", "1", "echo"))
+	c.Observe(toolResponseOnConn("s1", "server", 3, start.Add(1100*time.Millisecond), "client-a", "1", `"result":{"content":[]}`))
+	c.Observe(toolResponseOnConn("s1", "server", 4, start.Add(3*time.Second), "client-b", "1", `"error":{"code":-32603,"message":"boom"}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `",tool="echo"} 2`) {
+		t.Fatalf("same-id HTTP calls were not both counted:\n%s", got)
+	}
+	if !strings.Contains(got, `",tool="echo",error_type="protocol"} 1`) {
+		t.Fatalf("same-id HTTP protocol error was not retained:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_call_duration_seconds_sum{server="server",server_id="`) || !strings.Contains(got, `",tool="echo"} 3.1`) {
+		t.Fatalf("same-id HTTP durations were not both observed:\n%s", got)
+	}
+}
+
+func TestCollectorPrimeExcludesBackfillMetrics(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Prime(toolRequest("s1", "server", 1, start, "1", "echo"))
+	c.Prime(toolResponse("s1", "server", 2, start.Add(time.Second), "1", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), `",tool="echo"} 1`) {
+		t.Fatalf("backfill produced live metrics:\n%s", out.String())
+	}
+}
+
+func TestRunHeadlessMetricsDoesNotStartTUI(t *testing.T) {
+	if _, err := net.Listen("unix", filepath.Join(t.TempDir(), "probe.sock")); err != nil {
+		t.Skipf("unix sockets unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "hub.sock")
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := probe.Addr().String()
+	probe.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- RunHeadless(ctx, socket, dir, 0, addr) }()
+
+	var resp *http.Response
+	for range 50 {
+		resp, err = http.Get("http://" + addr + "/metrics")
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		cancel()
+		t.Fatalf("headless metrics listener did not start: %v", err)
+	}
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("headless metrics run = %v", err)
+	}
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		t.Fatalf("headless hub socket still exists, stat error = %v", err)
+	}
+}
+
+type blockingWriter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+	return len(p), nil
+}
+
+func TestCollectorScrapeDoesNotBlockLiveAggregation(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "1", "echo"))
+	c.Observe(toolResponse("s1", "server", 2, start.Add(time.Millisecond), "1", `"result":{"content":[]}`))
+
+	writer := &blockingWriter{started: make(chan struct{}), release: make(chan struct{})}
+	written := make(chan error, 1)
+	go func() { written <- c.Write(writer) }()
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("scrape did not start")
+	}
+
+	aggregated := make(chan struct{})
+	go func() {
+		c.Observe(toolRequest("s1", "server", 3, start.Add(time.Second), "2", "echo"))
+		close(aggregated)
+	}()
+	select {
+	case <-aggregated:
+	case <-time.After(time.Second):
+		close(writer.release)
+		t.Fatal("live aggregation was blocked by a scrape writer")
+	}
+	close(writer.release)
+	if err := <-written; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectorAggregatesConcurrentSessions(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	var wg sync.WaitGroup
+	for i := range 40 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			session := "s" + strconv.Itoa(i)
+			at := start.Add(time.Duration(i) * time.Millisecond)
+			c.Observe(toolRequest(session, "server", 1, at, "1", "echo"))
+			c.Observe(toolResponse(session, "server", 2, at.Add(10*time.Millisecond), "1", `"result":{"content":[]}`))
+		}(i)
+	}
+	wg.Wait()
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_calls_total{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="echo"} 40`) {
+		t.Fatalf("concurrent calls were lost or duplicated:\n%s", out.String())
+	}
+}
+
+func TestCollectorKeepsDistinctServerIdentitiesApart(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	for i, command := range [][]string{{"node", "alpha.js"}, {"node", "beta.js"}} {
+		session := "s" + strconv.Itoa(i)
+		meta, _ := json.Marshal(proxy.SessionMeta{Command: command, CWD: "/srv"})
+		c.Observe(proxy.Envelope{SessionID: session, ServerLabel: "same", Seq: 1, TS: start, Direction: proxy.DirectionMeta, Raw: meta})
+		c.Observe(toolRequest(session, "same", 2, start, "1", "search"))
+		c.Observe(toolResponse(session, "same", 3, start.Add(time.Millisecond), "1", `"result":{"content":[]}`))
+	}
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(out.String(), `mcpsnoop_tool_calls_total{server="same"`); got != 2 {
+		t.Fatalf("same-label servers were pooled, got %d series:\n%s", got, out.String())
+	}
+}
+
+func TestMetricsServerOnlyServesMetricsOnItsOwnListener(t *testing.T) {
+	c := New()
+	server, err := NewServer("127.0.0.1:0", c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve() }()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := <-serveErr; err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	resp, err := http.Get("http://" + server.Addr().String() + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/plain; version=0.0.4") {
+		t.Fatalf("metrics response = %d/%q", resp.StatusCode, resp.Header.Get("Content-Type"))
+	}
+	if !strings.Contains(string(body), "# TYPE mcpsnoop_tool_calls_total counter") {
+		t.Fatalf("metrics response missing exposition:\n%s", body)
+	}
+
+	resp, err = http.Get("http://" + server.Addr().String() + "/mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("non-metrics path status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestCollectorBoundsALabelTakenOffTheWire. A tool label is whatever a peer put
+// in params.name, a frame may carry 16 MiB of it, and Write repeats it on
+// seventeen lines per series. One request measured out at a 71 MB scrape body,
+// which Prometheus drops whole against body_size_limit, taking every real series
+// for that target with it.
+func TestCollectorBoundsALabelTakenOffTheWire(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	huge := strings.Repeat("A", 4<<20)
+	c.Observe(toolRequest("s1", "srv", 1, at, "1", huge))
+	c.Observe(toolResponse("s1", "srv", 2, at.Add(time.Millisecond), "1", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if n := out.Len(); n > 64<<10 {
+		t.Errorf("one 4 MiB tool name rendered %d bytes of exposition, want a bounded body", n)
+	}
+	if strings.Contains(out.String(), strings.Repeat("A", maxLabelBytes+1)) {
+		t.Error("the label reached the exposition at more than its cap")
+	}
+	if !strings.Contains(out.String(), labelElision) {
+		t.Error("the label was cut without saying so, so a reader cannot tell truncation from a real name")
+	}
+}
+
+// TestCollectorFoldsTooManyToolNamesRatherThanGrowingForever. Nothing on the
+// wire constrains how many tool names a peer uses, and neither peer has to
+// cooperate: the store recognises a tools/call by its method, so a server
+// writing them on its own stdout mints one series each. Past the cap the calls
+// still have to be counted, or the cap would discard the traffic it exists to
+// keep measuring.
+func TestCollectorFoldsTooManyToolNamesRatherThanGrowingForever(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	const flood = maxSeries * 3
+	for i := range flood {
+		id := strconv.Itoa(i)
+		c.Observe(toolRequest("s1", "srv", uint64(2*i+1), at, id, "tool-"+id))
+		c.Observe(toolResponse("s1", "srv", uint64(2*i+2), at.Add(time.Millisecond), id, `"result":{"content":[]}`))
+	}
+	c.mu.RLock()
+	held := len(c.series)
+	c.mu.RUnlock()
+	if held > maxSeries+1 {
+		t.Errorf("held %d series for %d tool names, want no more than the cap plus the overflow bucket", held, flood)
+	}
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	// Every call is still counted somewhere, so a dashboard's total stays true.
+	var total float64
+	for _, line := range strings.Split(out.String(), "\n") {
+		if !strings.HasPrefix(line, toolCallsMetric+"{") {
+			continue
+		}
+		// The value is after the last space, since a label may hold one.
+		cut := strings.LastIndex(line, " ")
+		if cut < 0 {
+			t.Fatalf("no value in %q", line)
+		}
+		value := line[cut+1:]
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			t.Fatalf("unparseable count in %q", line)
+		}
+		total += n
+	}
+	if int(total) != flood {
+		t.Errorf("counted %d calls across every series, want %d: folding must not lose the totals", int(total), flood)
+	}
+	if !strings.Contains(out.String(), overflowTool) {
+		t.Error("nothing in the exposition says the series list was capped")
+	}
+}
+
+// TestCollectorKeepsAToolCallASeverInitiatedRequestReuses. JSON-RPC scopes id
+// uniqueness to the sender, so a server may legally issue a request carrying the
+// id of a tool call that is still in flight. Keying the in-flight map without
+// the direction made that look like a retry, and the live call was finished
+// before its answer arrived, losing its error and its latency.
+func TestCollectorKeepsAToolCallASeverInitiatedRequestReuses(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "srv", 1, at, "7", "search"))
+	// The server asks the client something of its own, reusing id 7.
+	c.Observe(envelope("s1", "srv", 2, at.Add(5*time.Millisecond), proxy.ServerToClient,
+		`{"jsonrpc":"2.0","id":"7","method":"roots/list"}`))
+	c.Observe(toolResponse("s1", "srv", 3, at.Add(20*time.Millisecond), "7",
+		`"result":{"content":[],"isError":true}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	body := out.String()
+	// The values, not the substrings. Every metric name appears in a HELP and a
+	// TYPE line whether or not anything was counted, and the tool keeps its
+	// calls_total series either way, so presence proves nothing here.
+	if got := seriesValue(t, body, toolErrorsMetric, `tool="search"`); got != 1 {
+		t.Errorf("errors for the tool = %v, want 1: a server request reusing its id must not finish it\n%s", got, body)
+	}
+	if got := seriesValue(t, body, toolDurationMetric+"_count", `tool="search"`); got != 1 {
+		t.Errorf("latency observations for the tool = %v, want 1\n%s", got, body)
+	}
+}
+
+// seriesValue totals every sample of metric whose line contains match.
+//
+// Every one, not the first. A tool carries two error series, one per
+// error_type, so reading the first would let a count land in the other slot and
+// go unnoticed. The value is after the last space, since a label may hold one.
+func seriesValue(t *testing.T, body, metric, match string) float64 {
+	t.Helper()
+	var total float64
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, metric+"{") || !strings.Contains(line, match) {
+			continue
+		}
+		cut := strings.LastIndex(line, " ")
+		if cut < 0 {
+			t.Fatalf("no value in %q", line)
+		}
+		v, err := strconv.ParseFloat(line[cut+1:], 64)
+		if err != nil {
+			t.Fatalf("unparseable value in %q", line)
+		}
+		total += v
+	}
+	return total
+}
+
+// TestCollectorCountsATransportFailureThatHasNoTool. A gateway answering 502, or
+// a 401 challenge, arrives as a status and a body that is not JSON-RPC. Nothing
+// in it says which request it answered, so it can never be attributed to a tool.
+// Left uncounted, a gateway outage read as traffic stopping rather than traffic
+// failing, while `mcpsnoop check` over the same capture failed on it.
+func TestCollectorCountsATransportFailureThatHasNoTool(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequestOnConn("s1", "srv", 1, at, "c1", "1", "echo"))
+	c.Observe(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: at.Add(30 * time.Millisecond),
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP, ConnID: "c1", Status: 502,
+	})
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	body := out.String()
+	if got := seriesValue(t, body, transportErrorsMetric, `status="502"`); got != 1 {
+		t.Errorf("transport errors = %v, want 1\n%s", got, body)
+	}
+	// And it is not invented onto the tool, since nothing said it was that call's.
+	if got := seriesValue(t, body, toolErrorsMetric, `tool="echo"`); got != 0 {
+		t.Errorf("the 502 was attributed to a tool it cannot be known to belong to, got %v", got)
+	}
+	if !strings.Contains(body, "# TYPE "+transportErrorsMetric+" counter") {
+		t.Error("the family is missing its TYPE line")
+	}
+}
+
+// TestCollectorAlwaysDeclaresTheTransportFamily. A dashboard that graphs a
+// metric which only appears once something has failed cannot tell a healthy hub
+// from a broken query.
+func TestCollectorAlwaysDeclaresTheTransportFamily(t *testing.T) {
+	var out strings.Builder
+	if err := New().Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "# TYPE "+transportErrorsMetric+" counter") {
+		t.Errorf("an idle collector does not declare %s:\n%s", transportErrorsMetric, out.String())
+	}
+}

--- a/internal/npmpack/launcher_test.go
+++ b/internal/npmpack/launcher_test.go
@@ -1,0 +1,233 @@
+package npmpack
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The launcher is the one file in the npm distribution that runs on a user's
+// machine, and it stands in the pipe between an MCP client and its server. The
+// tests below drive the real file with the real node, against a stand-in for
+// the binary, because what matters about it is behaviour under a signal and at
+// a pipe, which reading it cannot settle.
+
+// launcher builds a node_modules tree holding the real launcher and a stand-in
+// for this machine's binary, and returns the launcher's path inside it.
+func launcher(t *testing.T, stub string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in binary is a shell script and the signals are POSIX ones")
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		// A Go contributor has no reason to have node installed, so locally
+		// this steps aside. In CI it must not: a silent skip would leave the
+		// only file that runs on a user's machine with no gate at all.
+		if os.Getenv("CI") != "" {
+			t.Fatal("node is missing, so the launcher would go untested; install it in the workflow")
+		}
+		t.Skip("node is not installed, so the launcher cannot be run")
+	}
+	var host Target
+	for _, tgt := range Targets() {
+		if tgt.GOOS == runtime.GOOS && tgt.GOARCH == runtime.GOARCH {
+			host = tgt
+		}
+	}
+	if host.OS == "" {
+		t.Skipf("the npm distribution does not cover %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	root := t.TempDir()
+	self := filepath.Join(root, "node_modules", "mcpsnoop", "bin")
+	if err := os.MkdirAll(self, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyInto(t, filepath.Join(source(t), "bin", "mcpsnoop.js"), filepath.Join(self, "mcpsnoop.js"))
+
+	if stub != "" {
+		pkg := filepath.Join(root, "node_modules", "@mcpsnoop", host.Dir())
+		if err := os.MkdirAll(filepath.Join(pkg, "bin"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkg, "package.json"),
+			[]byte(`{"name":"`+host.Package()+`","version":"0.0.0-test"}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkg, "bin", host.Binary()), []byte(stub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return filepath.Join(self, "mcpsnoop.js")
+}
+
+// run drives the launcher and returns what a caller would see.
+func run(t *testing.T, path, stdin string, args ...string) (stdout, stderr string, code int, signal syscall.Signal) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "node", append([]string{path}, args...)...)
+	cmd.Stdin = strings.NewReader(stdin)
+	var out, errBuf strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errBuf
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		t.Fatal("the launcher never exited, so a client waiting on it would hang")
+	}
+	var exit *exec.ExitError
+	if err != nil && !errors.As(err, &exit) {
+		t.Fatal(err)
+	}
+	if ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+		return out.String(), errBuf.String(), -1, ws.Signal()
+	}
+	return out.String(), errBuf.String(), cmd.ProcessState.ExitCode(), 0
+}
+
+func TestTheLauncherPassesItsArgumentsThroughUnchanged(t *testing.T) {
+	// The stand-in prints its arguments itself. Anything that re-parsed them on
+	// the way, node -e included, would eat the -- and the test would be
+	// measuring that instead of the launcher.
+	path := launcher(t, `#!/bin/sh
+for a in "$@"; do printf '%s\n' "$a"; done
+`)
+	// mcpsnoop is told what to wrap after a --, and the flags meant for the
+	// wrapped server look exactly like flags meant for the wrapper.
+	stdout, stderr, code, _ := run(t, path, "", "--", "node", "build/index.js", "--port", "3000")
+	if code != 0 {
+		t.Fatalf("exit %d, stderr %s", code, stderr)
+	}
+	got := strings.Split(strings.TrimSuffix(stdout, "\n"), "\n")
+	want := []string{"--", "node", "build/index.js", "--port", "3000"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("the binary was called with %q, want %q", got, want)
+	}
+}
+
+func TestTheLauncherReturnsTheBinarysExitCode(t *testing.T) {
+	path := launcher(t, "#!/bin/sh\nexit 42\n")
+	// mcpsnoop check is meant to be a CI gate, and mcpsnoop reports a wrapped
+	// server's exit code as its own. A wrapper that flattened either one would
+	// turn a red build green.
+	if _, _, code, _ := run(t, path, ""); code != 42 {
+		t.Errorf("exit %d, want 42", code)
+	}
+}
+
+func TestTheLauncherDiesTheWayTheBinaryDied(t *testing.T) {
+	path := launcher(t, "#!/bin/sh\nkill -TERM $$\n")
+	_, _, code, sig := run(t, path, "")
+	// Installing a signal handler takes away node's own default, which is to
+	// die. Raising the signal again while the handler is still installed only
+	// calls the handler, and the wrapper sits in its event loop for ever.
+	if sig != syscall.SIGTERM {
+		t.Errorf("exited with code %d and signal %v, want death by SIGTERM", code, sig)
+	}
+}
+
+func TestTheLauncherForwardsASignalToTheBinary(t *testing.T) {
+	mark := filepath.Join(t.TempDir(), "signalled")
+	path := launcher(t, `#!/bin/sh
+trap 'printf caught > "`+mark+`"; exit 0' TERM
+printf up > "`+mark+`.ready"
+while :; do sleep 0.05; done
+`)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "node", path)
+	cmd.Stdin = strings.NewReader("")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if _, err := os.Stat(mark + ".ready"); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			t.Fatal("the stand-in binary never started")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// A client stops its server by signalling the process it launched, which is
+	// the wrapper. Without forwarding, the shim never hears about it.
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("the launcher did not exit after being signalled")
+	}
+	if _, err := os.Stat(mark); err != nil {
+		t.Error("the binary was never signalled, so mcpsnoop's own shutdown never ran")
+	}
+}
+
+func TestTheLauncherExplainsAMissingPlatformPackage(t *testing.T) {
+	path := launcher(t, "")
+	stdout, stderr, code, _ := run(t, path, "")
+	if code != 1 {
+		t.Errorf("exit %d, want 1", code)
+	}
+	// npm drops an optional dependency for reasons that are not the user's
+	// fault, so the way out has to be in the message rather than in a stack
+	// trace naming a file inside node_modules.
+	for _, want := range []string{"@mcpsnoop/", "npm install", "npm cache clean", "go install"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("the message does not mention %q:\n%s", want, stderr)
+		}
+	}
+	if stdout != "" {
+		// Anything on stdout is a JSON-RPC frame as far as the client is
+		// concerned, so an error written there corrupts the stream.
+		t.Errorf("wrote %q to stdout, which the client reads as protocol", stdout)
+	}
+}
+
+func TestTheLauncherAddsNothingToTheStream(t *testing.T) {
+	path := launcher(t, "#!/bin/sh\ncat\n")
+	// The whole point of the shim is to be transparent, and the wrapper sits
+	// in the same pipe. A byte added or a newline dropped here breaks framing
+	// for every client.
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n" + `{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n"
+	stdout, stderr, code, _ := run(t, path, body)
+	if code != 0 {
+		t.Fatalf("exit %d, stderr %s", code, stderr)
+	}
+	if stdout != body {
+		t.Errorf("the stream came back changed:\n got %q\nwant %q", stdout, body)
+	}
+}
+
+func TestTheLauncherRunsABinaryThatLostItsExecuteBit(t *testing.T) {
+	path := launcher(t, "#!/bin/sh\nexit 21\n")
+	// npm carries the mode through, and TestBuildLeavesTheBinaryExecutable
+	// keeps it on going in. Other clients have not always, and the result is a
+	// package that installs cleanly and then cannot start at all.
+	var host Target
+	for _, tgt := range Targets() {
+		if tgt.GOOS == runtime.GOOS && tgt.GOARCH == runtime.GOARCH {
+			host = tgt
+		}
+	}
+	binary := filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(path))), "@mcpsnoop", host.Dir(), "bin", host.Binary())
+	if err := os.Chmod(binary, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, code, _ := run(t, path, ""); code != 21 {
+		t.Errorf("exit %d, want 21, so the binary never ran", code)
+	}
+}

--- a/internal/npmpack/npmpack.go
+++ b/internal/npmpack/npmpack.go
@@ -98,6 +98,8 @@ func Targets() []Target {
 const (
 	// checksumsFile is what the release calls its checksums file.
 	checksumsFile = "checksums.txt"
+	// rootPackage is the thin package a user asks for by name.
+	rootPackage = "mcpsnoop"
 	// placeholder is the version the checked-in root manifest carries. It is
 	// never a real release, so a run that forgot to stamp it is caught rather
 	// than published.
@@ -350,7 +352,7 @@ MIT licensed.
 // writeRoot copies the checked-in root package and stamps the release version
 // into its manifest, pinning every platform package to the same version.
 func writeRoot(src, out, version string) error {
-	dir := filepath.Join(out, "mcpsnoop")
+	dir := filepath.Join(out, rootPackage)
 	if err := os.MkdirAll(filepath.Join(dir, "bin"), 0o755); err != nil {
 		return err
 	}
@@ -423,8 +425,13 @@ func DistTag(version string) string {
 	return "latest"
 }
 
-// PublishOrder lists the seven package directories a run produces, relative to
-// the output directory, in the order they must be published in.
+// PublishOrder names the seven packages a run produces, in the order they must
+// be published in.
+//
+// A name doubles as the directory Build wrote that package to, relative to the
+// output directory, because npm spells a scoped name with the same separator a
+// path uses. That lets the release workflow check a name against the registry
+// and publish the directory of the same name without carrying two lists.
 //
 // The root package resolves to the other six, so it goes last. A run that
 // stopped halfway then leaves platform packages that nothing yet points at,
@@ -432,10 +439,10 @@ func DistTag(version string) string {
 // exist, which is broken for everyone and cannot be taken back: npm does not
 // let a published version be replaced.
 func PublishOrder() []string {
-	dirs := make([]string, 0, len(Targets())+1)
+	names := make([]string, 0, len(Targets())+1)
 	for _, t := range Targets() {
-		dirs = append(dirs, filepath.Join("@mcpsnoop", t.Dir()))
+		names = append(names, t.Package())
 	}
-	sort.Strings(dirs)
-	return append(dirs, "mcpsnoop")
+	sort.Strings(names)
+	return append(names, rootPackage)
 }

--- a/internal/npmpack/npmpack.go
+++ b/internal/npmpack/npmpack.go
@@ -1,0 +1,441 @@
+// Package npmpack turns a released set of mcpsnoop archives into the npm
+// packages that carry them.
+//
+// The npm distribution is seven packages. Six hold one binary each and name the
+// machine they are for through npm's os and cpu fields, so npm installs exactly
+// one of them and skips the rest. The seventh is the thin package a user asks
+// for by name; it holds a launcher and lists the other six as optional
+// dependencies. That shape is what lets the install work behind a proxy, from a
+// cache, and under --ignore-scripts, none of which hold for a postinstall that
+// fetches from GitHub.
+//
+// The input is the published archives and their checksums file, not the build
+// tree they came from. Two reasons. The archive is the artifact the project
+// promises, while the layout of a build directory is a private detail of
+// whatever produced it. And going through the checksums file means the bytes
+// inside the npm package are provably the bytes of the GitHub Release, which is
+// the claim worth being able to make about a binary strangers run with npx.
+package npmpack
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Options describes one run.
+type Options struct {
+	// Version is the release being packaged, without a leading v.
+	Version string
+	// DistDir holds the archives and the checksums file.
+	DistDir string
+	// SourceDir holds the checked-in root package: the launcher, its manifest,
+	// the README and the licence.
+	SourceDir string
+	// OutDir receives the finished package trees. It is created if missing and
+	// must be empty of anything this run would overwrite.
+	OutDir string
+}
+
+// Target is one of the six machines a release is built for.
+type Target struct {
+	GOOS   string // as the Go toolchain and the archive name spell it
+	GOARCH string
+	OS     string // as npm's os field spells it
+	CPU    string // as npm's cpu field spells it
+}
+
+// Package is the npm name of the platform package for t.
+func (t Target) Package() string { return "@mcpsnoop/" + t.Dir() }
+
+// Dir is the directory the platform package is written to, and the second half
+// of its npm name.
+func (t Target) Dir() string { return t.OS + "-" + t.CPU }
+
+// Binary is the name of the executable inside the archive and the package.
+func (t Target) Binary() string {
+	if t.GOOS == "windows" {
+		return "mcpsnoop.exe"
+	}
+	return "mcpsnoop"
+}
+
+// Archive is the file the release publishes for t.
+func (t Target) Archive(version string) string {
+	ext := "tar.gz"
+	if t.GOOS == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("mcpsnoop_%s_%s_%s.%s", version, t.GOOS, t.GOARCH, ext)
+}
+
+// Targets lists every machine the npm distribution covers, in the order the
+// manifests should list them. It matches the goos and goarch matrix in
+// .goreleaser.yaml, and the launcher's own table, and a change to one of the
+// three without the other two is a bug the tests catch.
+func Targets() []Target {
+	return []Target{
+		{GOOS: "darwin", GOARCH: "arm64", OS: "darwin", CPU: "arm64"},
+		{GOOS: "darwin", GOARCH: "amd64", OS: "darwin", CPU: "x64"},
+		{GOOS: "linux", GOARCH: "arm64", OS: "linux", CPU: "arm64"},
+		{GOOS: "linux", GOARCH: "amd64", OS: "linux", CPU: "x64"},
+		{GOOS: "windows", GOARCH: "arm64", OS: "win32", CPU: "arm64"},
+		{GOOS: "windows", GOARCH: "amd64", OS: "win32", CPU: "x64"},
+	}
+}
+
+const (
+	// checksumsFile is what the release calls its checksums file.
+	checksumsFile = "checksums.txt"
+	// placeholder is the version the checked-in root manifest carries. It is
+	// never a real release, so a run that forgot to stamp it is caught rather
+	// than published.
+	placeholder = "0.0.0"
+	// maxBinary bounds how much of an archive member is read. The binaries are
+	// around 14 MB, so this leaves room to grow without letting a malformed or
+	// hostile archive decompress without limit.
+	maxBinary = 128 << 20
+	// binaryMode is the mode the executable is written with. npm carries the
+	// mode of a file in the tarball through to the installed tree, and a
+	// binary that arrives without its execute bit cannot be run at all.
+	binaryMode = 0o755
+)
+
+// Build writes the seven package trees for one release.
+//
+// Everything is verified before anything is written. A release that is missing
+// one of its six archives, or that has one whose checksum does not match, must
+// produce no packages at all: a root package published against platform
+// packages that do not exist is broken for every user on that platform, and
+// npm versions cannot be replaced once published.
+func Build(opts Options) error {
+	version := strings.TrimPrefix(opts.Version, "v")
+	if version == "" {
+		return fmt.Errorf("npmpack: no version given")
+	}
+	if version == placeholder {
+		return fmt.Errorf("npmpack: %s is the placeholder version in the checked-in manifest, not a release", placeholder)
+	}
+	if strings.HasPrefix(version, "v") {
+		return fmt.Errorf("npmpack: version %q still starts with a v", version)
+	}
+
+	sums, err := readChecksums(filepath.Join(opts.DistDir, checksumsFile))
+	if err != nil {
+		return err
+	}
+
+	binaries := make(map[string][]byte, len(Targets()))
+	for _, t := range Targets() {
+		bin, err := verifiedBinary(opts.DistDir, t, version, sums)
+		if err != nil {
+			return err
+		}
+		binaries[t.Dir()] = bin
+	}
+
+	// Each platform package ships a binary, so each one carries the licence
+	// that binary is under rather than pointing at a sibling package for it.
+	licence, err := os.ReadFile(filepath.Join(opts.SourceDir, "LICENSE"))
+	if err != nil {
+		return fmt.Errorf("npmpack: %w", err)
+	}
+
+	if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
+		return err
+	}
+	for _, t := range Targets() {
+		if err := writePlatform(opts.OutDir, t, version, binaries[t.Dir()], licence); err != nil {
+			return err
+		}
+	}
+	return writeRoot(opts.SourceDir, opts.OutDir, version)
+}
+
+// verifiedBinary reads t's archive, checks it against the checksums file, and
+// returns the executable inside it.
+func verifiedBinary(dist string, t Target, version string, sums map[string]string) ([]byte, error) {
+	name := t.Archive(version)
+	want, ok := sums[name]
+	if !ok {
+		return nil, fmt.Errorf("npmpack: %s does not list %s, so its contents cannot be verified", checksumsFile, name)
+	}
+	raw, err := os.ReadFile(filepath.Join(dist, name))
+	if err != nil {
+		return nil, fmt.Errorf("npmpack: %w", err)
+	}
+	got := sha256.Sum256(raw)
+	if hex.EncodeToString(got[:]) != want {
+		return nil, fmt.Errorf("npmpack: %s does not match its checksum in %s, so it is not the released archive", name, checksumsFile)
+	}
+	bin, err := extract(raw, t)
+	if err != nil {
+		return nil, fmt.Errorf("npmpack: %s: %w", name, err)
+	}
+	if len(bin) == 0 {
+		return nil, fmt.Errorf("npmpack: %s holds an empty %s", name, t.Binary())
+	}
+	return bin, nil
+}
+
+// extract pulls the executable out of one archive.
+func extract(raw []byte, t Target) ([]byte, error) {
+	if t.GOOS == "windows" {
+		return extractZip(raw, t.Binary())
+	}
+	return extractTarGz(raw, t.Binary())
+}
+
+func extractTarGz(raw []byte, name string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if h.Typeflag != tar.TypeReg || filepath.Base(h.Name) != name {
+			continue
+		}
+		return io.ReadAll(io.LimitReader(tr, maxBinary))
+	}
+	return nil, fmt.Errorf("holds no %s", name)
+}
+
+func extractZip(raw []byte, name string) ([]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() || filepath.Base(f.Name) != name {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+		return io.ReadAll(io.LimitReader(rc, maxBinary))
+	}
+	return nil, fmt.Errorf("holds no %s", name)
+}
+
+// readChecksums parses the released checksums file into name to digest.
+func readChecksums(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("npmpack: %w", err)
+	}
+	defer f.Close()
+
+	sums := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		// The name may carry the binary marker some tools write.
+		sums[strings.TrimPrefix(fields[1], "*")] = strings.ToLower(fields[0])
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("npmpack: %w", err)
+	}
+	if len(sums) == 0 {
+		return nil, fmt.Errorf("npmpack: %s lists nothing", path)
+	}
+	return sums, nil
+}
+
+// platformManifest is one platform package's package.json.
+//
+// It deliberately declares no bin. npm would install a shim for every bin it
+// finds, and six packages all claiming the name mcpsnoop would fight the root
+// package for it. The root resolves the path itself instead.
+type platformManifest struct {
+	Name            string     `json:"name"`
+	Version         string     `json:"version"`
+	Description     string     `json:"description"`
+	Homepage        string     `json:"homepage"`
+	Repository      repository `json:"repository"`
+	License         string     `json:"license"`
+	OS              []string   `json:"os"`
+	CPU             []string   `json:"cpu"`
+	Files           []string   `json:"files"`
+	Engines         engines    `json:"engines"`
+	PreferUnplugged bool       `json:"preferUnplugged"`
+}
+
+type repository struct {
+	Type      string `json:"type"`
+	URL       string `json:"url"`
+	Directory string `json:"directory,omitempty"`
+}
+
+type engines struct {
+	Node string `json:"node"`
+}
+
+func writePlatform(out string, t Target, version string, bin, licence []byte) error {
+	dir := filepath.Join(out, "@mcpsnoop", t.Dir())
+	if err := os.MkdirAll(filepath.Join(dir, "bin"), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bin", t.Binary()), bin, binaryMode); err != nil {
+		return err
+	}
+	// WriteFile leaves an existing file's mode alone, and the execute bit is
+	// the difference between a working install and one that cannot start.
+	if err := os.Chmod(filepath.Join(dir, "bin", t.Binary()), binaryMode); err != nil {
+		return err
+	}
+
+	m := platformManifest{
+		Name:        t.Package(),
+		Version:     version,
+		Description: fmt.Sprintf("The %s binary for mcpsnoop. Installed for you by the mcpsnoop package; not meant to be depended on directly.", t.Dir()),
+		Homepage:    "https://github.com/kerlenton/mcpsnoop#readme",
+		Repository: repository{
+			Type: "git",
+			URL:  "git+https://github.com/kerlenton/mcpsnoop.git",
+		},
+		License:         "MIT",
+		OS:              []string{t.OS},
+		CPU:             []string{t.CPU},
+		Files:           []string{"bin/" + t.Binary()},
+		Engines:         engines{Node: ">=18"},
+		PreferUnplugged: true,
+	}
+	if err := writeJSON(filepath.Join(dir, "package.json"), m); err != nil {
+		return err
+	}
+
+	readme := fmt.Sprintf(`# %s
+
+The %s build of [mcpsnoop](https://github.com/kerlenton/mcpsnoop).
+
+This package holds one binary and nothing else. You do not install it yourself.
+Install `+"`mcpsnoop`"+`, and npm picks whichever of these six packages matches your
+machine and skips the other five.
+
+    npx mcpsnoop -- node build/index.js
+
+MIT licensed.
+`, t.Package(), t.Dir())
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(readme), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "LICENSE"), licence, 0o644)
+}
+
+// writeRoot copies the checked-in root package and stamps the release version
+// into its manifest, pinning every platform package to the same version.
+func writeRoot(src, out, version string) error {
+	dir := filepath.Join(out, "mcpsnoop")
+	if err := os.MkdirAll(filepath.Join(dir, "bin"), 0o755); err != nil {
+		return err
+	}
+	for _, name := range []string{"README.md", "LICENSE", filepath.Join("bin", "mcpsnoop.js")} {
+		b, err := os.ReadFile(filepath.Join(src, name))
+		if err != nil {
+			return fmt.Errorf("npmpack: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), b, 0o644); err != nil {
+			return err
+		}
+	}
+
+	raw, err := os.ReadFile(filepath.Join(src, "package.json"))
+	if err != nil {
+		return fmt.Errorf("npmpack: %w", err)
+	}
+	// Decoding into a map keeps every field the checked-in manifest carries,
+	// including ones added later that this code has never heard of, so the two
+	// files cannot drift apart in the one direction that matters.
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return fmt.Errorf("npmpack: %s: %w", filepath.Join(src, "package.json"), err)
+	}
+	deps, ok := m["optionalDependencies"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("npmpack: the root manifest lists no optionalDependencies, so nothing would carry the binary")
+	}
+	want := map[string]bool{}
+	for _, t := range Targets() {
+		want[t.Package()] = true
+	}
+	for name := range deps {
+		if !want[name] {
+			return fmt.Errorf("npmpack: the root manifest depends on %s, which is not one of the six platform packages", name)
+		}
+	}
+	for name := range want {
+		if _, ok := deps[name]; !ok {
+			return fmt.Errorf("npmpack: the root manifest is missing %s, so that platform would install with no binary", name)
+		}
+		deps[name] = version
+	}
+	m["version"] = version
+	return writeJSON(filepath.Join(dir, "package.json"), m)
+}
+
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+// DistTag is the npm tag a release should be published under.
+//
+// npm serves whatever carries the latest tag to a bare `npx mcpsnoop`, and a
+// publish claims that tag unless it is told otherwise. So a prerelease published
+// without this would be handed to everyone, and there is no taking it back: npm
+// does not let a version be replaced, and unpublishing closes after 72 hours.
+//
+// A prerelease is a version with a hyphen in it, which is what SemVer says and
+// what the release tags spell.
+func DistTag(version string) string {
+	v := strings.TrimPrefix(version, "v")
+	if strings.Contains(v, "-") {
+		return "next"
+	}
+	return "latest"
+}
+
+// PublishOrder lists the seven package directories a run produces, relative to
+// the output directory, in the order they must be published in.
+//
+// The root package resolves to the other six, so it goes last. A run that
+// stopped halfway then leaves platform packages that nothing yet points at,
+// which is inert, rather than a root package pointing at versions that do not
+// exist, which is broken for everyone and cannot be taken back: npm does not
+// let a published version be replaced.
+func PublishOrder() []string {
+	dirs := make([]string, 0, len(Targets())+1)
+	for _, t := range Targets() {
+		dirs = append(dirs, filepath.Join("@mcpsnoop", t.Dir()))
+	}
+	sort.Strings(dirs)
+	return append(dirs, "mcpsnoop")
+}

--- a/internal/npmpack/npmpack_test.go
+++ b/internal/npmpack/npmpack_test.go
@@ -413,9 +413,9 @@ func TestPublishOrderPutsTheRootPackageLast(t *testing.T) {
 	if got := order[len(order)-1]; got != "mcpsnoop" {
 		t.Errorf("the last package published is %s, want mcpsnoop", got)
 	}
-	for _, dir := range order[:len(order)-1] {
-		if !strings.HasPrefix(dir, "@mcpsnoop"+string(filepath.Separator)) {
-			t.Errorf("%s is published before the root package but is not a platform package", dir)
+	for _, name := range order[:len(order)-1] {
+		if !strings.HasPrefix(name, "@mcpsnoop/") {
+			t.Errorf("%s is published before the root package but is not a platform package", name)
 		}
 	}
 }
@@ -425,11 +425,16 @@ func TestPublishOrderNamesADirectoryThatBuildWrote(t *testing.T) {
 	if err := build(t, release(t), out); err != nil {
 		t.Fatal(err)
 	}
-	for _, dir := range PublishOrder() {
-		// The release workflow publishes exactly these paths, so a name that
-		// does not exist on disk is a release that fails halfway through.
-		if _, err := os.Stat(filepath.Join(out, dir, "package.json")); err != nil {
-			t.Errorf("the publish order names %s, which was not written: %v", dir, err)
+	for _, name := range PublishOrder() {
+		// The workflow asks the registry about a name and then publishes the
+		// directory of that same name, so the two have to be the one string.
+		// A name with nothing behind it is a release that fails halfway.
+		dir := filepath.Join(out, filepath.FromSlash(name))
+		if _, err := os.Stat(filepath.Join(dir, "package.json")); err != nil {
+			t.Errorf("the publish order names %s, which was not written: %v", name, err)
+		}
+		if got := readManifest(t, filepath.Join(dir, "package.json"))["name"]; got != name {
+			t.Errorf("the directory %s holds the package %v, so the workflow would ask the registry about the wrong name", name, got)
 		}
 	}
 }

--- a/internal/npmpack/npmpack_test.go
+++ b/internal/npmpack/npmpack_test.go
@@ -1,0 +1,585 @@
+package npmpack
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const testVersion = "0.19.0"
+
+// release writes a plausible set of release archives and their checksums file
+// into a fresh directory, and returns it.
+func release(t *testing.T, mutate ...func(files map[string][]byte)) string {
+	t.Helper()
+	files := map[string][]byte{}
+	for _, tgt := range Targets() {
+		files[tgt.Archive(testVersion)] = archive(t, tgt, []byte("binary for "+tgt.Dir()))
+	}
+	for _, m := range mutate {
+		m(files)
+	}
+
+	dir := t.TempDir()
+	var sums []string
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		d := sha256.Sum256(body)
+		sums = append(sums, fmt.Sprintf("%s  %s", hex.EncodeToString(d[:]), name))
+	}
+	sort.Strings(sums)
+	if err := os.WriteFile(filepath.Join(dir, checksumsFile), []byte(strings.Join(sums, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// archive packs one binary the way the release does for that platform.
+func archive(t *testing.T, tgt Target, bin []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if tgt.GOOS == "windows" {
+		zw := zip.NewWriter(&buf)
+		// The real archive carries these beside the binary, and the extractor
+		// has to walk past them rather than take the first member.
+		for _, name := range []string{"LICENSE", "README.md", tgt.Binary()} {
+			w, err := zw.Create(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := []byte("not the binary")
+			if name == tgt.Binary() {
+				body = bin
+			}
+			if _, err := w.Write(body); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, name := range []string{"LICENSE", "README.md", tgt.Binary()} {
+		body := []byte("not the binary")
+		mode := int64(0o644)
+		if name == tgt.Binary() {
+			body, mode = bin, 0o755
+		}
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: mode, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// source copies the checked-in root package, so the tests run against the real
+// launcher and the real manifest rather than a stand-in that could agree with
+// the code while the shipped files did not.
+func source(t *testing.T) string {
+	t.Helper()
+	return filepath.Join("..", "..", "npm", "mcpsnoop")
+}
+
+func build(t *testing.T, dist, out string) error {
+	t.Helper()
+	return Build(Options{Version: testVersion, DistDir: dist, SourceDir: source(t), OutDir: out})
+}
+
+func readManifest(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("%s is not valid JSON, so npm would refuse the package: %v", path, err)
+	}
+	return m
+}
+
+func TestBuildWritesOnePackagePerPlatformAndTheRoot(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "npm")
+	if err := build(t, release(t), out); err != nil {
+		t.Fatal(err)
+	}
+	for _, tgt := range Targets() {
+		m := readManifest(t, filepath.Join(out, "@mcpsnoop", tgt.Dir(), "package.json"))
+		if m["name"] != tgt.Package() {
+			t.Errorf("%s is named %v", tgt.Dir(), m["name"])
+		}
+		if m["version"] != testVersion {
+			t.Errorf("%s is version %v, want %s", tgt.Dir(), m["version"], testVersion)
+		}
+		// Without these npm has no way to tell which of the six belongs on the
+		// machine, and would install all of them.
+		if got := m["os"].([]any); len(got) != 1 || got[0] != tgt.OS {
+			t.Errorf("%s declares os %v, want [%s]", tgt.Dir(), got, tgt.OS)
+		}
+		if got := m["cpu"].([]any); len(got) != 1 || got[0] != tgt.CPU {
+			t.Errorf("%s declares cpu %v, want [%s]", tgt.Dir(), got, tgt.CPU)
+		}
+		if _, ok := m["bin"]; ok {
+			t.Errorf("%s declares a bin, which would fight the root package for the mcpsnoop name", tgt.Dir())
+		}
+	}
+	root := readManifest(t, filepath.Join(out, "mcpsnoop", "package.json"))
+	if root["version"] != testVersion {
+		t.Errorf("the root package is version %v, want %s", root["version"], testVersion)
+	}
+}
+
+func TestBuildPutsTheRightBinaryInEachPackage(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "npm")
+	if err := build(t, release(t), out); err != nil {
+		t.Fatal(err)
+	}
+	for _, tgt := range Targets() {
+		path := filepath.Join(out, "@mcpsnoop", tgt.Dir(), "bin", tgt.Binary())
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// A run that shuffled the archives would still produce seven packages
+		// that install cleanly, and would hand every user the wrong machine's
+		// binary.
+		if want := "binary for " + tgt.Dir(); string(got) != want {
+			t.Errorf("%s holds %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestBuildLeavesTheBinaryExecutable(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "npm")
+	if err := build(t, release(t), out); err != nil {
+		t.Fatal(err)
+	}
+	for _, tgt := range Targets() {
+		if tgt.GOOS == "windows" {
+			continue
+		}
+		fi, err := os.Stat(filepath.Join(out, "@mcpsnoop", tgt.Dir(), "bin", tgt.Binary()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// npm carries the mode through into the installed tree, so a binary
+		// packed without this cannot be started at all.
+		if fi.Mode().Perm()&0o111 == 0 {
+			t.Errorf("%s is packed as %v, which cannot be executed", tgt.Dir(), fi.Mode().Perm())
+		}
+	}
+}
+
+func TestBuildPinsEveryPlatformPackageToTheReleaseVersion(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "npm")
+	if err := build(t, release(t), out); err != nil {
+		t.Fatal(err)
+	}
+	deps := readManifest(t, filepath.Join(out, "mcpsnoop", "package.json"))["optionalDependencies"].(map[string]any)
+	if len(deps) != len(Targets()) {
+		t.Fatalf("the root package lists %d platform packages, want %d", len(deps), len(Targets()))
+	}
+	for _, tgt := range Targets() {
+		// A range rather than an exact version would let npm pair a root
+		// package with a binary from another release.
+		if got := deps[tgt.Package()]; got != testVersion {
+			t.Errorf("the root package wants %s at %v, want exactly %s", tgt.Package(), got, testVersion)
+		}
+	}
+}
+
+func TestBuildKeepsFieldsItDoesNotKnowAbout(t *testing.T) {
+	src := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join(source(t), "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["fundingLater"] = "https://example.invalid/funding"
+	b, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(src, "package.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"README.md", "LICENSE"} {
+		copyInto(t, filepath.Join(source(t), name), filepath.Join(src, name))
+	}
+	if err := os.MkdirAll(filepath.Join(src, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyInto(t, filepath.Join(source(t), "bin", "mcpsnoop.js"), filepath.Join(src, "bin", "mcpsnoop.js"))
+
+	out := filepath.Join(t.TempDir(), "npm")
+	if err := Build(Options{Version: testVersion, DistDir: release(t), SourceDir: src, OutDir: out}); err != nil {
+		t.Fatal(err)
+	}
+	// A manifest rebuilt from a fixed struct would quietly drop anything added
+	// to the checked-in one later, and the loss would only show on npm.
+	if got := readManifest(t, filepath.Join(out, "mcpsnoop", "package.json"))["fundingLater"]; got != "https://example.invalid/funding" {
+		t.Errorf("the stamped manifest dropped a field it did not recognise, got %v", got)
+	}
+}
+
+func copyInto(t *testing.T, from, to string) {
+	t.Helper()
+	b, err := os.ReadFile(from)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(to, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildRefusesAnArchiveThatDoesNotMatchItsChecksum(t *testing.T) {
+	dist := release(t, func(files map[string][]byte) {
+		files["mcpsnoop_"+testVersion+"_linux_amd64.tar.gz"] = archive(t, Target{GOOS: "linux", GOARCH: "amd64", OS: "linux", CPU: "x64"}, []byte("swapped"))
+	})
+	// Rewrite that one archive on disk after the checksums were taken.
+	tgt := Target{GOOS: "linux", GOARCH: "amd64", OS: "linux", CPU: "x64"}
+	if err := os.WriteFile(filepath.Join(dist, tgt.Archive(testVersion)), archive(t, tgt, []byte("tampered")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "npm")
+	err := build(t, dist, out)
+	if err == nil {
+		t.Fatal("packaged an archive whose bytes are not the released ones")
+	}
+	if !strings.Contains(err.Error(), "checksum") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("wrote packages anyway, so a partial publish is possible")
+	}
+}
+
+func TestBuildRefusesAReleaseMissingOnePlatform(t *testing.T) {
+	dist := release(t)
+	missing := Target{GOOS: "windows", GOARCH: "arm64", OS: "win32", CPU: "arm64"}
+	if err := os.Remove(filepath.Join(dist, missing.Archive(testVersion))); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "npm")
+	// Publishing the other five plus a root package that names all six leaves
+	// every win32-arm64 user with an install that resolves to nothing, and npm
+	// versions cannot be replaced once published.
+	if err := build(t, dist, out); err == nil {
+		t.Fatal("packaged a release that is missing win32-arm64")
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("wrote packages anyway")
+	}
+}
+
+func TestBuildRefusesAnArchiveTheChecksumsFileDoesNotList(t *testing.T) {
+	dist := release(t)
+	raw, err := os.ReadFile(filepath.Join(dist, checksumsFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kept []string
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if !strings.Contains(line, "darwin_arm64") {
+			kept = append(kept, line)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dist, checksumsFile), []byte(strings.Join(kept, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := build(t, dist, filepath.Join(t.TempDir(), "npm")); err == nil {
+		t.Fatal("packaged an archive that the checksums file does not vouch for")
+	}
+}
+
+func TestBuildRefusesTheePlaceholderVersion(t *testing.T) {
+	// The checked-in manifest carries 0.0.0 so that it is obvious it is a
+	// template. Stamping it back in would publish a package that outranks
+	// nothing and shadows every real release in a lockfile.
+	err := Build(Options{Version: placeholder, DistDir: release(t), SourceDir: source(t), OutDir: filepath.Join(t.TempDir(), "npm")})
+	if err == nil {
+		t.Fatal("packaged the placeholder version as if it were a release")
+	}
+	if !strings.Contains(err.Error(), placeholder) {
+		t.Errorf("the error does not name the version: %v", err)
+	}
+}
+
+func TestBuildTakesATagWithItsLeadingV(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "npm")
+	// The release is driven by a pushed tag, which is spelled v0.19.0, while
+	// npm versions and the archive names are not.
+	if err := Build(Options{Version: "v" + testVersion, DistDir: release(t), SourceDir: source(t), OutDir: out}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readManifest(t, filepath.Join(out, "mcpsnoop", "package.json"))["version"]; got != testVersion {
+		t.Errorf("the root package is version %v, want %s", got, testVersion)
+	}
+}
+
+func TestBuildRefusesARootManifestMissingAPlatform(t *testing.T) {
+	src := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join(source(t), "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	delete(m["optionalDependencies"].(map[string]any), "@mcpsnoop/linux-x64")
+	b, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(src, "package.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"README.md", "LICENSE"} {
+		copyInto(t, filepath.Join(source(t), name), filepath.Join(src, name))
+	}
+	if err := os.MkdirAll(filepath.Join(src, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyInto(t, filepath.Join(source(t), "bin", "mcpsnoop.js"), filepath.Join(src, "bin", "mcpsnoop.js"))
+
+	err = Build(Options{Version: testVersion, DistDir: release(t), SourceDir: src, OutDir: filepath.Join(t.TempDir(), "npm")})
+	if err == nil {
+		t.Fatal("packaged a root manifest that leaves linux-x64 with no binary")
+	}
+	if !strings.Contains(err.Error(), "@mcpsnoop/linux-x64") {
+		t.Errorf("the error does not name the missing platform: %v", err)
+	}
+}
+
+func TestBuildRefusesAnArchiveWithNoBinaryInIt(t *testing.T) {
+	tgt := Target{GOOS: "linux", GOARCH: "amd64", OS: "linux", CPU: "x64"}
+	dist := release(t, func(files map[string][]byte) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		body := []byte("only docs here")
+		if err := tw.WriteHeader(&tar.Header{Name: "README.md", Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+		tw.Close()
+		gz.Close()
+		files[tgt.Archive(testVersion)] = buf.Bytes()
+	})
+	err := build(t, dist, filepath.Join(t.TempDir(), "npm"))
+	if err == nil {
+		t.Fatal("packaged an archive that holds no binary")
+	}
+	if !strings.Contains(err.Error(), "mcpsnoop") {
+		t.Errorf("the error does not say what was missing: %v", err)
+	}
+}
+
+func TestPublishOrderPutsTheRootPackageLast(t *testing.T) {
+	order := PublishOrder()
+	if len(order) != len(Targets())+1 {
+		t.Fatalf("the order lists %d packages, want %d", len(order), len(Targets())+1)
+	}
+	// The root package resolves to the other six. Published first, it is broken
+	// for the window before they land, and npm serves it to anyone installing
+	// in that window.
+	if got := order[len(order)-1]; got != "mcpsnoop" {
+		t.Errorf("the last package published is %s, want mcpsnoop", got)
+	}
+	for _, dir := range order[:len(order)-1] {
+		if !strings.HasPrefix(dir, "@mcpsnoop"+string(filepath.Separator)) {
+			t.Errorf("%s is published before the root package but is not a platform package", dir)
+		}
+	}
+}
+
+func TestPublishOrderNamesADirectoryThatBuildWrote(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "npm")
+	if err := build(t, release(t), out); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range PublishOrder() {
+		// The release workflow publishes exactly these paths, so a name that
+		// does not exist on disk is a release that fails halfway through.
+		if _, err := os.Stat(filepath.Join(out, dir, "package.json")); err != nil {
+			t.Errorf("the publish order names %s, which was not written: %v", dir, err)
+		}
+	}
+}
+
+func TestTargetsMatchTheReleaseMatrix(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", ".goreleaser.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A platform added to the release but not here would be built and published
+	// to GitHub and silently left out of npm.
+	want := map[string]bool{}
+	for _, goos := range yamlList(t, raw, "goos") {
+		for _, goarch := range yamlList(t, raw, "goarch") {
+			want[goos+"/"+goarch] = true
+		}
+	}
+	got := map[string]bool{}
+	for _, tgt := range Targets() {
+		got[tgt.GOOS+"/"+tgt.GOARCH] = true
+	}
+	for pair := range want {
+		if !got[pair] {
+			t.Errorf(".goreleaser.yaml builds %s but the npm packages do not cover it", pair)
+		}
+	}
+	for pair := range got {
+		if !want[pair] {
+			t.Errorf("the npm packages cover %s but .goreleaser.yaml does not build it", pair)
+		}
+	}
+}
+
+// yamlList reads one flow-style list from .goreleaser.yaml. It is deliberately
+// narrow, and fails loudly rather than returning nothing, so that a rewrite of
+// the release config is noticed here instead of quietly disarming the check.
+func yamlList(t *testing.T, raw []byte, key string) []string {
+	t.Helper()
+	m := regexp.MustCompile(`(?m)^\s*` + key + `:\s*\[([^\]]*)\]`).FindSubmatch(raw)
+	if m == nil {
+		t.Fatalf(".goreleaser.yaml no longer spells %s as a flow list, so this check reads nothing; update it", key)
+	}
+	var out []string
+	for _, f := range strings.Split(string(m[1]), ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			out = append(out, f)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf(".goreleaser.yaml lists no %s", key)
+	}
+	return out
+}
+
+func TestTargetsMatchTheLauncherTable(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(source(t), "bin", "mcpsnoop.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := regexp.MustCompile(`'(@mcpsnoop/[a-z0-9-]+)'`).FindAllSubmatch(raw, -1)
+	if len(found) == 0 {
+		t.Fatal("the launcher no longer names its platform packages the way this check reads them; update it")
+	}
+	got := map[string]bool{}
+	for _, m := range found {
+		got[string(m[1])] = true
+	}
+	want := map[string]bool{}
+	for _, tgt := range Targets() {
+		want[tgt.Package()] = true
+	}
+	// The launcher decides at runtime which package to look for. A platform
+	// packaged here but absent there installs fine and then refuses to start.
+	for name := range want {
+		if !got[name] {
+			t.Errorf("%s is packaged but the launcher never looks for it", name)
+		}
+	}
+	for name := range got {
+		if !want[name] {
+			t.Errorf("the launcher looks for %s, which is never packaged", name)
+		}
+	}
+}
+
+func TestTargetsMatchTheRootManifest(t *testing.T) {
+	deps, ok := readManifest(t, filepath.Join(source(t), "package.json"))["optionalDependencies"].(map[string]any)
+	if !ok {
+		t.Fatal("the checked-in root manifest lists no optionalDependencies")
+	}
+	for _, tgt := range Targets() {
+		if _, ok := deps[tgt.Package()]; !ok {
+			t.Errorf("the checked-in root manifest does not depend on %s", tgt.Package())
+		}
+	}
+	if len(deps) != len(Targets()) {
+		t.Errorf("the checked-in root manifest lists %d platform packages, want %d", len(deps), len(Targets()))
+	}
+}
+
+func TestArchiveNamesMatchTheReleaseTemplate(t *testing.T) {
+	// .goreleaser.yaml names archives {{ .ProjectName }}_{{ .Version }}_{{ .Os
+	// }}_{{ .Arch }}, gzipped except on windows. Reading the wrong name means
+	// every archive looks missing.
+	for _, tgt := range Targets() {
+		want := "mcpsnoop_" + testVersion + "_" + tgt.GOOS + "_" + tgt.GOARCH
+		if tgt.GOOS == "windows" {
+			want += ".zip"
+		} else {
+			want += ".tar.gz"
+		}
+		if got := tgt.Archive(testVersion); got != want {
+			t.Errorf("expects %s, the release publishes %s", got, want)
+		}
+	}
+}
+
+func TestDistTagKeepsAPrereleaseOffLatest(t *testing.T) {
+	for _, c := range []struct{ version, want string }{
+		{"0.19.0", "latest"},
+		{"v0.19.0", "latest"},
+		{"1.0.0", "latest"},
+		// npm hands whatever carries latest to a bare npx mcpsnoop. A release
+		// candidate published there reaches everyone, and the version cannot
+		// be replaced afterwards.
+		{"0.20.0-rc.1", "next"},
+		{"v0.20.0-rc.1", "next"},
+		{"1.0.0-beta.3", "next"},
+		{"0.19.0-next.20260823", "next"},
+	} {
+		if got := DistTag(c.version); got != c.want {
+			t.Errorf("DistTag(%q) = %q, want %q", c.version, got, c.want)
+		}
+	}
+}
+
+func TestTheNpmLicenceIsTheProjectLicence(t *testing.T) {
+	// npm wants a licence file inside the package, so the root package carries
+	// its own copy and the six platform packages get that copy stamped into
+	// them. Two files that must stay the same word for word, and only one of
+	// them is the one anybody edits.
+	repo, err := os.ReadFile(filepath.Join("..", "..", "LICENSE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shipped, err := os.ReadFile(filepath.Join(source(t), "LICENSE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(repo, shipped) {
+		t.Error("npm/mcpsnoop/LICENSE has drifted from LICENSE, so npm would ship different terms from the repository")
+	}
+}

--- a/internal/proxy/endpoint.go
+++ b/internal/proxy/endpoint.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"net/url"
+	"strings"
+)
+
+// strippedValue marks a part of an endpoint mcpsnoop removed before writing it
+// down. It is deliberately not redactedValue: that placeholder means a
+// --redact-secrets, --redact-key, --redact-value or --redact-path rule matched,
+// and a reader who is running with none of those and sees it would be right to
+// call it a bug. This removal happens either way.
+const strippedValue = "[stripped]"
+
+// EndpointForLog renders an MCP endpoint URL for the session log with the parts
+// that could carry a credential removed by construction rather than by pattern.
+//
+// The Streamable HTTP transport says a server "MUST provide a single HTTP
+// endpoint path (hereafter referred to as the MCP endpoint)", so that URL
+// identifies an HTTP server the way argv identifies a stdio one, and an HTTP
+// capture that does not record it cannot say what it captured. The label is not
+// a substitute, because it defaults to the target host alone and two proxies
+// pointed at two paths of one host produce the same one.
+//
+// Writing the URL down verbatim is what needs care. Redaction is off unless
+// asked for, so a target carrying ?api_key=... would reach the log of every user
+// who never turned it on, and this is not a payload they chose to send but a
+// flag they had to pass to run the proxy at all. Three parts go and the rest
+// stays, since a reader still has to tell two endpoints apart.
+//
+//   - Userinfo goes whole and leaves a marker behind. A password is never
+//     anything else, and Basic credentials routinely put the key in the user
+//     half, so keeping either half keeps the secret.
+//   - Query values go and their keys stay. The key is what distinguishes two
+//     endpoints of one host, and the value is where a token hides. Telling an
+//     api_key from a region needs a denylist, and a denylist fails open.
+//   - The fragment goes because it never reaches the server. RFC 3986 makes it
+//     client-side and Go builds the forwarded request line from path and query
+//     alone, so dropping it records what was actually on the wire.
+//
+// An empty string means there was nothing safe to record, which is also what a
+// target with no host gives, matching the condition the http command already
+// uses to decide a target is usable at all.
+func EndpointForLog(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		// Unparseable is not a reason to fall back to the original bytes. Whatever
+		// is in there is precisely what could not be inspected.
+		return ""
+	}
+	var b strings.Builder
+	if u.Scheme != "" {
+		b.WriteString(u.Scheme)
+		b.WriteString("://")
+	}
+	if u.User != nil {
+		b.WriteString(strippedValue)
+		b.WriteByte('@')
+	}
+	b.WriteString(u.Host)
+	b.WriteString(u.EscapedPath())
+	if q := stripQueryValues(u.RawQuery); q != "" {
+		b.WriteByte('?')
+		b.WriteString(q)
+	}
+	return b.String()
+}
+
+// stripQueryValues rewrites each value of a raw query in place, walking the
+// bytes rather than round-tripping through url.Values. Encode sorts its keys and
+// re-escapes what it emits, so a round trip would reorder and respell a query
+// the user typed, and this only has to change the halves after the equals signs.
+func stripQueryValues(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	parts := strings.Split(rawQuery, "&")
+	for i, part := range parts {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok || value == "" {
+			continue // a bare key carries no value to remove
+		}
+		parts[i] = key + "=" + strippedValue
+	}
+	return strings.Join(parts, "&")
+}

--- a/internal/proxy/endpoint_test.go
+++ b/internal/proxy/endpoint_test.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEndpointForLogKeepsIdentityAndDropsCredentials pins what an HTTP session
+// log is allowed to say about its endpoint. Redaction is off unless the user
+// asks for it, so anything this keeps is kept for everyone.
+func TestEndpointForLogKeepsIdentityAndDropsCredentials(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "https://api.example.com/mcp", "https://api.example.com/mcp"},
+		{"port and path survive", "http://localhost:3000/v1/mcp", "http://localhost:3000/v1/mcp"},
+		{"userinfo leaves a marker", "https://user:pw@api.example.com/mcp", "https://[stripped]@api.example.com/mcp"},
+		{"user only is still a credential", "https://sk-live-abc@api.example.com/mcp", "https://[stripped]@api.example.com/mcp"},
+		{"query keys stay, values go", "https://h/mcp?api_key=sk-live-abc&tenant=acme", "https://h/mcp?api_key=[stripped]&tenant=[stripped]"},
+		{"an empty value has nothing to remove", "https://h/mcp?debug=", "https://h/mcp?debug="},
+		{"a bare key has no value", "https://h/mcp?debug", "https://h/mcp?debug"},
+		{"the fragment goes", "https://h/mcp#token", "https://h/mcp"},
+		{"everything at once", "https://u:p@h:8443/mcp?k=v#f", "https://[stripped]@h:8443/mcp?k=[stripped]"},
+		{"an escaped path stays escaped", "https://h/a%20b/mcp", "https://h/a%20b/mcp"},
+		{"no host is not an endpoint", "/mcp", ""},
+		{"empty is empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"unparseable records nothing", "http://[::1", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EndpointForLog(tc.in); got != tc.want {
+				t.Fatalf("EndpointForLog(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEndpointForLogNeverEchoesASecret is the property the table above is a
+// sample of. A value is a secret whatever it is spelled like, so no input that
+// carries one may come back out, including one shaped like the marker itself.
+func TestEndpointForLogNeverEchoesASecret(t *testing.T) {
+	const secret = "sk-live-do-not-log-me"
+	for _, in := range []string{
+		"https://" + secret + "@h/mcp",
+		"https://u:" + secret + "@h/mcp",
+		"https://h/mcp?token=" + secret,
+		"https://h/mcp?a=1&token=" + secret + "&b=2",
+		"https://h/mcp#" + secret,
+		"https://h/mcp?x=[stripped]&token=" + secret,
+	} {
+		if got := EndpointForLog(in); strings.Contains(got, secret) {
+			t.Fatalf("EndpointForLog(%q) = %q, which still carries the secret", in, got)
+		}
+	}
+}

--- a/internal/proxy/frame.go
+++ b/internal/proxy/frame.go
@@ -32,9 +32,23 @@ const (
 
 // SessionMeta describes a proxied session so it can be replayed later (even from
 // a backfilled log). It travels as the first envelope of a session.
+//
+// It grows by adding optional fields and never by changing what an existing one
+// means, because a reader of an old log has to keep working and a reader of a
+// new log has to survive an mcpsnoop that predates the field. Which fields a
+// session has is therefore what says how it was captured, not a version number.
 type SessionMeta struct {
+	// Command and CWD describe a stdio session, and are what a replay runs. Both
+	// are empty on HTTP, where mcpsnoop launched nothing.
 	Command []string `json:"command"`
 	CWD     string   `json:"cwd,omitempty"`
+	// Target is the MCP endpoint of an HTTP session, with userinfo, query values
+	// and the fragment removed by EndpointForLog. Empty on stdio, and empty on an
+	// HTTP log captured before mcpsnoop recorded it, which is the same absence a
+	// reader has to handle either way. It is not dialable and is not meant to be:
+	// it identifies the endpoint for a reader, and a replay that wants to reach it
+	// takes the address from the person running the replay.
+	Target string `json:"target,omitempty"`
 }
 
 // MCPParamHeader is one custom tool-parameter header observed on an HTTP

--- a/internal/proxy/frame.go
+++ b/internal/proxy/frame.go
@@ -104,6 +104,35 @@ type Envelope struct {
 	// response header worth keeping verbatim: a 401 without it is a dead end,
 	// and with it names the scheme and the resource metadata to go to next.
 	AuthChallenge string `json:"auth_challenge,omitempty"`
+	// TransportHeaders carries the Streamable HTTP headers the transport
+	// specification makes normative, which are the ones a conformance check can
+	// be written against. Nil on stdio, and nil on a log captured before mcpsnoop
+	// recorded them, which is what keeps reading an old log from reporting every
+	// frame in it for a header nobody ever wrote down.
+	TransportHeaders *TransportHeaders `json:"transport_headers,omitempty"`
+}
+
+// TransportHeaders are the spec-mandated Streamable HTTP headers of one frame.
+// A closed list drawn from normative clauses, not a general header dump: someone
+// who wants every header wants mitmproxy, and this exists so `check` can gate on
+// rules the transport actually states.
+//
+// Authorization is deliberately absent. Decoding a challenge into token facts is
+// its own problem and putting a bearer token on disk is not the answer to it.
+// Mcp-Session-Id and Last-Event-ID are absent too: 2026-07-28 removed both, and
+// tells a server to ignore them, so there is no rule left to check.
+type TransportHeaders struct {
+	// Accept is the client's Accept header. The client MUST list both
+	// application/json and text/event-stream on a POST.
+	Accept string `json:"accept,omitempty"`
+	// ContentType is the frame's own Content-Type, the request's on a client
+	// frame and the response's on a server one. A server answering a JSON-RPC
+	// request MUST return one of the same two types.
+	ContentType string `json:"content_type,omitempty"`
+	// Origin is the request's Origin. Servers MUST validate it and MUST answer
+	// 403 when it is invalid, which mcpsnoop cannot judge without knowing the
+	// allowed set, so this is recorded for the reader rather than checked.
+	Origin string `json:"origin,omitempty"`
 }
 
 // RPCError is the JSON-RPC error object.

--- a/internal/proxy/header.go
+++ b/internal/proxy/header.go
@@ -52,3 +52,42 @@ func DecodeHeaderValue(value string) (string, bool) {
 	}
 	return "", false
 }
+
+// EncodeHeaderValue renders a value for a routing header, wrapping it in the
+// Base64 sentinel when it cannot travel as it stands.
+//
+// This is the other half of DecodeHeaderValue and it exists for the one caller
+// that has to build a header rather than read one: a replay derives Mcp-Name
+// from the body it is about to send, because the header "MUST match" that body
+// and a value copied from the capture would not when the body has been edited.
+//
+// The rule is the transport's. A field value may hold only visible ASCII, space
+// and tab, so anything outside that set is wrapped, and so is a value with
+// leading or trailing whitespace, which a reader would strip. A plain value that
+// happens to spell the sentinel is wrapped too, for the same reason the decoder
+// only unwraps once: left alone it would decode into something the body never
+// said.
+func EncodeHeaderValue(value string) string {
+	if needsSentinel(value) {
+		return Base64SentinelPrefix + base64.StdEncoding.EncodeToString([]byte(value)) + Base64SentinelSuffix
+	}
+	return value
+}
+
+func needsSentinel(value string) bool {
+	if value == "" {
+		return false
+	}
+	if strings.TrimSpace(value) != value {
+		return true
+	}
+	if strings.HasPrefix(value, Base64SentinelPrefix) && strings.HasSuffix(value, Base64SentinelSuffix) {
+		return true
+	}
+	for i := range len(value) {
+		if c := value[i]; c != '\t' && (c < 0x20 || c > 0x7e) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/jsonwire"
 )
 
 // HTTPConfig configures a transparent MCP streamable-HTTP proxy run.
@@ -108,9 +110,21 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 	// because it is no longer greater. A capture that lost nothing then fails
 	// check --fail-on incomplete.
 	var (
-		seqMu sync.Mutex
-		seq   uint64
+		seqMu    sync.Mutex
+		seq      uint64
+		metaSent bool
 	)
+	// The meta frame is built once here and emitted on the first observed frame
+	// rather than at startup, so a proxy nobody has called yet leaves a zero-byte
+	// log. ResolveSessionPath skips those on purpose: a bare check or export means
+	// the last real capture, and a listener started an hour ago and never used is
+	// the newest file in the directory. Emitting eagerly would put one line in it
+	// and walk straight back into the bug that skip exists for.
+	//
+	// jsonwire, because this and RunStdio's copy are the only Envelope.Raw the
+	// proxy builds instead of copying, and a target containing & would otherwise be
+	// the one escaped frame in an otherwise verbatim log.
+	metaRaw, metaErr := jsonwire.Marshal(SessionMeta{Target: EndpointForLog(cfg.Target)})
 	return func(dir Direction, body []byte, r route) {
 		raw, text := splitObserved(body)
 		env := Envelope{
@@ -136,6 +150,25 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 		}
 		seqMu.Lock()
 		defer seqMu.Unlock()
+		// Under the same lock as the frame it precedes, so the meta reaches the sink
+		// first and takes seq 1 with no window for a second goroutine to claim it.
+		// Its timestamp is the frame's own, since the frame read the clock before
+		// taking the lock and a later reading here would order seq 1 after seq 2.
+		if !metaSent {
+			metaSent = true
+			if metaErr == nil {
+				seq++
+				sink.Emit(Envelope{
+					SessionID:   cfg.SessionID,
+					ServerLabel: cfg.Label,
+					Seq:         seq,
+					TS:          env.TS,
+					Direction:   DirectionMeta,
+					Transport:   TransportHTTP,
+					Raw:         metaRaw,
+				})
+			}
+		}
 		seq++
 		env.Seq = seq
 		sink.Emit(env)

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -226,24 +227,51 @@ func observeBody(emit func(Direction, []byte, route), dir Direction, observed []
 	emitFrames(emit, dir, observed, rt)
 }
 
+// appendForwardedFor reproduces what a Director-based ReverseProxy did on its
+// own: add this hop to the client's X-Forwarded-For chain rather than replace
+// it. Rewrite strips the inbound value before it is called, so without this the
+// target would stop seeing where a request came from.
+func appendForwardedFor(r *httputil.ProxyRequest) {
+	hop, _, err := net.SplitHostPort(r.In.RemoteAddr)
+	if err != nil {
+		return // no address to add, which is not a reason to invent one
+	}
+	if prior := r.In.Header.Values("X-Forwarded-For"); len(prior) > 0 {
+		hop = strings.Join(prior, ", ") + ", " + hop
+	}
+	r.Out.Header.Set("X-Forwarded-For", hop)
+}
+
 // httpProxyHandler builds the reverse-proxy handler that taps request and
 // response bodies. Exposed (unexported) for testing with httptest.
 func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http.Handler {
 	rp := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = target.Scheme
-			req.URL.Host = target.Host
-			req.Host = target.Host
+		// Rewrite rather than the deprecated Director, and deliberately not
+		// SetXForwarded. This proxy sits in the real data path, so a migration off
+		// a deprecated hook has to leave the target seeing exactly what it saw
+		// before. Rewrite's own defaults do not: it strips the client's
+		// X-Forwarded-* headers, and SetXForwarded would replace the forwarding
+		// chain with this one hop and invent an X-Forwarded-Host and
+		// X-Forwarded-Proto the target never used to receive.
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.Out.URL.Scheme = target.Scheme
+			r.Out.URL.Host = target.Host
+			r.Out.Host = target.Host
 			if target.Path != "" && target.Path != "/" {
-				req.URL.Path = target.Path
+				r.Out.URL.Path = target.Path
 			}
+			// Rewrite drops query parameters net/url cannot parse. Dropping part of
+			// a request is the one thing a transparent proxy must not do, so the
+			// query the client wrote is put back verbatim.
+			r.Out.URL.RawQuery = r.In.URL.RawQuery
 			// mcpsnoop has to read the response body to observe it, so it must not
 			// arrive compressed. Force identity rather than let the client's gzip
 			// preference reach the target and turn every observed frame into noise.
 			// identity is always acceptable to the client.
-			req.Header.Set("Accept-Encoding", "identity")
+			r.Out.Header.Set("Accept-Encoding", "identity")
+			appendForwardedFor(r)
 			// The routing headers are not hop-by-hop, so the reverse proxy forwards
-			// them to the target verbatim; the Director leaves them untouched.
+			// them to the target verbatim; nothing here touches them.
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			// The status and the challenge ride every frame observed on this

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -101,13 +100,22 @@ const wwwAuthenticateHeader = "WWW-Authenticate"
 
 // newHTTPEmitter returns an emit function bound to a session and sink.
 func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
-	var seq atomic.Uint64
+	// The lock is held across the emit, not just the increment, the same way
+	// RunStdio holds one. An atomic counter makes every Seq distinct but says
+	// nothing about the order they reach the sink in, and two concurrent requests
+	// arriving as 6 then 5 make the store's gap detector infer a dropped frame:
+	// it advances lastSeq to 6, counts five missing, and then ignores 5 entirely
+	// because it is no longer greater. A capture that lost nothing then fails
+	// check --fail-on incomplete.
+	var (
+		seqMu sync.Mutex
+		seq   uint64
+	)
 	return func(dir Direction, body []byte, r route) {
 		raw, text := splitObserved(body)
 		env := Envelope{
 			SessionID:          cfg.SessionID,
 			ServerLabel:        cfg.Label,
-			Seq:                seq.Add(1),
 			TS:                 time.Now(),
 			Direction:          dir,
 			Transport:          TransportHTTP,
@@ -126,6 +134,10 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 		if raw != nil {
 			env.Raw = append([]byte(nil), raw...)
 		}
+		seqMu.Lock()
+		defer seqMu.Unlock()
+		seq++
+		env.Seq = seq
 		sink.Emit(env)
 	}
 }
@@ -247,6 +259,16 @@ func appendForwardedFor(r *httputil.ProxyRequest) {
 	r.Out.Header.Set("X-Forwarded-For", hop)
 }
 
+// joinChallenges keeps every WWW-Authenticate line a response carried. Get
+// returns only the first, so a server offering Bearer alongside DPoP lost half
+// of what it said, on the one response header this proxy keeps verbatim because
+// a 401 without it is a dead end. RFC 9110 makes several field lines equivalent
+// to one comma-joined line, so a reader parses the join exactly as it would have
+// parsed the lines.
+func joinChallenges(values []string) string {
+	return strings.Join(values, ", ")
+}
+
 // httpProxyHandler builds the reverse-proxy handler that taps request and
 // response bodies. Exposed (unexported) for testing with httptest.
 func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http.Handler {
@@ -283,7 +305,7 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 			// response, so the transport layer is visible even when the body is not.
 			rt := route{
 				status:    resp.StatusCode,
-				challenge: resp.Header.Get(wwwAuthenticateHeader),
+				challenge: joinChallenges(resp.Header.Values(wwwAuthenticateHeader)),
 				// Read a few lines below to pick the SSE branch, and until now
 				// discarded afterwards, so nothing could check the rule it decides.
 				headers: &TransportHeaders{ContentType: resp.Header.Get("Content-Type")},

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -88,6 +88,10 @@ type route struct {
 	truncated bool   // the observed copy was cut at the frame-size cap
 	status    int    // HTTP status of the response carrying this frame
 	challenge string // WWW-Authenticate on that response
+	// headers are the spec-mandated transport headers of this frame. A pointer so
+	// a frame mcpsnoop captured with none is distinguishable from a log written
+	// before it recorded them at all.
+	headers *TransportHeaders
 }
 
 // wwwAuthenticateHeader carries the challenge on a 401. It is kept verbatim
@@ -117,6 +121,7 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 			Truncated:          r.truncated,
 			Status:             r.status,
 			AuthChallenge:      r.challenge,
+			TransportHeaders:   r.headers,
 		}
 		if raw != nil {
 			env.Raw = append([]byte(nil), raw...)
@@ -276,7 +281,13 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 		ModifyResponse: func(resp *http.Response) error {
 			// The status and the challenge ride every frame observed on this
 			// response, so the transport layer is visible even when the body is not.
-			rt := route{status: resp.StatusCode, challenge: resp.Header.Get(wwwAuthenticateHeader)}
+			rt := route{
+				status:    resp.StatusCode,
+				challenge: resp.Header.Get(wwwAuthenticateHeader),
+				// Read a few lines below to pick the SSE branch, and until now
+				// discarded afterwards, so nothing could check the rule it decides.
+				headers: &TransportHeaders{ContentType: resp.Header.Get("Content-Type")},
+			}
 			if resp.Request != nil {
 				rt.conn = resp.Request.RemoteAddr
 			}
@@ -337,8 +348,13 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 				method:          r.Header.Get(mcpMethodHeader),
 				name:            r.Header.Get(mcpNameHeader),
 				protocolVersion: r.Header.Get(mcpProtocolVersionHeader),
-				params:          mcpParamHeaders(r.Header),
-				conn:            r.RemoteAddr,
+				headers: &TransportHeaders{
+					Accept:      r.Header.Get("Accept"),
+					ContentType: r.Header.Get("Content-Type"),
+					Origin:      r.Header.Get("Origin"),
+				},
+				params: mcpParamHeaders(r.Header),
+				conn:   r.RemoteAddr,
 			}
 			// Same streaming tap for the request body, so a large upload is forwarded
 			// without being held in memory whole.

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -843,3 +844,118 @@ func TestProxyCapturesTheSpecMandatedHeaders(t *testing.T) {
 		t.Fatalf("an envelope with nothing captured is not nil: %+v", got)
 	}
 }
+
+// TestProxyKeepsEveryAuthChallenge. AuthChallenge is the one response header
+// this proxy keeps verbatim, because a 401 without it is a dead end. Reading it
+// with Header.Get kept only the first line, so a server offering DPoP beside
+// Bearer had half its answer dropped before anything could read it.
+func TestProxyKeepsEveryAuthChallenge(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("WWW-Authenticate", `Bearer realm="mcp", resource_metadata="https://x/.well-known/oauth-protected-resource"`)
+		w.Header().Add("WWW-Authenticate", `DPoP algs="ES256"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"unauthorized"}}`)
+	}))
+	defer target.Close()
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var challenge string
+	front := httptest.NewServer(httpProxyHandler(u, func(dir Direction, _ []byte, rt route) {
+		if dir == ServerToClient && rt.challenge != "" {
+			challenge = rt.challenge
+		}
+	}))
+	defer front.Close()
+
+	req, err := http.NewRequest(http.MethodPost, front.URL+"/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	for _, want := range []string{"Bearer", "resource_metadata", "DPoP", "ES256"} {
+		if !strings.Contains(challenge, want) {
+			t.Errorf("the captured challenge lost %q: %q", want, challenge)
+		}
+	}
+}
+
+// TestHTTPFramesReachTheSinkInSequenceOrder. An atomic counter makes every Seq
+// distinct but says nothing about the order frames reach the sink in. Two
+// concurrent requests arriving as 6 then 5 make the store's gap detector infer a
+// dropped frame, and a capture that lost nothing then fails check --fail-on
+// incomplete. RunStdio has held a lock across the emit for this reason since it
+// hit the same thing.
+func TestHTTPFramesReachTheSinkInSequenceOrder(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer target.Close()
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	var seen []uint64
+	// The sink is deliberately slow. Holding the lock across the emit serializes
+	// these by construction, while releasing it after the increment lets every
+	// waiting goroutine pile into the sink at once, so the reorder is reliable
+	// rather than a race the test has to be lucky to catch.
+	emit := newHTTPEmitter(HTTPConfig{SessionID: "s1", Label: "l"}, &orderSink{fn: func(e Envelope) {
+		time.Sleep(time.Millisecond)
+		mu.Lock()
+		seen = append(seen, e.Seq)
+		mu.Unlock()
+	}})
+	front := httptest.NewServer(httpProxyHandler(u, emit))
+	defer front.Close()
+
+	var wg sync.WaitGroup
+	for i := range 60 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodPost, front.URL+"/mcp",
+				strings.NewReader(`{"jsonrpc":"2.0","id":`+strconv.Itoa(i)+`,"method":"ping"}`))
+			if err != nil {
+				return
+			}
+			if resp, err := http.DefaultClient.Do(req); err == nil {
+				resp.Body.Close()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The store's own gap arithmetic, run over the order the sink actually saw.
+	var last, missing uint64
+	for _, s := range seen {
+		if s > last {
+			if expected := last + 1; s > expected {
+				missing += s - expected
+			}
+			last = s
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("a capture that lost nothing reports %d missing frames out of %d, arrival order %v",
+			missing, len(seen), seen)
+	}
+}
+
+type orderSink struct{ fn func(Envelope) }
+
+func (o *orderSink) Emit(e Envelope) { o.fn(e) }
+func (o *orderSink) Close() error    { return nil }

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -687,3 +687,84 @@ func TestHTTPDoesNotInventAFailureOnClientCancellation(t *testing.T) {
 		t.Fatalf("a client hanging up is not a target failure, got status %d", env.Status)
 	}
 }
+
+// TestProxyForwardsTheRequestUnchanged pins what the target actually receives.
+// mcpsnoop sits in the real data path and CONTRIBUTING calls that transparency
+// invariant, so this exists to make any change to the forwarding path, including
+// a mechanical one like migrating off a deprecated hook, prove it altered
+// nothing. Only Accept-Encoding is deliberately rewritten, because an observer
+// cannot read a compressed body.
+func TestProxyForwardsTheRequestUnchanged(t *testing.T) {
+	var got *http.Request
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Clone(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer target.Close()
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var conns []string
+	front := httptest.NewServer(httpProxyHandler(u, func(_ Direction, _ []byte, rt route) {
+		if rt.conn != "" {
+			conns = append(conns, rt.conn)
+		}
+	}))
+	defer front.Close()
+
+	req, err := http.NewRequest(http.MethodPost, front.URL+"/mcp?a=1&raw=%zz&b=2",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Method", "ping")
+	req.Header.Set("Origin", "http://localhost:1234")
+	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if got == nil {
+		t.Fatal("the target was never reached")
+	}
+	if got.Host != u.Host {
+		t.Fatalf("Host = %q, want the target's %q", got.Host, u.Host)
+	}
+	// The routing headers and everything else the client wrote arrive verbatim.
+	for header, want := range map[string]string{
+		"Accept":          "application/json, text/event-stream",
+		"Mcp-Method":      "ping",
+		"Origin":          "http://localhost:1234",
+		"Accept-Encoding": "identity",
+	} {
+		if got := got.Header.Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+	// This hop is appended to whatever chain the client sent rather than replacing
+	// it, and no X-Forwarded-Host or X-Forwarded-Proto is invented.
+	if xff := got.Header.Get("X-Forwarded-For"); !strings.HasPrefix(xff, "203.0.113.9, ") {
+		t.Errorf("X-Forwarded-For = %q, want the client's chain with this hop appended", xff)
+	}
+	for _, invented := range []string{"X-Forwarded-Host", "X-Forwarded-Proto", "Forwarded"} {
+		if v := got.Header.Get(invented); v != "" {
+			t.Errorf("%s = %q, a header the target never used to see", invented, v)
+		}
+	}
+	// A query the net/url parser rejects still reaches the target, since dropping
+	// part of a request is exactly what a transparent proxy must not do.
+	if got.URL.RawQuery != "a=1&raw=%zz&b=2" {
+		t.Errorf("RawQuery = %q, want it forwarded byte for byte", got.URL.RawQuery)
+	}
+	// The observed frames carry the client's address, which is what keeps two
+	// clients that both start at JSON-RPC id 1 in separate id spaces.
+	if len(conns) == 0 || conns[0] == "" {
+		t.Fatalf("no frame carried a connection identity: %v", conns)
+	}
+}

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -768,3 +768,78 @@ func TestProxyForwardsTheRequestUnchanged(t *testing.T) {
 		t.Fatalf("no frame carried a connection identity: %v", conns)
 	}
 }
+
+// TestProxyCapturesTheSpecMandatedHeaders. check already gates on routing
+// headers, but the rest of the transport's mandatory headers reached no frame,
+// so no signal could be written against them. Content-Type was the sharpest
+// case: the response side already read it to pick the SSE branch and then threw
+// it away.
+func TestProxyCapturesTheSpecMandatedHeaders(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer target.Close()
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []Envelope
+	front := httptest.NewServer(httpProxyHandler(u, func(dir Direction, body []byte, rt route) {
+		got = append(got, Envelope{Direction: dir, TransportHeaders: rt.headers})
+	}))
+	defer front.Close()
+
+	req, err := http.NewRequest(http.MethodPost, front.URL+"/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:1234")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	var request, response *TransportHeaders
+	for _, e := range got {
+		if e.Direction == ClientToServer {
+			request = e.TransportHeaders
+		} else {
+			response = e.TransportHeaders
+		}
+	}
+	if request == nil {
+		t.Fatal("the client frame carried no transport headers")
+	}
+	for field, want := range map[string]string{
+		"Accept":      "application/json, text/event-stream",
+		"ContentType": "application/json",
+		"Origin":      "http://localhost:1234",
+	} {
+		var got string
+		switch field {
+		case "Accept":
+			got = request.Accept
+		case "ContentType":
+			got = request.ContentType
+		case "Origin":
+			got = request.Origin
+		}
+		if got != want {
+			t.Errorf("%s = %q, want %q", field, got, want)
+		}
+	}
+	if response == nil || response.ContentType != "application/json" {
+		t.Fatalf("the response frame did not carry its Content-Type: %+v", response)
+	}
+	// A pointer, not a value, so a log written before this existed stays
+	// distinguishable from a request that genuinely carried none.
+	if got := (&Envelope{}).TransportHeaders; got != nil {
+		t.Fatalf("an envelope with nothing captured is not nil: %+v", got)
+	}
+}

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -959,3 +960,119 @@ type orderSink struct{ fn func(Envelope) }
 
 func (o *orderSink) Emit(e Envelope) { o.fn(e) }
 func (o *orderSink) Close() error    { return nil }
+
+// TestHTTPEmitterWritesNothingUntilTheFirstFrame is the reason the meta frame is
+// built at startup but emitted lazily. ResolveSessionPath skips zero-byte logs so
+// that a bare check or export means the last real capture rather than a listener
+// somebody started and never called, and that listener is always the newest file
+// in the sessions directory. Emitting eagerly would put a line in it and defeat
+// the skip.
+func TestHTTPEmitterWritesNothingUntilTheFirstFrame(t *testing.T) {
+	sink := &captureSink{}
+	emit := newHTTPEmitter(HTTPConfig{SessionID: "s", Label: "l", Target: "https://h/mcp"}, sink)
+
+	if got := len(sink.byDir(DirectionMeta)); got != 0 {
+		t.Fatalf("an idle proxy emitted %d meta frames, want 0", got)
+	}
+
+	emit(ClientToServer, []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`), route{})
+
+	meta := sink.byDir(DirectionMeta)
+	if len(meta) != 1 {
+		t.Fatalf("meta frames after the first request = %d, want 1", len(meta))
+	}
+	if meta[0].Seq != 1 {
+		t.Fatalf("meta Seq = %d, want 1, since the store reads the session from the frame before the traffic", meta[0].Seq)
+	}
+	if meta[0].Transport != TransportHTTP {
+		t.Fatalf("meta Transport = %q, want %q", meta[0].Transport, TransportHTTP)
+	}
+	if meta[0].SessionID != "s" || meta[0].ServerLabel != "l" {
+		t.Fatalf("meta identity = %q/%q, want s/l", meta[0].SessionID, meta[0].ServerLabel)
+	}
+
+	first := sink.byDir(ClientToServer)
+	if len(first) != 1 || first[0].Seq != 2 {
+		t.Fatalf("first traffic frame = %+v, want one frame at Seq 2", first)
+	}
+	// The meta borrows the frame's own timestamp rather than reading the clock
+	// under the lock. The frame reads it before locking, so a second reading here
+	// would always be later and seq 1 would sort after seq 2.
+	if !meta[0].TS.Equal(first[0].TS) {
+		t.Fatalf("meta TS %v is not the frame's own %v", meta[0].TS, first[0].TS)
+	}
+
+	emit(ServerToClient, []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`), route{})
+	if got := len(sink.byDir(DirectionMeta)); got != 1 {
+		t.Fatalf("meta frames after a second request = %d, want it emitted exactly once", got)
+	}
+}
+
+// TestHTTPEmitterRecordsTheStrippedEndpoint checks the bytes that actually reach
+// the log, not just EndpointForLog's return value, since the meta frame is the
+// only place a target is written down and redaction is off by default.
+func TestHTTPEmitterRecordsTheStrippedEndpoint(t *testing.T) {
+	sink := &captureSink{}
+	emit := newHTTPEmitter(HTTPConfig{SessionID: "s", Target: "https://u:sk-live-secret@api.example.com:8443/mcp?api_key=sk-live-secret&tenant=acme#frag"}, sink)
+	emit(ClientToServer, []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`), route{})
+
+	meta := sink.byDir(DirectionMeta)
+	if len(meta) != 1 {
+		t.Fatalf("meta frames = %d, want 1", len(meta))
+	}
+	if strings.Contains(string(meta[0].Raw), "sk-live-secret") {
+		t.Fatalf("the log carries the credential: %s", meta[0].Raw)
+	}
+	var got SessionMeta
+	if err := json.Unmarshal(meta[0].Raw, &got); err != nil {
+		t.Fatalf("meta frame is not a SessionMeta: %v", err)
+	}
+	const want = "https://[stripped]@api.example.com:8443/mcp?api_key=[stripped]&tenant=[stripped]"
+	if got.Target != want {
+		t.Fatalf("Target = %q, want %q", got.Target, want)
+	}
+	if len(got.Command) != 0 || got.CWD != "" {
+		t.Fatalf("an HTTP session recorded a command to run: %+v", got)
+	}
+}
+
+// TestHTTPTargetFragmentReachesNeitherTheServerNorTheLog pins the assumption
+// behind dropping the fragment, which is that it was never on the wire to begin
+// with. If Go ever forwarded it, dropping it would be losing something.
+func TestHTTPTargetFragmentReachesNeitherTheServerNorTheLog(t *testing.T) {
+	seen := make(chan string, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case seen <- r.URL.RequestURI() + "|" + r.URL.Fragment:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer backend.Close()
+
+	targetURL := backend.URL + "/mcp#never-sent"
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &captureSink{}
+	front := httptest.NewServer(httpProxyHandler(target, newHTTPEmitter(HTTPConfig{SessionID: "s", Target: targetURL}, sink)))
+	defer front.Close()
+
+	resp, err := http.Post(front.URL+"/mcp", "application/json", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	got := <-seen
+	if strings.Contains(got, "never-sent") {
+		t.Fatalf("the backend saw the fragment in %q, so dropping it from the log loses what was on the wire", got)
+	}
+	meta := sink.byDir(DirectionMeta)
+	if len(meta) != 1 || strings.Contains(string(meta[0].Raw), "never-sent") {
+		t.Fatalf("meta = %+v, want exactly one frame with no fragment", meta)
+	}
+}

--- a/internal/replay/http.go
+++ b/internal/replay/http.go
@@ -1,0 +1,391 @@
+package replay
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// HTTPTarget is where a replayed request goes and what it carries besides the
+// body.
+//
+// URL comes from whoever is replaying, never from the capture. What a capture
+// records is the endpoint with its userinfo and every query value removed, on
+// purpose, so it identifies the server without being an address to dial. A
+// replay reaches a live server, which may be the production one, so the person
+// asking for it says where it goes.
+type HTTPTarget struct {
+	URL string
+	// Headers are extra request headers as "Name: value". They are applied last,
+	// so a caller can override anything below, and they are how a credential
+	// reaches the request. mcpsnoop never records one and never replays one.
+	Headers []string
+}
+
+// Routing is the request metadata a captured frame carried, re-sent verbatim.
+//
+// The transport makes these mandatory: Mcp-Method on every request, Mcp-Name on
+// tools/call, resources/read and prompts/get, and one Mcp-Param-{Name} per
+// parameter a tool annotated with x-mcp-header. A server rejects a mismatch with
+// 400 and -32020, so a POST of the bare captured body gets an error rather than
+// a result.
+//
+// Verbatim matters. A value outside the safe ASCII set travels Base64-wrapped in
+// the =?base64?…?= sentinel, and the capture holds whatever the client sent, so
+// re-sending it needs no encoder and cannot disagree with what the body says.
+type Routing struct {
+	// Name is the Mcp-Name the capture carried. It is a fallback: the header is
+	// derived from the body actually being sent, because the transport says it
+	// "MUST match" that body and an edit can change what the body names. The
+	// captured value is used only when the body names nothing, which is what a
+	// capture from a client that predates this revision looks like.
+	Name         string
+	ParamHeaders []proxy.MCPParamHeader
+	// Edited says the person replaying rewrote the params. The captured
+	// Mcp-Param-* headers mirror the captured arguments, so against a body
+	// somebody rewrote they assert something mcpsnoop cannot know is still true.
+	Edited bool
+}
+
+// methodsNeedingName are the requests the transport marks Mcp-Name REQUIRED for.
+var methodsNeedingName = map[string]struct{}{
+	"tools/call":     {},
+	"resources/read": {},
+	"prompts/get":    {},
+}
+
+// ReplayHTTP re-issues one captured request as an HTTP POST against target.
+//
+// It sends exactly one request. The transport makes every message its own POST
+// and this revision has no handshake to perform, so there is nothing to
+// negotiate first: the request describes itself in its own _meta, which
+// withClientMeta builds, and in the headers that mirror it.
+func ReplayHTTP(ctx context.Context, target HTTPTarget, method string, params json.RawMessage, routing Routing, timeout time.Duration) (Result, error) {
+	if strings.TrimSpace(target.URL) == "" {
+		return Result{}, errors.New("replay: no target to send to, pass --replay-target")
+	}
+	if _, err := url.Parse(target.URL); err != nil {
+		return Result{}, fmt.Errorf("replay: invalid target %q: %w", target.URL, err)
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	// A redacted header value is mcpsnoop's placeholder, not the client's data.
+	// Sending it would put that placeholder on a live server as though a user had
+	// typed it, and omitting it would produce a header mismatch the server reports
+	// as the client's fault. Refusing says which it is.
+	for _, h := range routing.ParamHeaders {
+		if h.Redacted {
+			return Result{}, fmt.Errorf("replay: %s was scrubbed by redaction in this capture, so there is nothing to re-send; replay from an unredacted capture", h.Name)
+		}
+	}
+
+	body := withClientMeta(params)
+	frame := map[string]any{"jsonrpc": "2.0", "id": 1, "method": method, "params": body}
+	encoded, err := json.Marshal(frame)
+	if err != nil {
+		return Result{}, fmt.Errorf("replay: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.URL, bytes.NewReader(encoded))
+	if err != nil {
+		return Result{}, fmt.Errorf("replay: %w", err)
+	}
+	applyReplayHeaders(req, method, body, routing, target.Headers)
+
+	start := time.Now()
+	resp, err := replayClient.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("replay: %w", err)
+	}
+	defer resp.Body.Close()
+
+	out := Result{Method: method, Params: body}
+	raw, err := readReplayResponse(resp)
+	out.Duration = time.Since(start)
+	if err != nil {
+		return out, err
+	}
+	out.Response = raw
+
+	var msg struct {
+		Result json.RawMessage `json:"result"`
+		Error  *proxy.RPCError `json:"error"`
+	}
+	// Both halves. Valid JSON that carries neither a result nor an error is not a
+	// response to anything, and reporting it as ok let a proxy's own success page
+	// read as the server having answered.
+	if json.Unmarshal(raw, &msg) != nil || (len(msg.Result) == 0 && msg.Error == nil) {
+		return out, fmt.Errorf("replay: the server answered something that is not a JSON-RPC response: %s", clip(raw))
+	}
+	out.RPCResult, out.Err = msg.Result, msg.Error
+	out.ToolErr = isToolError(msg.Result)
+	return out, nil
+}
+
+// applyReplayHeaders sets what the transport requires of every POST, then
+// whatever the caller asked for, so a caller can override any of it.
+func applyReplayHeaders(req *http.Request, method string, body json.RawMessage, routing Routing, extra []string) {
+	req.Header.Set("Content-Type", "application/json")
+	// Both types, because the client "MUST include an Accept header listing both
+	// application/json and text/event-stream", and a server may answer either.
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	// Derived from what withClientMeta put in the body, never copied from the
+	// capture. The header value "MUST match the io.modelcontextprotocol/protocolVersion
+	// field carried in the request body's _meta", and the body is rebuilt here, so
+	// echoing the captured revision would disagree with it by construction.
+	req.Header.Set("MCP-Protocol-Version", statelessProtocolVersion)
+	req.Header.Set("Mcp-Method", method)
+	if _, needs := methodsNeedingName[method]; needs {
+		if name := mcpName(body, routing.Name); name != "" {
+			req.Header.Set("Mcp-Name", name)
+		}
+	}
+	if !routing.Edited {
+		for _, h := range routing.ParamHeaders {
+			// Only the family the annotations produce. A capture is a file people hand
+			// around, and setting whatever name it carries let a doctored one overwrite
+			// the mandatory headers above, or add an Authorization the operator never
+			// passed.
+			if !strings.HasPrefix(textproto.CanonicalMIMEHeaderKey(h.Name), mcpParamPrefix) {
+				continue
+			}
+			req.Header.Set(h.Name, h.Value)
+		}
+	}
+	for _, h := range extra {
+		name, value, ok := strings.Cut(h, ":")
+		if !ok {
+			continue
+		}
+		req.Header.Set(strings.TrimSpace(name), strings.TrimSpace(value))
+	}
+}
+
+// mcpParamPrefix is the header family a tool's x-mcp-header annotations produce,
+// in the spelling net/http canonicalises to.
+const mcpParamPrefix = "Mcp-Param-"
+
+// mcpName is the operation the request names, taken from the body being sent.
+//
+// The transport sources this header from "params.name or params.uri", and
+// requires a server to reject a header that disagrees with the body. So it is
+// derived rather than copied: an edit that renames the tool would otherwise send
+// the captured name against a body naming another, which is exactly the mismatch
+// the server is told to refuse. The captured value is the fallback for a body
+// that names nothing.
+func mcpName(body json.RawMessage, captured string) string {
+	var params struct {
+		Name string `json:"name"`
+		URI  string `json:"uri"`
+	}
+	if json.Unmarshal(body, &params) == nil {
+		if params.Name != "" {
+			return proxy.EncodeHeaderValue(params.Name)
+		}
+		if params.URI != "" {
+			return proxy.EncodeHeaderValue(params.URI)
+		}
+	}
+	return captured
+}
+
+// readReplayResponse reads whichever of the two shapes the server chose.
+//
+// A request is answered with "either Content-Type: application/json (a single
+// JSON object) or Content-Type: text/event-stream (an SSE response stream)", and
+// on a stream "the final JSON-RPC response SHOULD terminate the stream", with
+// request-scoped notifications before it. A replay wants the response, so the
+// notifications are read past.
+func readReplayResponse(resp *http.Response) (json.RawMessage, error) {
+	if resp.StatusCode != http.StatusOK {
+		return nil, statusError(resp)
+	}
+	// Compared case-insensitively. A media type is case-insensitive in HTTP and Go
+	// canonicalises header names but never values, so a server spelling it
+	// Text/Event-Stream sent a perfectly legal answer that was then parsed as one
+	// JSON object and reported as garbage.
+	if isEventStream(resp.Header.Get("Content-Type")) {
+		return readSSEResponse(resp.Body)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxReplayBody+1))
+	if err != nil {
+		return nil, fmt.Errorf("replay: %w", err)
+	}
+	if len(raw) > maxReplayBody {
+		// Said rather than handed over cut in half. A truncated body is not a server
+		// that answered nonsense, and blaming it for one would send somebody looking
+		// in the wrong place.
+		return nil, fmt.Errorf("replay: the answer is larger than the %d MiB a replay will hold, so it was not read", maxReplayBody>>20)
+	}
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("replay: the server answered %d with an empty body", resp.StatusCode)
+	}
+	return json.RawMessage(raw), nil
+}
+
+// isEventStream reports whether a Content-Type names the streamed shape,
+// ignoring case and any parameters after the type itself.
+func isEventStream(contentType string) bool {
+	media, _, _ := strings.Cut(contentType, ";")
+	return strings.EqualFold(strings.TrimSpace(media), "text/event-stream")
+}
+
+// maxReplayBody bounds what one replayed answer may hand back, since the overlay
+// that renders it holds it in memory and the server on the other end is not
+// mcpsnoop's.
+const maxReplayBody = 8 << 20
+
+// replayClient refuses to follow a redirect.
+//
+// The address a replay posts to is the one the person replaying named and
+// answered for, and following a redirect hands that choice back to the far end.
+// Go's default client would resend the body and, on a hop that only changes the
+// port, the Authorization header too, so a staging endpoint answering 307 could
+// deliver a mutating tools/call and a credential to production while the overlay
+// reported success and never named the host that answered. A 301, 302 or 303
+// would additionally rewrite the POST into a bodiless GET.
+//
+// So the hop is reported instead, with the address it wanted, and the person
+// decides whether to name that one.
+var replayClient = &http.Client{
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// statusError turns a non-200 into a message that says what to do about it.
+//
+// The transport distinguishes these, so the reader is told which one happened
+// rather than being handed a number. A 400 is where a modern server reports a
+// header or version problem, which is exactly what a replay gets wrong, and a
+// 404 with a JSON-RPC body is an unknown method rather than a wrong address.
+func statusError(resp *http.Response) error {
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxReplayBody))
+	raw = bytes.TrimSpace(raw)
+	var msg struct {
+		Error *proxy.RPCError `json:"error"`
+	}
+	modern := json.Unmarshal(raw, &msg) == nil && msg.Error != nil
+
+	switch {
+	case isRedirect(resp.StatusCode):
+		to := resp.Header.Get("Location")
+		if to == "" {
+			to = "somewhere it did not name"
+		}
+		return fmt.Errorf("replay: %s answered %d redirecting to %s, and a replay goes only where you named; pass --replay-target %s if that is where you meant to send it",
+			resp.Request.URL.Redacted(), resp.StatusCode, to, to)
+	case resp.StatusCode == http.StatusUnauthorized:
+		challenge := strings.Join(resp.Header.Values("WWW-Authenticate"), ", ")
+		if challenge == "" {
+			return errors.New("replay: the server answered 401 and named no scheme; pass a credential with --replay-header")
+		}
+		return fmt.Errorf("replay: the server answered 401 demanding %s; pass a credential with --replay-header", challenge)
+	case modern && msg.Error.Code == headerMismatchCode:
+		return fmt.Errorf("replay: the server rejected the request metadata: %s", msg.Error.Message)
+	case modern:
+		return fmt.Errorf("replay: the server answered %d with %s", resp.StatusCode, msg.Error.Message)
+	case resp.StatusCode == http.StatusBadRequest, resp.StatusCode == http.StatusNotFound,
+		resp.StatusCode == http.StatusMethodNotAllowed:
+		// The era test the transport prescribes, run the other way round from the
+		// stdio one. A modern server answers these with a JSON-RPC error, so a body
+		// that is not one means the address is not a modern MCP endpoint.
+		return fmt.Errorf("replay: %s answered %d with no JSON-RPC error, so it is not a Streamable HTTP MCP endpoint of this revision",
+			resp.Request.URL.Redacted(), resp.StatusCode)
+	case len(raw) == 0:
+		return fmt.Errorf("replay: the server answered %d with an empty body", resp.StatusCode)
+	default:
+		return fmt.Errorf("replay: the server answered %d: %s", resp.StatusCode, clip(raw))
+	}
+}
+
+// headerMismatchCode is what a server returns when the mirrored headers and the
+// body disagree, which is the failure a replay is most likely to cause.
+const headerMismatchCode = -32020
+
+// isRedirect covers the codes a client would otherwise follow.
+func isRedirect(code int) bool {
+	switch code {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
+		http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		return true
+	}
+	return false
+}
+
+// readSSEResponse reads an event stream until the JSON-RPC response arrives.
+func readSSEResponse(r io.Reader) (json.RawMessage, error) {
+	scanner := bufio.NewScanner(io.LimitReader(r, maxReplayBody))
+	scanner.Buffer(make([]byte, 0, 64<<10), maxReplayBody)
+	var data []byte
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		switch {
+		case len(bytes.TrimSpace(line)) == 0:
+			// End of one event. A response terminates the stream; anything else is a
+			// request-scoped notification and is read past.
+			if len(data) > 0 {
+				if isRPCResponse(data) {
+					return json.RawMessage(append([]byte(nil), data...)), nil
+				}
+				data = data[:0]
+			}
+		case bytes.HasPrefix(line, []byte(":")):
+			// A comment, which servers send as a keep-alive. Ignored, as the spec says.
+		case bytes.HasPrefix(line, []byte("data:")):
+			chunk := bytes.TrimPrefix(line, []byte("data:"))
+			chunk = bytes.TrimPrefix(chunk, []byte(" "))
+			if len(data) > 0 {
+				data = append(data, '\n')
+			}
+			data = append(data, chunk...)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("replay: reading the response stream: %w", err)
+	}
+	if len(data) > 0 && isRPCResponse(data) {
+		return json.RawMessage(data), nil
+	}
+	return nil, errors.New("replay: the response stream ended without a JSON-RPC response")
+}
+
+// isRPCResponse reports whether a stream event is the answer rather than one of
+// the notifications that precede it.
+func isRPCResponse(data []byte) bool {
+	var msg struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal(data, &msg) != nil {
+		return false
+	}
+	return msg.Method == "" && len(msg.ID) > 0 && (len(msg.Result) > 0 || len(msg.Error) > 0)
+}
+
+// clip bounds a server's answer when it goes into an error message, since it is
+// a stranger's bytes and the message is read in a terminal.
+func clip(raw []byte) string {
+	const limit = 200
+	if len(raw) <= limit {
+		return string(raw)
+	}
+	return string(raw[:limit]) + "…"
+}

--- a/internal/replay/http_test.go
+++ b/internal/replay/http_test.go
@@ -1,0 +1,506 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// mcpEndpoint is a server that enforces what the transport makes mandatory, so a
+// replay missing any of it gets the error a real server would send rather than a
+// result.
+func mcpEndpoint(t *testing.T, answer func(w http.ResponseWriter, seen http.Header, msg map[string]json.RawMessage)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		var method string
+		_ = json.Unmarshal(msg["method"], &method)
+		reject := func(message string) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1,
+				"error": map[string]any{"code": -32020, "message": message}})
+		}
+		switch {
+		case r.Header.Get("MCP-Protocol-Version") == "":
+			reject("missing MCP-Protocol-Version")
+		case r.Header.Get("Mcp-Method") != method:
+			reject("Mcp-Method does not match the body")
+		case !strings.Contains(r.Header.Get("Accept"), "application/json") ||
+			!strings.Contains(r.Header.Get("Accept"), "text/event-stream"):
+			reject("Accept must list both types")
+		default:
+			answer(w, r.Header, msg)
+		}
+	}))
+}
+
+func okJSON(w http.ResponseWriter, text string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1,
+		"result": map[string]any{"content": []any{map[string]any{"type": "text", "text": text}}}})
+}
+
+// TestReplayHTTPSendsWhatTheTransportRequires is the whole point: a POST of the
+// bare captured body gets a -32020, not a result, so the replay carries the
+// request metadata the specification makes mandatory.
+func TestReplayHTTPSendsWhatTheTransportRequires(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	res, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo","arguments":{"text":"hi"}}`),
+		Routing{Name: "echo", ParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}}},
+		5*time.Second)
+	if err != nil {
+		t.Fatalf("replay failed: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("the server answered an error: %+v", res.Err)
+	}
+	for name, want := range map[string]string{
+		"Mcp-Method":           "tools/call",
+		"Mcp-Name":             "echo",
+		"Mcp-Param-Region":     "us-west1",
+		"Mcp-Protocol-Version": statelessProtocolVersion,
+		"Content-Type":         "application/json",
+	} {
+		if got := seen.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+	if accept := seen.Get("Accept"); !strings.Contains(accept, "application/json") || !strings.Contains(accept, "text/event-stream") {
+		t.Fatalf("Accept = %q, want both types", accept)
+	}
+}
+
+// TestReplayHTTPDeclaresTheRevisionItActuallySends covers the one header that
+// cannot be copied from the capture. withClientMeta rewrites the body's
+// protocolVersion, and the header "MUST match" it, so echoing what the capture
+// declared would disagree with the body by construction.
+func TestReplayHTTPDeclaresTheRevisionItActuallySends(t *testing.T) {
+	var header, body string
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, msg map[string]json.RawMessage) {
+		header = h.Get("MCP-Protocol-Version")
+		var params struct {
+			Meta struct {
+				Version string `json:"io.modelcontextprotocol/protocolVersion"`
+			} `json:"_meta"`
+		}
+		_ = json.Unmarshal(msg["params"], &params)
+		body = params.Meta.Version
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	// The captured body declares an older revision, which withClientMeta replaces.
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo","_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}`),
+		Routing{Name: "echo"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if header != body {
+		t.Fatalf("header says %q and the body says %q; a server rejects that with -32020", header, body)
+	}
+	if header != statelessProtocolVersion {
+		t.Fatalf("declared %q, want the revision the replay actually speaks", header)
+	}
+}
+
+// TestReplayHTTPReadsAStreamedAnswer covers the other shape a server may choose,
+// where request-scoped notifications precede the response.
+func TestReplayHTTPReadsAStreamedAnswer(t *testing.T) {
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, ":\r\n\r\n") // a keep-alive comment, which clients must ignore
+		fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{}}\n\n")
+		fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"streamed\"}]}}\n\n")
+	})
+	defer srv.Close()
+
+	res, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Err != nil {
+		t.Fatalf("error: %+v", res.Err)
+	}
+	if !strings.Contains(string(res.RPCResult), "streamed") {
+		t.Fatalf("the answer was not read past the notifications: %s", res.RPCResult)
+	}
+}
+
+// TestReplayHTTPNamesWhatWentWrong covers the failures a replay is most likely
+// to cause, so a reader is told what to do rather than handed a status code.
+func TestReplayHTTPNamesWhatWentWrong(t *testing.T) {
+	t.Run("a credential is missing", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="https://h/.well-known/x"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "--replay-header") {
+			t.Fatalf("err = %v, want it to name the way to send one", err)
+		}
+		if !strings.Contains(err.Error(), "Bearer") {
+			t.Fatalf("err = %v, want the scheme the server demanded", err)
+		}
+	})
+
+	t.Run("the address is not an MCP endpoint", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}))
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "not a Streamable HTTP MCP endpoint") {
+			t.Fatalf("err = %v, want it to say the address is wrong", err)
+		}
+	})
+
+	t.Run("the server rejected the metadata", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1,
+				"error": map[string]any{"code": -32020, "message": "Mcp-Name does not match"}})
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "rejected the request metadata") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("no target", func(t *testing.T) {
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{}, "tools/call", nil, Routing{}, time.Second)
+		if err == nil || !strings.Contains(err.Error(), "--replay-target") {
+			t.Fatalf("err = %v, want it to name the flag", err)
+		}
+	})
+}
+
+// TestReplayHTTPRefusesToSendAPlaceholder keeps mcpsnoop's own scrubbing off a
+// live server. A redacted header value is not the client's data, and sending it
+// would put that placeholder on the server as though a user had typed it.
+func TestReplayHTTPRefusesToSendAPlaceholder(t *testing.T) {
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+		t.Error("the request should never have been sent")
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`),
+		Routing{Name: "echo", ParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Token", Value: "[REDACTED]", Redacted: true}}},
+		5*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "scrubbed by redaction") {
+		t.Fatalf("err = %v, want a refusal naming the reason", err)
+	}
+}
+
+// TestReplayHTTPCarriesACallerHeader is how a credential reaches the server,
+// since mcpsnoop records none and replays none.
+func TestReplayHTTPCarriesACallerHeader(t *testing.T) {
+	var auth string
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		auth = h.Get("Authorization")
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL, Headers: []string{"Authorization: Bearer sk-test"}},
+		"tools/call", json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if auth != "Bearer sk-test" {
+		t.Fatalf("Authorization = %q", auth)
+	}
+}
+
+// TestReplayHTTPSendsMcpNameOnlyWhereItIsRequired keeps a header off a request
+// the transport does not ask it for.
+func TestReplayHTTPSendsMcpNameOnlyWhereItIsRequired(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/list",
+		json.RawMessage(`{}`), Routing{Name: "leftover"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := seen.Get("Mcp-Name"); got != "" {
+		t.Fatalf("Mcp-Name = %q on tools/list, which the transport does not require it for", got)
+	}
+	if got := seen.Get("Mcp-Method"); got != "tools/list" {
+		t.Fatalf("Mcp-Method = %q", got)
+	}
+}
+
+// TestReplayHTTPDeclaresEveryRequiredMetaField covers the body, which the header
+// tests do not. From this revision clientCapabilities is required on every
+// request and clientInfo is not, and a request missing a required field is
+// malformed: the server "MUST reject it with JSON-RPC error code -32602" and
+// answer 400. mcpsnoop's own checker reports a client that omits it, so leaving
+// it out meant flagging its own replayed request.
+func TestReplayHTTPDeclaresEveryRequiredMetaField(t *testing.T) {
+	var meta map[string]json.RawMessage
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, msg map[string]json.RawMessage) {
+		var params struct {
+			Meta map[string]json.RawMessage `json:"_meta"`
+		}
+		_ = json.Unmarshal(msg["params"], &params)
+		meta = params.Meta
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		"io.modelcontextprotocol/protocolVersion",
+		"io.modelcontextprotocol/clientCapabilities",
+	} {
+		if _, ok := meta[field]; !ok {
+			t.Fatalf("_meta is missing %s, which the revision requires on every request: %v", field, meta)
+		}
+	}
+	if got := string(meta["io.modelcontextprotocol/clientCapabilities"]); got != "{}" {
+		t.Fatalf("clientCapabilities = %s, want an empty declaration; a one-shot replay can answer no input request", got)
+	}
+}
+
+// TestReplayHTTPWillNotFollowARedirect is the safety property the whole design
+// rests on. The address is the one the person replaying named and answered for,
+// and following a redirect hands that choice back to the far end: a 307 resends
+// the body, and on a hop that only changes the port Go forwards Authorization
+// too, so a staging endpoint could deliver a mutating call and a credential to
+// production while the overlay reported success.
+func TestReplayHTTPWillNotFollowARedirect(t *testing.T) {
+	var reached string
+	var sawAuth string
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = r.Host
+		sawAuth = r.Header.Get("Authorization")
+		okJSON(w, "reached the wrong host")
+	}))
+	defer second.Close()
+
+	for _, code := range []int{301, 302, 303, 307, 308} {
+		t.Run(fmt.Sprintf("%d", code), func(t *testing.T) {
+			reached, sawAuth = "", ""
+			first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Location", second.URL)
+				w.WriteHeader(code)
+			}))
+			defer first.Close()
+
+			_, err := ReplayHTTP(context.Background(),
+				HTTPTarget{URL: first.URL, Headers: []string{"Authorization: Bearer sk-secret", "X-Api-Key: k-secret"}},
+				"tools/call", json.RawMessage(`{"name":"echo","arguments":{"t":"private"}}`),
+				Routing{Name: "echo"}, 5*time.Second)
+			if err == nil {
+				t.Fatal("a redirect was followed and reported as a success")
+			}
+			if reached != "" {
+				t.Fatalf("the request reached %s, which nobody named; auth forwarded = %q", reached, sawAuth)
+			}
+			if !strings.Contains(err.Error(), "--replay-target") {
+				t.Fatalf("err = %v, want it to name where it wanted to go and how to allow it", err)
+			}
+		})
+	}
+}
+
+// TestReplayHTTPDerivesMcpNameFromTheBody covers the header the transport
+// sources from "params.name or params.uri" and requires a server to reject when
+// it disagrees with the body. Copying the captured one sent the old name against
+// a body somebody had renamed, and sent nothing at all for a capture from a
+// client that predates the header.
+func TestReplayHTTPDerivesMcpNameFromTheBody(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		method   string
+		params   string
+		captured string
+		want     string
+	}{
+		{"the body names the tool", "tools/call", `{"name":"renamed"}`, "captured", "renamed"},
+		{"a capture that carried none", "tools/call", `{"name":"echo"}`, "", "echo"},
+		{"a resource names its uri", "resources/read", `{"uri":"file:///a.txt"}`, "", "file:///a.txt"},
+		{"a body naming nothing falls back", "tools/call", `{}`, "captured", "captured"},
+		{"a name outside plain ascii is wrapped", "tools/call", `{"name":"Hello, 世界"}`, "", "=?base64?SGVsbG8sIOS4lueVjA==?="},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen string
+			srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+				seen = h.Get("Mcp-Name")
+				okJSON(w, "ok")
+			})
+			defer srv.Close()
+			if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, tc.method,
+				json.RawMessage(tc.params), Routing{Name: tc.captured}, 5*time.Second); err != nil {
+				t.Fatal(err)
+			}
+			if seen != tc.want {
+				t.Fatalf("Mcp-Name = %q, want %q", seen, tc.want)
+			}
+		})
+	}
+}
+
+// TestReplayHTTPOnlySetsTheParamFamilyFromACapture keeps a log from choosing the
+// request's headers. A capture is a file people hand around, and setting
+// whatever name it carries let a doctored one overwrite the mandatory headers or
+// add a credential the operator never passed.
+func TestReplayHTTPOnlySetsTheParamFamilyFromACapture(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo", ParamHeaders: []proxy.MCPParamHeader{
+			{Name: "Mcp-Param-Region", Value: "us-west1"},
+			{Name: "Authorization", Value: "Bearer stolen"},
+			{Name: "MCP-Protocol-Version", Value: "1999-01-01"},
+			{Name: "Accept", Value: "text/plain"},
+			{Name: "Mcp-Method", Value: "tools/list"},
+		}}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := seen.Get("Mcp-Param-Region"); got != "us-west1" {
+		t.Fatalf("the family that should be replayed was dropped: %q", got)
+	}
+	for name, notWant := range map[string]string{
+		"Authorization":        "Bearer stolen",
+		"MCP-Protocol-Version": "1999-01-01",
+		"Accept":               "text/plain",
+		"Mcp-Method":           "tools/list",
+	} {
+		if seen.Get(name) == notWant {
+			t.Fatalf("a capture set %s to %q", name, notWant)
+		}
+	}
+}
+
+// TestReplayHTTPDropsMirroredHeadersOnAnEditedBody keeps a stale assertion off
+// the request. An Mcp-Param-* mirrors a captured argument, so against a body
+// somebody rewrote it claims something mcpsnoop cannot know is still true.
+func TestReplayHTTPDropsMirroredHeadersOnAnEditedBody(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo","arguments":{"region":"eu-west1"}}`),
+		Routing{Name: "echo", Edited: true,
+			ParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}}},
+		5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := seen.Get("Mcp-Param-Region"); got != "" {
+		t.Fatalf("Mcp-Param-Region = %q, want none; the body was rewritten and the header mirrors the old one", got)
+	}
+	// The name is still derived, since it comes from the body being sent.
+	if got := seen.Get("Mcp-Name"); got != "echo" {
+		t.Fatalf("Mcp-Name = %q", got)
+	}
+}
+
+// TestReplayHTTPNamesAnAnswerItCannotUse covers the shapes that used to be
+// reported as a success or blamed on the wrong thing.
+func TestReplayHTTPNamesAnAnswerItCannotUse(t *testing.T) {
+	t.Run("valid json that is not a response", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","message":"proxy says hello"}`))
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "not a JSON-RPC response") {
+			t.Fatalf("err = %v, want it to say the answer is not a response", err)
+		}
+	})
+
+	t.Run("an empty body", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "empty body") {
+			t.Fatalf("err = %v, want it to name the empty body", err)
+		}
+	})
+
+	t.Run("a stream whose media type is spelled differently", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "Text/Event-Stream; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[]}}\n\n")
+		})
+		defer srv.Close()
+		res, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err != nil {
+			t.Fatalf("a media type is case-insensitive: %v", err)
+		}
+		if res.Err != nil {
+			t.Fatalf("error: %+v", res.Err)
+		}
+	})
+
+	t.Run("an answer past the cap", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"`))
+			chunk := strings.Repeat("x", 64<<10)
+			for range (maxReplayBody / len(chunk)) + 2 {
+				_, _ = w.Write([]byte(chunk))
+			}
+			_, _ = w.Write([]byte(`"}]}}`))
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 20*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "larger than") {
+			t.Fatalf("err = %v, want the size named rather than the server blamed for a cut body", err)
+		}
+	})
+}

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -25,6 +25,7 @@ type Result struct {
 	Response  json.RawMessage // raw response frame
 	RPCResult json.RawMessage
 	Err       *proxy.RPCError
+	ToolErr   bool // tools/call result.isError == true
 	Duration  time.Duration
 }
 
@@ -133,8 +134,20 @@ func Replay(ctx context.Context, command []string, cwd, method string, params js
 		Response:  resp,
 		RPCResult: msg.Result,
 		Err:       msg.Error,
+		ToolErr:   method == "tools/call" && isToolError(msg.Result),
 		Duration:  dur,
 	}, nil
+}
+
+// isToolError mirrors the store's own definition of a tool-level error, kept
+// here because the two packages are peers and neither imports the other. Change
+// one and check the other, or a replayed call and the captured call it came from
+// will disagree about the same bytes.
+func isToolError(result json.RawMessage) bool {
+	var r struct {
+		IsError bool `json:"isError"`
+	}
+	return json.Unmarshal(result, &r) == nil && r.IsError
 }
 
 // withClientMeta adds the self-describing _meta a stateless server expects,

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -170,6 +170,18 @@ func withClientMeta(params json.RawMessage) json.RawMessage {
 	meta["io.modelcontextprotocol/protocolVersion"] = json.RawMessage(strconv.Quote(statelessProtocolVersion))
 	meta["io.modelcontextprotocol/clientInfo"] = json.RawMessage(
 		fmt.Sprintf(`{"name":%q,"version":"dev"}`, clientName))
+	// Required on every request from this revision, unlike clientInfo, which is
+	// not. A request missing a required field is malformed and the server "MUST
+	// reject it with JSON-RPC error code -32602", answering 400 over HTTP, so
+	// leaving it out made every replay fail against a conforming server. The
+	// store's own checker reports a client that omits it, which is to say
+	// mcpsnoop was flagging its own replayed request.
+	//
+	// An empty object is the honest declaration rather than a placeholder. It says
+	// this client has nothing to offer, which is true of a one-shot replay: it
+	// cannot answer an input request, and a server is told not to rely on a
+	// capability nobody declared.
+	meta["io.modelcontextprotocol/clientCapabilities"] = json.RawMessage(`{}`)
 
 	// jsonwire on all three marshals in this file: these carry captured params
 	// back to a live server, and the replay overlay renders what is built here.

--- a/internal/replay/replay_test.go
+++ b/internal/replay/replay_test.go
@@ -53,6 +53,8 @@ func handle(line []byte) {
 		if req.Params.Name == "echo" {
 			time.Sleep(120 * time.Millisecond)
 			out["result"] = map[string]any{"content": []map[string]string{{"type": "text", "text": "echo: " + req.Params.Arguments.Text}}}
+		} else if req.Params.Name == "tool-error" {
+			out["result"] = map[string]any{"content": []map[string]string{{"type": "text", "text": "bad argument"}}, "isError": true}
 		} else {
 			out["error"] = map[string]any{"code": -32601, "message": "unknown tool: " + req.Params.Name}
 		}
@@ -190,6 +192,20 @@ func TestReplayToolError(t *testing.T) {
 	}
 }
 
+func TestReplayToolResultError(t *testing.T) {
+	res, err := Replay(context.Background(), []string{demoBin}, "",
+		"tools/call", json.RawMessage(`{"name":"tool-error"}`), 10*time.Second)
+	if err != nil {
+		t.Fatalf("Replay transport error: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("tool-level error must not become a JSON-RPC error: %+v", res.Err)
+	}
+	if !res.ToolErr {
+		t.Fatalf("result.isError was not classified: %s", res.RPCResult)
+	}
+}
+
 func TestReplayEmptyCommand(t *testing.T) {
 	if _, err := Replay(context.Background(), nil, "", "tools/list", nil, time.Second); err == nil {
 		t.Fatal("expected error for empty command")
@@ -222,7 +238,7 @@ func TestReadResponseRejectsMalformedResponse(t *testing.T) {
 // the initialize error and carry on rather than giving up or hanging.
 func TestReplayAgainstStatelessServer(t *testing.T) {
 	res, err := Replay(context.Background(), []string{statelessBin}, "",
-		"tools/call", json.RawMessage(`{"name":"echo","arguments":{"text":"hi"}}`), 10*time.Second)
+		"tools/call", json.RawMessage(`{"name":"echo","arguments":{"text":"hi"},"_meta":{"progressToken":"p-7"}}`), 10*time.Second)
 	if err != nil {
 		t.Fatalf("Replay: %v", err)
 	}
@@ -233,6 +249,12 @@ func TestReplayAgainstStatelessServer(t *testing.T) {
 	// proves the request described itself.
 	if !strings.Contains(string(res.RPCResult), "stateless echo "+statelessProtocolVersion) {
 		t.Fatalf("result missing the self-describing metadata: %s", res.RPCResult)
+	}
+	if !strings.Contains(string(res.Params), statelessProtocolVersion) {
+		t.Fatalf("Result.Params must be the actual wire params with injected metadata: %s", res.Params)
+	}
+	if !strings.Contains(string(res.Params), `"progressToken":"p-7"`) {
+		t.Fatalf("injected metadata must preserve captured _meta values: %s", res.Params)
 	}
 }
 

--- a/internal/store/conformance.go
+++ b/internal/store/conformance.go
@@ -63,8 +63,10 @@ func wrongDirectionWarning(dir proxy.Direction, msg proxy.RPCMessage, stateless 
 
 // inputRequiredWarnings reports what an InputRequiredResult breaks. c is the
 // request it answers, nil when mcpsnoop never saw that half, in which case the
-// method rule cannot be decided and stays silent.
-func inputRequiredWarnings(state inputRequired, c *call) []string {
+// method rule cannot be decided and stays silent. redacted says the frame passed
+// through mcpsnoop's own redaction, which is what makes the placeholder below
+// trustworthy as a placeholder rather than a name a server chose.
+func inputRequiredWarnings(state inputRequired, c *call, redacted bool) []string {
 	var warnings []string
 	if c != nil {
 		if _, allowed := mrtrCapableMethods[c.method]; !allowed {
@@ -79,6 +81,12 @@ func inputRequiredWarnings(state inputRequired, c *call) []string {
 			"and 2026-07-28 requires at least one")
 	}
 	for _, method := range state.methods {
+		// A method name mcpsnoop's own redaction rewrote is unreadable, not wrong.
+		// Reporting it accuses a conforming server of the user's privacy setting on
+		// a signal that fails a default check run.
+		if partlyRedacted(redacted, method) {
+			continue
+		}
 		if _, ok := inputRequestMethods[method]; !ok {
 			warnings = append(warnings, "inputRequests names "+strconv.Quote(method)+
 				", and 2026-07-28 allows only elicitation/create, sampling/createMessage and roots/list")

--- a/internal/store/conformance_test.go
+++ b/internal/store/conformance_test.go
@@ -380,3 +380,43 @@ func TestSubscriptionStreamRules(t *testing.T) {
 		}
 	})
 }
+
+// TestInputRequestsAreUnverifiableAfterRedaction. The method names inside an
+// InputRequiredResult are ordinary string values, so --redact-path and
+// --redact-value reach them. Reading the placeholder as a method the spec does
+// not allow reports a conforming server for the user's own privacy setting, on a
+// signal that fails a default check run.
+func TestInputRequestsAreUnverifiableAfterRedaction(t *testing.T) {
+	answer := func(method string, redacted bool) string {
+		s := New()
+		t0 := time.Now()
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"slow"}`))
+		e := resp(2, t0, proxy.ServerToClient, "1",
+			`"result":{"resultType":"input_required","inputRequests":{"q1":{"method":"`+method+`","params":{}}}}`)
+		e.Redacted = redacted
+		return s.Ingest(e).Warning
+	}
+
+	if got := answer("[REDACTED]", true); got != "" {
+		t.Fatalf("a scrubbed method was reported as a violation: %q", got)
+	}
+	if got := answer("prefix/[REDACTED]", true); got != "" {
+		t.Fatalf("a partly scrubbed method was reported as a violation: %q", got)
+	}
+	// Only mcpsnoop's own rewriting earns that silence. The placeholder is a
+	// string a server may legally send, so a check that stops at those bytes alone
+	// is a check the traffic can switch off.
+	if got := answer("[REDACTED]", false); got == "" {
+		t.Fatal("an unredacted capture spelling the placeholder must still be judged")
+	}
+	// And a real violation is still reported.
+	if got := answer("tools/call", false); got == "" {
+		t.Fatal("a method the spec does not allow in inputRequests went unreported")
+	}
+	// A conforming one stays silent either way.
+	for _, redacted := range []bool{false, true} {
+		if got := answer("elicitation/create", redacted); got != "" {
+			t.Fatalf("a conforming inputRequests was reported (redacted=%v): %q", redacted, got)
+		}
+	}
+}

--- a/internal/store/elicitation.go
+++ b/internal/store/elicitation.go
@@ -1,0 +1,325 @@
+package store
+
+import (
+	"cmp"
+	"encoding/json"
+	"net/url"
+	"slices"
+	"time"
+)
+
+// elicitMethod is the only input request this ledger records. Sampling and roots
+// travel through the same map and are deliberately not rows here: elicitation is
+// the one path where a human types data into a server, which is what makes a
+// record of what was asked worth keeping.
+const elicitMethod = "elicitation/create"
+
+// What one recorded question is allowed to cost. These are held on the call for
+// the life of the session, outside the frame budget that releases bodies, so a
+// server answering every call with an input request would otherwise grow the
+// store by whatever it felt like writing.
+//
+// The limits are generous enough that no real question meets them. A message is
+// prose for a person to read, a url has practical limits everywhere else it is
+// handled, and the specification restricts a form schema to "flat objects with
+// primitive properties only", which is not a thousand of them.
+const (
+	maxElicitMessage = 1 << 10
+	maxElicitURL     = 2 << 10
+	maxElicitFields  = 256
+)
+
+// clip bounds one recorded string and says so, rather than trailing off, so a
+// reader can tell a truncated message from a server that wrote exactly that.
+func clip(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "… (truncated)"
+}
+
+// Elicitation modes. A request that names none is form mode, because the
+// specification says clients "MUST treat requests without a mode field as form
+// mode", so an absent field is a value rather than a gap.
+const (
+	ElicitModeForm = "form"
+	ElicitModeURL  = "url"
+)
+
+// elicitation is one question a server put to the user through the client, and
+// the answer that came back on the retry, if one ever did.
+//
+// It holds the shape of the question and never its answer. The submitted values
+// live in the log for anyone who needs them, and keeping them out of here means
+// no new field can leak what a redaction rule was set to hide, which matters
+// most in url mode, where the specification puts credentials on purpose.
+type elicitation struct {
+	// key is the inputRequests entry this question was filed under, which is also
+	// what pairs it with its inputResponses answer. One result may carry several.
+	key     string
+	mode    string
+	message string
+	// fields are the requestedSchema property names and declared types of a form
+	// mode question. Names and types, never a value or a default.
+	fields []elicitField
+	// target is the url of a url mode question, kept whole because the
+	// specification makes the client "show the full URL to the user for
+	// examination before consent", and host is what it "SHOULD highlight" to
+	// mitigate subdomain spoofing.
+	target string
+	host   string
+	asked  time.Time
+	// action is empty until a retry answers this key, and answered is when it did.
+	action   string
+	answered time.Time
+}
+
+// elicitField is one property of a form mode requestedSchema.
+type elicitField struct {
+	name string
+	// typ is the declared type, or empty when the schema does not declare one.
+	// Redaction can replace a whole subschema with its placeholder string, and a
+	// placeholder is not a type, so this stays empty rather than reporting
+	// mcpsnoop's own scrubbing as something the server said.
+	typ string
+}
+
+// parseElicitations reads the elicitation questions out of one inputRequests
+// map. Entries for any other method are skipped, so a result carrying a
+// sampling/createMessage beside an elicitation/create produces one row.
+//
+// Every field is decoded on its own rather than through one typed struct. A
+// struct fails whole on the first field whose JSON type does not match, and the
+// fields here are not mcpsnoop's to shape: redaction replaces a matched value
+// with a string, so a requestedSchema under a matching key becomes one, and a
+// server is free to send something malformed. Losing the row for that means a
+// capture taken with --redact-secrets can report no elicitation at all, which is
+// a far worse answer than one field reading as unknown.
+func parseElicitations(requests map[string]json.RawMessage, at time.Time) []*elicitation {
+	out := make([]*elicitation, 0, len(requests))
+	for key, raw := range requests {
+		var entry struct {
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if json.Unmarshal(raw, &entry) != nil || entry.Method != elicitMethod {
+			continue
+		}
+		var params struct {
+			Mode            json.RawMessage `json:"mode"`
+			Message         json.RawMessage `json:"message"`
+			URL             json.RawMessage `json:"url"`
+			RequestedSchema json.RawMessage `json:"requestedSchema"`
+		}
+		// Params that are not an object at all still leave a row. The question was
+		// asked, and a reader is better served by knowing that than by a gap.
+		_ = json.Unmarshal(entry.Params, &params)
+
+		e := &elicitation{
+			key:     key,
+			mode:    jsonString(params.Mode),
+			message: clip(jsonString(params.Message), maxElicitMessage),
+			asked:   at,
+		}
+		if e.mode == "" {
+			e.mode = ElicitModeForm
+		}
+		if e.mode == ElicitModeURL {
+			e.target = clip(jsonString(params.URL), maxElicitURL)
+			e.host = urlHost(e.target)
+		} else {
+			e.fields = schemaFields(params.RequestedSchema)
+		}
+		out = append(out, e)
+	}
+	// Sorted, because a map iterates in no order and a ledger is a document people
+	// diff.
+	slices.SortFunc(out, func(a, b *elicitation) int { return cmp.Compare(a.key, b.key) })
+	return out
+}
+
+// jsonString reads a value that should be a string, and answers with nothing
+// when it is not one. A number where a url belongs is a server that is wrong,
+// not a reason to lose the question it asked.
+func jsonString(raw json.RawMessage) string {
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
+		return ""
+	}
+	return s
+}
+
+// schemaFields lists a requestedSchema's property names and declared types.
+//
+// A schema that is not an object yields no fields rather than losing the row it
+// belongs to. That is what a redacted requestedSchema looks like: --redact-secrets
+// replaces the whole value under a matching key, so the schema arrives as the
+// placeholder string.
+func schemaFields(raw json.RawMessage) []elicitField {
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if json.Unmarshal(raw, &schema) != nil || len(schema.Properties) == 0 {
+		return nil
+	}
+	fields := make([]elicitField, 0, min(len(schema.Properties), maxElicitFields))
+	for name, sub := range schema.Properties {
+		field := elicitField{name: name}
+		var declared struct {
+			Type json.RawMessage `json:"type"`
+		}
+		// A subschema that is not an object leaves the type empty, and so does a type
+		// that is not a string. Both are the redacted case: the placeholder replaces
+		// whatever it matched. The name survives, which is the half that carries the
+		// meaning, and reporting the placeholder as a type would present mcpsnoop's
+		// own scrubbing as the server's declaration.
+		if json.Unmarshal(sub, &declared) == nil {
+			field.typ = jsonString(declared.Type)
+		}
+		fields = append(fields, field)
+	}
+	slices.SortFunc(fields, func(a, b elicitField) int { return cmp.Compare(a.name, b.name) })
+	if len(fields) > maxElicitFields {
+		// Sorted first, so which ones survive is the same on every run rather than
+		// whichever the map happened to yield.
+		fields = fields[:maxElicitFields]
+	}
+	return fields
+}
+
+// urlHost is the host of a url mode target, empty when it does not parse. The
+// specification tells a client to highlight it, so a reader gets it named rather
+// than having to find it inside the whole address.
+func urlHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// answer records what a retry said about one key. An action mcpsnoop does not
+// recognise is kept verbatim: the three the specification names are accept,
+// decline and cancel, and a fourth is either a newer revision or a client that
+// is wrong, and both are worth seeing rather than dropping.
+func (e *elicitation) answer(action string, at time.Time) {
+	if e.action != "" || action == "" {
+		return
+	}
+	e.action, e.answered = action, at
+}
+
+// elicitActions reads the action of each inputResponses entry.
+func elicitActions(responses map[string]json.RawMessage) map[string]string {
+	if len(responses) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(responses))
+	for key, raw := range responses {
+		var r struct {
+			Action string `json:"action"`
+		}
+		if json.Unmarshal(raw, &r) == nil && r.Action != "" {
+			out[key] = r.Action
+		}
+	}
+	return out
+}
+
+// ElicitationView is one row of the ledger: a question a server put to the user,
+// and the answer that came back.
+//
+// It carries the shape of the question and never its content. A submitted value
+// is in the log for whoever needs it, and keeping it out of here is what makes
+// the ledger safe to export and pass around whatever redaction was set to.
+type ElicitationView struct {
+	// CallSeq, CallID, Method and ToolName name the operation the question
+	// interrupted, so a row can be traced back to the call it belongs to. Every
+	// round of one operation names the same one. CallSeq is the sequence of the
+	// request frame that opened it, which is what the exporter indexes calls by,
+	// since an id alone is only unique while a call is in flight.
+	CallSeq  uint64
+	CallID   string
+	Method   string
+	ToolName string
+	// Key is the inputRequests entry the question was filed under, and what pairs
+	// it with its answer.
+	Key string
+	// Mode is form or url. A request naming neither is form, which is what the
+	// specification tells a client to assume.
+	Mode    string
+	Message string
+	// Fields are the form mode requestedSchema properties, names and declared
+	// types. Nil in url mode, where there is no form to describe.
+	Fields []ElicitFieldView
+	// URL and Host are the url mode target and the host to highlight. Empty in
+	// form mode.
+	URL  string
+	Host string
+	// Action is what the user did, one of accept, decline or cancel, or whatever
+	// else a client sent. Empty means no retry ever answered this question.
+	Action string
+	// Asked is when the server put the question, Answered when the retry carrying
+	// the answer arrived, and Elapsed the gap, which is roughly how long the human
+	// took. Answered is zero and Elapsed is zero while the question is unanswered.
+	Asked    time.Time
+	Answered time.Time
+	Elapsed  time.Duration
+}
+
+// Pending reports a question no retry ever answered.
+func (e ElicitationView) Pending() bool { return e.Action == "" }
+
+// ElicitFieldView is one requestedSchema property. Type is empty when the schema
+// declared none, which includes a subschema redaction replaced with its
+// placeholder, since a placeholder is not a type the server chose.
+type ElicitFieldView struct {
+	Name string
+	Type string
+}
+
+func (e *elicitation) view(c *call) ElicitationView {
+	out := ElicitationView{
+		CallSeq: c.requestSeq, CallID: c.id, Method: c.method, ToolName: c.toolName,
+		Key: e.key, Mode: e.mode, Message: e.message,
+		URL: e.target, Host: e.host,
+		Action: e.action, Asked: e.asked, Answered: e.answered,
+	}
+	if len(e.fields) > 0 {
+		out.Fields = make([]ElicitFieldView, 0, len(e.fields))
+		for _, f := range e.fields {
+			out.Fields = append(out.Fields, ElicitFieldView{Name: f.name, Type: f.typ})
+		}
+	}
+	if !e.answered.IsZero() {
+		out.Elapsed = e.answered.Sub(e.asked)
+	}
+	return out
+}
+
+// sameElicitRound reports whether a freshly parsed round is the one already
+// recorded, which is how a server resending its InputRequiredResult on one id is
+// told apart from a genuine next round.
+//
+// Compared on what the question is rather than on when it arrived, since a
+// resend carries the same question at a later timestamp.
+func sameElicitRound(recorded, parsed []*elicitation) bool {
+	if len(recorded) == 0 || len(recorded) != len(parsed) {
+		return false
+	}
+	for i, e := range recorded {
+		o := parsed[i]
+		if e.key != o.key || e.mode != o.mode || e.message != o.message || e.target != o.target {
+			return false
+		}
+		if len(e.fields) != len(o.fields) {
+			return false
+		}
+		for j := range e.fields {
+			if e.fields[j] != o.fields[j] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/store/elicitation_test.go
+++ b/internal/store/elicitation_test.go
@@ -1,0 +1,525 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// elicitAsk is one round of an exchange: what the server asked, under which key.
+type elicitAsk struct {
+	key      string
+	request  string // the whole inputRequests entry
+	state    string
+	answer   string // the whole inputResponses entry, empty when never answered
+	askDelay time.Duration
+}
+
+// elicitSession ingests one operation and its rounds, returning the store and
+// the session id. Each round is an InputRequiredResult answered by a retry under
+// a new id, which is what MRTR requires.
+func elicitSession(t *testing.T, tool string, rounds []elicitAsk) (*Store, string) {
+	t.Helper()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s := New()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq := uint64(0)
+	at := t0
+	emit := func(dir proxy.Direction, raw string) {
+		seq++
+		s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: at,
+			Direction: dir, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)})
+	}
+	seq++
+	s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: at,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+
+	id := 1
+	at = at.Add(time.Second)
+	emit(proxy.ClientToServer, fmt.Sprintf(`{"jsonrpc":"2.0","id":"%d","method":"tools/call","params":{"name":%q}}`, id, tool))
+	for _, round := range rounds {
+		at = at.Add(time.Second)
+		state := ""
+		if round.state != "" {
+			state = fmt.Sprintf(`,"requestState":%q`, round.state)
+		}
+		emit(proxy.ServerToClient, fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":"%d","result":{"resultType":"input_required","inputRequests":{%s}%s}}`,
+			id, round.request, state))
+		if round.answer == "" {
+			return s, "s1" // nobody ever retried
+		}
+		at = at.Add(round.askDelay)
+		id++
+		echo := ""
+		if round.state != "" {
+			echo = fmt.Sprintf(`,"requestState":%q`, round.state)
+		}
+		emit(proxy.ClientToServer, fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":"%d","method":"tools/call","params":{"name":%q,"inputResponses":{%s}%s}}`,
+			id, tool, round.answer, echo))
+	}
+	at = at.Add(time.Second)
+	emit(proxy.ServerToClient, fmt.Sprintf(`{"jsonrpc":"2.0","id":"%d","result":{"content":[]}}`, id))
+	return s, "s1"
+}
+
+func elicitReq(key, params string) string {
+	return fmt.Sprintf(`%q:{"method":"elicitation/create","params":%s}`, key, params)
+}
+
+// TestElicitationLedgerPairsQuestionWithAnswer is the whole feature. Under MRTR
+// the question and the answer are fields inside two different requests, and only
+// the retry link ties them together.
+func TestElicitationLedgerPairsQuestionWithAnswer(t *testing.T) {
+	s, id := elicitSession(t, "create_account", []elicitAsk{{
+		key:      "profile",
+		state:    "st-1",
+		request:  elicitReq("profile", `{"mode":"form","message":"Please provide your contact information","requestedSchema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"number"}},"required":["name"]}}`),
+		answer:   `"profile":{"action":"accept","content":{"name":"Monalisa","age":30}}`,
+		askDelay: 9 * time.Second,
+	}})
+
+	rows := s.Elicitations(id)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1: %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.Key != "profile" || row.Mode != ElicitModeForm {
+		t.Fatalf("key %q mode %q", row.Key, row.Mode)
+	}
+	if row.Action != "accept" {
+		t.Fatalf("action = %q, want accept", row.Action)
+	}
+	if row.Elapsed != 9*time.Second {
+		t.Fatalf("elapsed = %v, want 9s of human time", row.Elapsed)
+	}
+	if row.ToolName != "create_account" || row.Method != "tools/call" {
+		t.Fatalf("the row does not name the operation it interrupted: %+v", row)
+	}
+	want := []ElicitFieldView{{Name: "age", Type: "number"}, {Name: "name", Type: "string"}}
+	if len(row.Fields) != 2 || row.Fields[0] != want[0] || row.Fields[1] != want[1] {
+		t.Fatalf("fields = %+v, want %+v", row.Fields, want)
+	}
+	if row.Message != "Please provide your contact information" {
+		t.Fatalf("message = %q", row.Message)
+	}
+}
+
+// TestElicitationNeverCarriesASubmittedValue is the privacy boundary the ledger
+// is built on. The values are in the capture for anyone who needs them, and a
+// summary surface built to be pasted around must not repeat them.
+func TestElicitationNeverCarriesASubmittedValue(t *testing.T) {
+	const secret = "hunter2-do-not-repeat-me"
+	s, id := elicitSession(t, "t", []elicitAsk{{
+		key:     "k",
+		state:   "st",
+		request: elicitReq("k", `{"mode":"form","message":"who are you","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}}}}`),
+		answer:  fmt.Sprintf(`"k":{"action":"accept","content":{"name":%q}}`, secret),
+	}})
+	rendered, err := json.Marshal(s.Elicitations(id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(rendered), secret) {
+		t.Fatalf("a submitted value reached the ledger: %s", rendered)
+	}
+}
+
+// TestElicitationDefaultsToFormMode covers the rule the specification states
+// outright: clients "MUST treat requests without a mode field as form mode", so
+// an absent field is a value rather than a gap.
+func TestElicitationDefaultsToFormMode(t *testing.T) {
+	s, id := elicitSession(t, "t", []elicitAsk{{
+		key:     "k",
+		state:   "st",
+		request: elicitReq("k", `{"message":"no mode named","requestedSchema":{"type":"object","properties":{"ok":{"type":"boolean"}}}}`),
+		answer:  `"k":{"action":"accept"}`,
+	}})
+	rows := s.Elicitations(id)
+	if len(rows) != 1 || rows[0].Mode != ElicitModeForm {
+		t.Fatalf("mode = %q, want form for a request that named none", rows[0].Mode)
+	}
+}
+
+// TestElicitationURLModeCarriesTheAddressAndHost covers what the specification
+// makes a client show. The full url "for examination before consent", and the
+// host it "SHOULD highlight" against subdomain spoofing.
+func TestElicitationURLModeCarriesTheAddressAndHost(t *testing.T) {
+	const target = "https://mcp.example.com/ui/set_api_key?flow=abc123"
+	s, id := elicitSession(t, "sync", []elicitAsk{{
+		key:     "auth",
+		state:   "st",
+		request: elicitReq("auth", fmt.Sprintf(`{"mode":"url","url":%q,"message":"Please provide your API key to continue."}`, target)),
+		answer:  `"auth":{"action":"accept"}`,
+	}})
+	rows := s.Elicitations(id)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Mode != ElicitModeURL || row.URL != target {
+		t.Fatalf("mode %q url %q, want url mode carrying the address whole", row.Mode, row.URL)
+	}
+	if row.Host != "mcp.example.com" {
+		t.Fatalf("host = %q, want the domain named on its own", row.Host)
+	}
+	if len(row.Fields) != 0 {
+		t.Fatalf("a url mode question claimed a form field list: %+v", row.Fields)
+	}
+}
+
+// TestElicitationRecordsEveryAction covers the three the specification names and
+// one it does not. An unrecognised action is either a newer revision or a client
+// that is wrong, and both are worth seeing rather than dropping.
+func TestElicitationRecordsEveryAction(t *testing.T) {
+	for _, action := range []string{"accept", "decline", "cancel", "something-else"} {
+		t.Run(action, func(t *testing.T) {
+			s, id := elicitSession(t, "t", []elicitAsk{{
+				key:     "k",
+				state:   "st",
+				request: elicitReq("k", `{"message":"m","requestedSchema":{"type":"object","properties":{}}}`),
+				answer:  fmt.Sprintf(`"k":{"action":%q}`, action),
+			}})
+			rows := s.Elicitations(id)
+			if len(rows) != 1 || rows[0].Action != action {
+				t.Fatalf("action = %q, want %q recorded verbatim", rows[0].Action, action)
+			}
+			if rows[0].Pending() {
+				t.Fatal("an answered question reads as pending")
+			}
+		})
+	}
+}
+
+// TestElicitationWithNoRetryIsPending covers the outcome MRTR makes ordinary:
+// the specification tells servers they must not assume a client will retry.
+func TestElicitationWithNoRetryIsPending(t *testing.T) {
+	s, id := elicitSession(t, "abandoned", []elicitAsk{{
+		key:     "q",
+		state:   "st",
+		request: elicitReq("q", `{"message":"Still there?","requestedSchema":{"type":"object","properties":{"ok":{"type":"boolean"}}}}`),
+	}})
+	rows := s.Elicitations(id)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want the unanswered question still recorded", len(rows))
+	}
+	row := rows[0]
+	if !row.Pending() || row.Action != "" {
+		t.Fatalf("action = %q, want none", row.Action)
+	}
+	if !row.Answered.IsZero() || row.Elapsed != 0 {
+		t.Fatalf("an unanswered question claims a time: answered %v elapsed %v", row.Answered, row.Elapsed)
+	}
+	if row.Message != "Still there?" {
+		t.Fatalf("the question itself was lost: %+v", row)
+	}
+}
+
+// TestElicitationIgnoresItsSiblings covers a result carrying more than one input
+// request. Sampling and roots travel through the same map and are not questions
+// put to a user, so they are not rows.
+func TestElicitationIgnoresItsSiblings(t *testing.T) {
+	request := strings.Join([]string{
+		elicitReq("auth", `{"mode":"url","url":"https://h/ui","message":"m"}`),
+		`"summarise":{"method":"sampling/createMessage","params":{"messages":[]}}`,
+		`"where":{"method":"roots/list","params":{}}`,
+	}, ",")
+	s, id := elicitSession(t, "t", []elicitAsk{{
+		key: "auth", state: "st", request: request,
+		answer: `"auth":{"action":"accept"},"summarise":{"role":"assistant"},"where":{"roots":[]}`,
+	}})
+	rows := s.Elicitations(id)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want only the elicitation: %+v", len(rows), rows)
+	}
+	if rows[0].Key != "auth" {
+		t.Fatalf("the wrong entry became a row: %+v", rows[0])
+	}
+}
+
+// TestElicitationChainKeepsEveryRoundOnOneCall covers an exchange whose retry is
+// itself answered with another InputRequiredResult. Each round is its own
+// question and all of them belong to the operation that started it.
+func TestElicitationChainKeepsEveryRoundOnOneCall(t *testing.T) {
+	s, id := elicitSession(t, "setup", []elicitAsk{
+		{key: "one", state: "st-1", request: elicitReq("one", `{"message":"first","requestedSchema":{"type":"object","properties":{"a":{"type":"string"}}}}`),
+			answer: `"one":{"action":"accept","content":{"a":"x"}}`, askDelay: 2 * time.Second},
+		{key: "two", state: "st-2", request: elicitReq("two", `{"mode":"url","url":"https://h/second","message":"second"}`),
+			answer: `"two":{"action":"decline"}`, askDelay: 5 * time.Second},
+	})
+	rows := s.Elicitations(id)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want one per round: %+v", len(rows), rows)
+	}
+	if rows[0].CallID != rows[1].CallID {
+		t.Fatalf("the two rounds point at different calls: %q and %q", rows[0].CallID, rows[1].CallID)
+	}
+	if rows[0].Action != "accept" || rows[1].Action != "decline" {
+		t.Fatalf("the rounds took each other's answers: %q then %q", rows[0].Action, rows[1].Action)
+	}
+	if rows[0].Elapsed != 2*time.Second || rows[1].Elapsed != 5*time.Second {
+		t.Fatalf("elapsed = %v and %v, want 2s then 5s", rows[0].Elapsed, rows[1].Elapsed)
+	}
+	// One operation, still one call, which is what correlating MRTR is for.
+	if calls := s.Calls(id); len(calls) != 1 {
+		t.Fatalf("calls = %d, want the chain to remain one operation", len(calls))
+	}
+}
+
+// TestElicitationRedactedSchemaHasNoType covers what a capture taken with
+// --redact-secrets looks like. The key rules reach requestedSchema, so a matching
+// property's whole subschema becomes the placeholder string. The name survives,
+// which is the half that carries the meaning, and reporting the placeholder as a
+// type would present mcpsnoop's own scrubbing as the server's declaration.
+func TestElicitationRedactedSchemaHasNoType(t *testing.T) {
+	s, id := elicitSession(t, "t", []elicitAsk{{
+		key:     "creds",
+		state:   "st",
+		request: elicitReq("creds", `{"message":"m","requestedSchema":{"type":"object","properties":{"password":"[REDACTED]","user":{"type":"string"}},"required":["password"]}}`),
+		answer:  `"creds":{"action":"decline"}`,
+	}})
+	rows := s.Elicitations(id)
+	if len(rows) != 1 || len(rows[0].Fields) != 2 {
+		t.Fatalf("fields = %+v, want both properties listed", rows[0].Fields)
+	}
+	byName := map[string]string{}
+	for _, f := range rows[0].Fields {
+		byName[f.Name] = f.Type
+	}
+	if byName["password"] != "" {
+		t.Fatalf("the redacted property reports type %q, want none; a placeholder is not a type", byName["password"])
+	}
+	if byName["user"] != "string" {
+		t.Fatalf("an untouched property lost its type: %q", byName["user"])
+	}
+}
+
+// TestElicitationDoesNotDisturbTheRetryLink is the constraint the parsing change
+// had to respect. matchRetry keys on the answered key set and the echoed
+// requestState, and reading more out of the same bytes must not change either.
+func TestElicitationDoesNotDisturbTheRetryLink(t *testing.T) {
+	// Stateless, so the link rests entirely on the key set, which is the fragile
+	// half.
+	s, id := elicitSession(t, "t", []elicitAsk{{
+		key:     "k",
+		request: elicitReq("k", `{"message":"m","requestedSchema":{"type":"object","properties":{"a":{"type":"string"}}}}`),
+		answer:  `"k":{"action":"accept"}`,
+	}})
+	calls := s.Calls(id)
+	if len(calls) != 1 {
+		t.Fatalf("calls = %d, want the retry linked to the operation it continues", len(calls))
+	}
+	if rows := s.Elicitations(id); len(rows) != 1 || rows[0].Action != "accept" {
+		t.Fatalf("the answer did not reach the ledger: %+v", rows)
+	}
+}
+
+// TestASessionWithoutElicitationHasNoLedger keeps an ordinary capture unchanged.
+func TestASessionWithoutElicitationHasNoLedger(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"t"}`))
+	s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"content":[]}`))
+	if rows := s.Elicitations("s1"); len(rows) != 0 {
+		t.Fatalf("a session with no elicitation produced %d rows", len(rows))
+	}
+	if rows := s.Elicitations("nosuch"); rows != nil {
+		t.Fatalf("an unknown session produced %+v", rows)
+	}
+}
+
+// TestAChainReusingOneKeyKeepsEachRoundsOwnAnswer is why an answered round is
+// not answered twice. A server is free to ask under the same inputRequests key
+// on every round, and the retry that answers the second round carries that key
+// too, so without a guard it would reach back and rewrite the first round's
+// answer with the second one's.
+func TestAChainReusingOneKeyKeepsEachRoundsOwnAnswer(t *testing.T) {
+	s, id := elicitSession(t, "setup", []elicitAsk{
+		{key: "k", state: "st-1", request: elicitReq("k", `{"message":"first","requestedSchema":{"type":"object","properties":{"a":{"type":"string"}}}}`),
+			answer: `"k":{"action":"accept"}`, askDelay: 2 * time.Second},
+		{key: "k", state: "st-2", request: elicitReq("k", `{"message":"second","requestedSchema":{"type":"object","properties":{"b":{"type":"string"}}}}`),
+			answer: `"k":{"action":"cancel"}`, askDelay: 7 * time.Second},
+	})
+	rows := s.Elicitations(id)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want one per round: %+v", len(rows), rows)
+	}
+	if rows[0].Message != "first" || rows[1].Message != "second" {
+		t.Fatalf("the rounds are out of order: %q then %q", rows[0].Message, rows[1].Message)
+	}
+	if rows[0].Action != "accept" {
+		t.Fatalf("the first round's answer became %q; a later round under the same key rewrote it", rows[0].Action)
+	}
+	if rows[1].Action != "cancel" {
+		t.Fatalf("the second round's answer = %q, want cancel", rows[1].Action)
+	}
+	if rows[0].Elapsed != 2*time.Second || rows[1].Elapsed != 7*time.Second {
+		t.Fatalf("elapsed = %v and %v, want 2s then 7s", rows[0].Elapsed, rows[1].Elapsed)
+	}
+}
+
+// TestALaterRoundDoesNotAnswerAnEarlierOne is the direction the chain test could
+// not fail on. A retry is matched on the requestState and key set of the round it
+// was issued from, so that is the round it answers.
+//
+// The case is the specification's own recovery path: MRTR says that when a client
+// omits some of what was asked, the server "SHOULD respond with a new
+// InputRequiredResult requesting the missing information again". So an earlier
+// round holding one unanswered key beside an answered one is ordinary traffic,
+// and reaching back to it reported a decline the user never gave.
+func TestALaterRoundDoesNotAnswerAnEarlierOne(t *testing.T) {
+	s, id := elicitSession(t, "checkout", []elicitAsk{
+		{
+			key:   "card",
+			state: "A",
+			request: strings.Join([]string{
+				elicitReq("card", `{"mode":"url","url":"https://pay.example.com/x","message":"card"}`),
+				elicitReq("who", `{"message":"who","requestedSchema":{"type":"object","properties":{"n":{"type":"string"}}}}`),
+			}, ","),
+			// The client answers only one of the two keys.
+			answer:   `"who":{"action":"accept"}`,
+			askDelay: 3 * time.Second,
+		},
+		{
+			key:      "card",
+			state:    "B",
+			request:  elicitReq("card", `{"mode":"url","url":"https://pay.example.com/x","message":"card, again"}`),
+			answer:   `"card":{"action":"cancel"}`,
+			askDelay: 100 * time.Second,
+		},
+	})
+
+	rows := s.Elicitations(id)
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want two from the first round and one from the second: %+v", len(rows), rows)
+	}
+	byRound := map[string]ElicitationView{}
+	for _, r := range rows {
+		byRound[r.Message] = r
+	}
+	first := byRound["card"]
+	if !first.Pending() {
+		t.Fatalf("the first round's card was answered %q after %v; the client never answered it",
+			first.Action, first.Elapsed)
+	}
+	if !first.Answered.IsZero() {
+		t.Fatalf("an unanswered question carries a time: %v", first.Answered)
+	}
+	if got := byRound["who"]; got.Action != "accept" || got.Elapsed != 3*time.Second {
+		t.Fatalf("the answered key of the first round = %q after %v, want accept after 3s", got.Action, got.Elapsed)
+	}
+	if got := byRound["card, again"]; got.Action != "cancel" || got.Elapsed != 100*time.Second {
+		t.Fatalf("the second round = %q after %v, want cancel after 100s", got.Action, got.Elapsed)
+	}
+}
+
+// TestAMalformedQuestionStillMakesARow covers what redaction and a wrong server
+// both produce. Decoding through one typed struct lost the whole row on the
+// first field whose JSON type did not match, so a capture taken with
+// --redact-secrets could report no elicitation at all.
+func TestAMalformedQuestionStillMakesARow(t *testing.T) {
+	for _, tc := range []struct {
+		name, params string
+		wantMode     string
+		wantFields   int
+	}{
+		{"redacted schema", `{"message":"password please","requestedSchema":"[REDACTED]"}`, ElicitModeForm, 0},
+		{"redacted properties", `{"message":"m","requestedSchema":{"type":"object","properties":"[REDACTED]"}}`, ElicitModeForm, 0},
+		{"boolean schema", `{"message":"m","requestedSchema":true}`, ElicitModeForm, 0},
+		{"url is a number", `{"mode":"url","url":12345,"message":"m"}`, ElicitModeURL, 0},
+		{"mode is a number", `{"mode":5,"message":"m","requestedSchema":{"type":"object","properties":{"a":{"type":"string"}}}}`, ElicitModeForm, 1},
+		{"message is an object", `{"message":{"a":1},"requestedSchema":{"type":"object","properties":{"a":{"type":"string"}}}}`, ElicitModeForm, 1},
+		{"params is an array", `[1,2,3]`, ElicitModeForm, 0},
+		{"type is an array", `{"message":"m","requestedSchema":{"type":"object","properties":{"a":{"type":["string","null"]}}}}`, ElicitModeForm, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, id := elicitSession(t, "t", []elicitAsk{{
+				key: "k", state: "st", request: elicitReq("k", tc.params),
+				answer: `"k":{"action":"decline"}`,
+			}})
+			rows := s.Elicitations(id)
+			if len(rows) != 1 {
+				t.Fatalf("rows = %d, want the question still recorded", len(rows))
+			}
+			if rows[0].Mode != tc.wantMode {
+				t.Fatalf("mode = %q, want %q", rows[0].Mode, tc.wantMode)
+			}
+			if len(rows[0].Fields) != tc.wantFields {
+				t.Fatalf("fields = %+v, want %d", rows[0].Fields, tc.wantFields)
+			}
+			if rows[0].Action != "decline" {
+				t.Fatalf("the answer was lost with the malformed half: %q", rows[0].Action)
+			}
+		})
+	}
+}
+
+// TestAResentResultIsNotASecondRound covers a server repeating its
+// InputRequiredResult on one id. Parking deliberately leaves the call Pending, so
+// the duplicate guard cannot catch it, and every question would be recorded twice
+// and one answer reported as two.
+func TestAResentResultIsNotASecondRound(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s := New()
+	seq := uint64(0)
+	emit := func(dir proxy.Direction, off time.Duration, raw string) {
+		seq++
+		s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "d", Seq: seq, TS: t0.Add(off),
+			Direction: dir, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)})
+	}
+	const result = `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create","params":{"message":"m","requestedSchema":{"type":"object","properties":{"a":{"type":"string"}}}}}}}}`
+	emit(proxy.ClientToServer, time.Second, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`)
+	emit(proxy.ServerToClient, 2*time.Second, result)
+	emit(proxy.ServerToClient, 3*time.Second, result) // the same answer again
+	emit(proxy.ClientToServer, 9*time.Second, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t","inputResponses":{"k":{"action":"accept"}},"requestState":"st"}}`)
+
+	rows := s.Elicitations("s1")
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want one question however many times the result was sent: %+v", len(rows), rows)
+	}
+	if rows[0].Action != "accept" {
+		t.Fatalf("action = %q", rows[0].Action)
+	}
+}
+
+// TestARecordedQuestionIsBounded keeps one question's cost predictable. These
+// strings are held for the life of the session, outside the frame budget that
+// releases bodies, so a server is not free to make one arbitrarily expensive.
+func TestARecordedQuestionIsBounded(t *testing.T) {
+	huge := strings.Repeat("m", 200_000)
+	properties := make([]string, 0, 1000)
+	for i := range 1000 {
+		properties = append(properties, fmt.Sprintf(`"f%04d":{"type":"string"}`, i))
+	}
+	s, id := elicitSession(t, "t", []elicitAsk{{
+		key: "k", state: "st",
+		request: elicitReq("k", fmt.Sprintf(`{"message":%q,"requestedSchema":{"type":"object","properties":{%s}}}`,
+			huge, strings.Join(properties, ","))),
+		answer: `"k":{"action":"accept"}`,
+	}})
+	rows := s.Elicitations(id)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d", len(rows))
+	}
+	if n := len(rows[0].Message); n > maxElicitMessage+32 {
+		t.Fatalf("message is %d bytes, want it bounded near %d", n, maxElicitMessage)
+	}
+	if !strings.HasSuffix(rows[0].Message, "(truncated)") {
+		t.Fatal("a truncated message does not say it was truncated")
+	}
+	if n := len(rows[0].Fields); n != maxElicitFields {
+		t.Fatalf("fields = %d, want the cap of %d", n, maxElicitFields)
+	}
+	// Sorted before the cap, so which survive is the same on every run.
+	if rows[0].Fields[0].Name != "f0000" {
+		t.Fatalf("the kept fields are not the first by name: %q", rows[0].Fields[0].Name)
+	}
+}

--- a/internal/store/extensions.go
+++ b/internal/store/extensions.go
@@ -3,6 +3,8 @@ package store
 import (
 	"encoding/json"
 	"slices"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
 )
 
 // ExtensionsCapability is the capabilities field carrying the negotiated
@@ -65,4 +67,90 @@ func mergeExtensions(client, server []string) []ExtensionView {
 		out = append(out, ExtensionView{ID: id, Client: inClient[id], Server: inServer[id]})
 	}
 	return out
+}
+
+// tasksExtension is the identifier the Tasks extension is negotiated under. It
+// is the one extension mcpsnoop models the methods of, so it is the one it can
+// say anything about.
+const tasksExtension = "io.modelcontextprotocol/tasks"
+
+// extensionsFrom is the revision that moved optional features out of the core
+// protocol and into negotiated extensions (SEP-2133).
+//
+// The gate is not cosmetic. In 2025-11-25 tasks/get, tasks/result, tasks/cancel
+// and tasks/list are in the core schema and there is no extensions field to
+// negotiate, so a client driving them there is correct and reporting it would
+// fire on conforming traffic. In 2026-07-28 they are gone from the core schema
+// and Tasks is an extension like any other.
+const extensionsFrom = "2026-07-28"
+
+// extensionState is what a capture can say about one side's support for one
+// extension. Three-valued on purpose: a declaration mcpsnoop never saw, or one
+// its own redaction scrubbed, is not the same as a side that declared none, and
+// treating the two alike turns a capture that starts mid-session into an
+// accusation.
+type extensionState int
+
+const (
+	extensionUnknown extensionState = iota
+	extensionAbsent
+	extensionAdvertised
+)
+
+// advertises reports whether one side's capabilities declare an extension.
+// Capabilities that were never observed, or that will not decode, answer
+// unknown rather than absent.
+func advertises(raw json.RawMessage, id string) extensionState {
+	if len(raw) == 0 {
+		return extensionUnknown
+	}
+	var caps struct {
+		Extensions map[string]json.RawMessage `json:"extensions"`
+	}
+	if json.Unmarshal(raw, &caps) != nil {
+		return extensionUnknown
+	}
+	if _, ok := caps.Extensions[id]; ok {
+		return extensionAdvertised
+	}
+	return extensionAbsent
+}
+
+// unnegotiatedTasksWarning reports a frame driving the Tasks extension at a side
+// that never advertised it.
+//
+// The rule is in Versioning and Compatibility for 2026-07-28, "If one party
+// supports an extension but the other does not, the supporting party MUST either
+// revert to core protocol behavior or reject the request with an appropriate
+// error". Neither happened here: the feature was used anyway, and what a reader
+// gets instead is a -32601 or a -32021 several frames later, or a task that
+// simply never progresses.
+//
+// dir is the direction of the frame using the extension, so the side that has to
+// have advertised it is the other one. Silence is the answer whenever the
+// capture cannot show that side's declaration, since a capture that starts after
+// the handshake is the ordinary case rather than a violation.
+func (sess *session) unnegotiatedTasksWarning(dir proxy.Direction, version string) string {
+	if !atLeastRevision(valueOrDefault(version, sess.caps.protocolVersion), extensionsFrom) {
+		return ""
+	}
+	peer, side := sess.caps.server, "server"
+	if dir == proxy.ServerToClient {
+		peer, side = sess.caps.client, "client"
+	}
+	if advertises(peer, tasksExtension) != extensionAbsent {
+		return ""
+	}
+	return "uses the " + tasksExtension + " extension, which the " + side +
+		" never advertised, and 2026-07-28 requires the supporting side to fall back to core behaviour or reject the request"
+}
+
+// valueOrDefault prefers a request's own declared revision and falls back to the
+// session's, so a stateless capture where every request carries its version is
+// judged by that request rather than by whatever the handshake said.
+func valueOrDefault(primary, fallback string) string {
+	if primary != "" {
+		return primary
+	}
+	return fallback
 }

--- a/internal/store/extensions_test.go
+++ b/internal/store/extensions_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -128,5 +129,151 @@ func TestExtensionIDsIgnoresUnreadableDeclarations(t *testing.T) {
 		if got := extensionIDs(json.RawMessage(raw)); got != nil {
 			t.Fatalf("extensionIDs(%q) = %v, want nil", raw, got)
 		}
+	}
+}
+
+// TestUnnegotiatedTasksIsReportedOnlyWhenTheCaptureCanShowIt. SEP-2133 moved
+// Tasks out of the core protocol, and 2026-07-28 says that if one party supports
+// an extension and the other does not, the supporting party MUST fall back to
+// core behaviour or reject the request. mcpsnoop correlated the whole
+// unnegotiated lifecycle instead and said nothing, so a feature that silently
+// does nothing looked exactly like one that works.
+func TestUnnegotiatedTasksIsReportedOnlyWhenTheCaptureCanShowIt(t *testing.T) {
+	const tasksCaps = `{"extensions":{"io.modelcontextprotocol/tasks":{}}}`
+
+	for name, tc := range map[string]struct {
+		version              string
+		client, server       string
+		redactedHandshake    bool
+		wantRequestWarning   bool
+		wantTaskHandleWarned bool
+	}{
+		"neither side advertised": {
+			version: "2026-07-28", client: `{}`, server: `{}`,
+			wantRequestWarning: true, wantTaskHandleWarned: true,
+		},
+		"both advertised": {
+			version: "2026-07-28", client: tasksCaps, server: tasksCaps,
+		},
+		// The side that has to have advertised is the one being asked, so a server
+		// that supports Tasks answers tasks/get legitimately while the handle it
+		// hands a client that does not is still the violation.
+		"only the server advertised": {
+			version: "2026-07-28", client: `{}`, server: tasksCaps,
+			wantTaskHandleWarned: true,
+		},
+		"only the client advertised": {
+			version: "2026-07-28", client: tasksCaps, server: `{}`,
+			wantRequestWarning: true,
+		},
+		// In 2025-11-25 tasks/get and its siblings are in the core schema and there
+		// is no extensions field to negotiate, so driving them is correct there.
+		"an earlier revision where tasks are core": {
+			version: "2025-11-25", client: `{}`, server: `{}`,
+		},
+		// A capture that starts after the handshake, and one whose capabilities
+		// mcpsnoop's own redaction scrubbed, both cannot show what was negotiated.
+		"capabilities never observed": {
+			version: "", client: "", server: "",
+		},
+		// Both sides, since each half of the check reads the other side's
+		// declaration and a guard on only one of them would be half a guard.
+		"capabilities scrubbed by redaction": {
+			version: "2026-07-28", client: `"[REDACTED]"`, server: `"[REDACTED]"`, redactedHandshake: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := New()
+			t0 := time.Now()
+			seq := uint64(0)
+			next := func() uint64 { seq++; return seq }
+
+			if tc.version != "" {
+				s.Ingest(req(next(), t0, proxy.ClientToServer, "1", "initialize",
+					`{"protocolVersion":"`+tc.version+`","capabilities":`+tc.client+`,"clientInfo":{"name":"c","version":"1"}}`))
+				e := resp(next(), t0, proxy.ServerToClient, "1",
+					`"result":{"protocolVersion":"`+tc.version+`","capabilities":`+tc.server+`,"serverInfo":{"name":"s","version":"1"}}`)
+				e.Redacted = tc.redactedHandshake
+				s.Ingest(e)
+			}
+
+			s.Ingest(req(next(), t0, proxy.ClientToServer, "2", "tools/call", `{"name":"slow"}`))
+			handle := s.Ingest(resp(next(), t0, proxy.ServerToClient, "2",
+				`"result":{"resultType":"task","taskId":"t-1","status":"working"}`))
+			request := s.Ingest(req(next(), t0, proxy.ClientToServer, "3", "tasks/get", `{"taskId":"t-1"}`))
+
+			if got := strings.Contains(request.Warning, "never advertised"); got != tc.wantRequestWarning {
+				t.Errorf("tasks/get warned = %v, want %v (warning %q)", got, tc.wantRequestWarning, request.Warning)
+			}
+			if got := strings.Contains(handle.Warning, "never advertised"); got != tc.wantTaskHandleWarned {
+				t.Errorf("task handle warned = %v, want %v (warning %q)", got, tc.wantTaskHandleWarned, handle.Warning)
+			}
+			// Whichever way it goes, the message names the side that was short, or a
+			// reader has to guess which end to go and look at.
+			if tc.wantRequestWarning && !strings.Contains(request.Warning, "the server never advertised") {
+				t.Errorf("the request warning does not name the server: %q", request.Warning)
+			}
+			if tc.wantTaskHandleWarned && !strings.Contains(handle.Warning, "the client never advertised") {
+				t.Errorf("the handle warning does not name the client: %q", handle.Warning)
+			}
+		})
+	}
+}
+
+// TestAdvertisesSeparatesAbsentFromUnknown. Reading an unparsable declaration as
+// "not advertised" is what turns a capture that starts mid-session, or one the
+// user asked mcpsnoop to redact, into an accusation against traffic that was
+// correct.
+func TestAdvertisesSeparatesAbsentFromUnknown(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw  string
+		want extensionState
+	}{
+		"never observed":            {``, extensionUnknown},
+		"scrubbed whole":            {`"[REDACTED]"`, extensionUnknown},
+		"extensions map scrubbed":   {`{"extensions":"[REDACTED]"}`, extensionUnknown},
+		"not JSON at all":           {`{oops`, extensionUnknown},
+		"declared none":             {`{}`, extensionAbsent},
+		"declared other extensions": {`{"extensions":{"io.modelcontextprotocol/ui":{}}}`, extensionAbsent},
+		"declared it":               {`{"extensions":{"io.modelcontextprotocol/tasks":{}}}`, extensionAdvertised},
+		// The settings object is opaque, so a scrubbed one still declares the id.
+		"declared it, settings scrubbed": {`{"extensions":{"io.modelcontextprotocol/tasks":"[REDACTED]"}}`, extensionAdvertised},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := advertises(json.RawMessage(tc.raw), tasksExtension); got != tc.want {
+				t.Fatalf("advertises(%s) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUnnegotiatedTasksCoversTheNotification. A server pushing
+// notifications/tasks is reaching for the extension as much as one handing out a
+// task handle, and it is the frame a client that never advertised Tasks has no
+// idea what to do with.
+func TestUnnegotiatedTasksCoversTheNotification(t *testing.T) {
+	notify := func(clientCaps string) EventView {
+		s := New()
+		t0 := time.Now()
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "initialize",
+			`{"protocolVersion":"2026-07-28","capabilities":`+clientCaps+`,"clientInfo":{"name":"c","version":"1"}}`))
+		s.Ingest(resp(2, t0, proxy.ServerToClient, "1",
+			`"result":{"protocolVersion":"2026-07-28","capabilities":{},"serverInfo":{"name":"s","version":"1"}}`))
+		return s.Ingest(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: t0, Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"t-1","status":"failed"}}`),
+		})
+	}
+
+	silent := notify(`{"extensions":{"io.modelcontextprotocol/tasks":{}}}`)
+	if strings.Contains(silent.Warning, "never advertised") {
+		t.Fatalf("a client that advertised Tasks was warned about: %q", silent.Warning)
+	}
+	warned := notify(`{}`)
+	if !strings.Contains(warned.Warning, "the client never advertised") {
+		t.Fatalf("notifications/tasks to a client that never advertised Tasks: %q", warned.Warning)
+	}
+	if !strings.Contains(warned.Warning, "notifications/tasks") {
+		t.Fatalf("the warning does not name the frame: %q", warned.Warning)
 	}
 }

--- a/internal/store/interaction.go
+++ b/internal/store/interaction.go
@@ -1,0 +1,241 @@
+package store
+
+import (
+	"bytes"
+	"slices"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// InteractionView is one logical operation, however many requests it took on the
+// wire.
+//
+// Under multi round-trip requests a tool call can be several requests, each with
+// its own JSON-RPC id, because the specification says the id "MUST be different
+// between the initial request and the retry, as they are independent requests".
+// A call with no retry is a one hop interaction, so this describes every
+// operation uniformly rather than only the chained ones.
+type InteractionView struct {
+	// CallID is the id of the request that opened the operation, and CallSeq the
+	// sequence of that frame, which is what the exporter indexes calls by.
+	CallSeq  uint64
+	CallID   string
+	Method   string
+	ToolName string
+	// RoundTrips is how many requests the operation took. One means no retry.
+	RoundTrips int
+	// ServerTime is how long the server held the operation across every hop, and
+	// ClientTurnaround the rest, which is the time between an answer arriving and
+	// the client coming back, mostly a person deciding. They sum to Duration by
+	// construction rather than by arithmetic anyone has to trust.
+	ServerTime       time.Duration
+	ClientTurnaround time.Duration
+	Duration         time.Duration
+	Start            time.Time
+	State            CallState
+	Errored          bool
+	// LateResult marks a cancelled operation whose answer arrived anyway, which is
+	// what makes its timing real rather than a stub.
+	LateResult bool
+	// Hops is the per-hop breakdown, newest last, and is built only for an
+	// operation that took more than one request. A single hop's breakdown is the
+	// totals above it word for word, so producing one would restate them and, on a
+	// session of twenty thousand ordinary calls, allocate twenty thousand slices to
+	// do it, under the read lock a live panel holds.
+	//
+	// It is derived from the frames still held, so a live store that has released
+	// old ones reports fewer hops than RoundTrips counts. HopsComplete says which
+	// case this is, because a partial breakdown that looked whole would understate
+	// an operation rather than declining to describe it.
+	Hops         []HopView
+	HopsComplete bool
+	// swapped records that this operation's request came from the server, so the
+	// walk knows to swap each hop the way the totals already are.
+	swapped bool
+}
+
+// Done reports whether the operation is no longer open, the same question
+// CallView.Done answers about a single request.
+func (i InteractionView) Done() bool { return i.State != Pending && i.State != Streaming }
+
+// Measurable reports whether this operation has a latency worth judging, which
+// is the rule --max-duration already applies to a call. An operation still open
+// has none, a superseded one was never answered, and a cancelled one without a
+// late result delivered nothing.
+func (i InteractionView) Measurable() bool {
+	return i.Done() && i.State != Superseded && (i.State != Cancelled || i.LateResult)
+}
+
+// HopView is one request and its answer inside an interaction.
+type HopView struct {
+	// RequestID is the JSON-RPC id of this hop, which differs from the others by
+	// specification.
+	RequestID  string
+	RequestAt  time.Time
+	ResponseAt time.Time
+	// ServerTime is this hop alone, and ClientTurnaround is the wait before it,
+	// zero on the first hop since nothing preceded it.
+	ServerTime       time.Duration
+	ClientTurnaround time.Duration
+	// Asked names the server-to-client requests this hop's answer carried, sorted,
+	// and is empty on a hop that finished the operation. AskedUnknown separates
+	// that from a hop whose answer is no longer readable, which a live store
+	// produces by releasing frame bodies to stay inside its byte budget: the frame
+	// is still there and its timing is still exact, so the breakdown is complete
+	// and only this one field is not.
+	Asked        []string
+	AskedUnknown bool
+	// Pending marks a hop whose answer never arrived.
+	Pending bool
+}
+
+// Interactions returns one entry per operation in the session, oldest first.
+//
+// The counts and the two totals come from the call, which accumulates them as
+// frames arrive, so they are exact whatever the store has since released. The
+// per-hop breakdown is read from the frames still held, which is the whole log
+// on a batch read and a window on a live one.
+func (s *Store) Interactions(sessionID string) []InteractionView {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil
+	}
+
+	// One pass, one map. Grouping the frames first and then walking each group
+	// allocated a slice per call, and this runs under the read lock while the live
+	// panel rebuilds on a timer, so every allocation here is one the ingest path
+	// waits behind.
+	out := make([]InteractionView, 0, 16)
+	at := make(map[*call]int, 16)
+	// lastResponse is where each entry's previous hop ended, which is what the
+	// next hop's wait is measured from.
+	lastResponse := make([]time.Time, 0, 16)
+	for _, ev := range sess.events {
+		if ev.call == nil {
+			continue
+		}
+		i, known := at[ev.call]
+		switch ev.kind {
+		case EventRequest:
+			if !known {
+				i = len(out)
+				at[ev.call] = i
+				out = append(out, interactionOf(ev.call))
+				lastResponse = append(lastResponse, time.Time{})
+			}
+			if out[i].RoundTrips < 2 {
+				continue // one hop, and its breakdown is the totals already recorded
+			}
+			hop := HopView{RequestID: ev.id, RequestAt: ev.ts, Pending: true}
+			if prev := lastResponse[i]; !prev.IsZero() && ev.ts.After(prev) {
+				hop.ClientTurnaround = ev.ts.Sub(prev)
+			}
+			out[i].Hops = append(out[i].Hops, hop)
+		case EventResponse:
+			if !known || out[i].RoundTrips < 2 || len(out[i].Hops) == 0 {
+				continue // the request that opened this hop is no longer held
+			}
+			hop := &out[i].Hops[len(out[i].Hops)-1]
+			if !hop.Pending {
+				continue // already answered, a duplicate or late response
+			}
+			hop.ResponseAt, hop.Pending = ev.ts, false
+			if ev.ts.After(hop.RequestAt) {
+				hop.ServerTime = ev.ts.Sub(hop.RequestAt)
+			}
+			hop.Asked, hop.AskedUnknown = askedOf(ev)
+			lastResponse[i] = ev.ts
+		}
+	}
+
+	for i := range out {
+		if out[i].swapped {
+			for h := range out[i].Hops {
+				hop := &out[i].Hops[h]
+				hop.ServerTime, hop.ClientTurnaround = hop.ClientTurnaround, hop.ServerTime
+			}
+		}
+		// Complete means the breakdown accounts for the totals, not merely that the
+		// hop count matches. Work can settle off the request and response pair a hop
+		// is made of, a task handle being the plain case, and a breakdown adding up
+		// to a hundred milliseconds must not describe itself as the whole of a
+		// thirty second operation.
+		var hopServer, hopClient time.Duration
+		for _, h := range out[i].Hops {
+			hopServer += h.ServerTime
+			hopClient += h.ClientTurnaround
+		}
+		if out[i].RoundTrips < 2 {
+			// Nothing to be incomplete about. The totals are the whole description of
+			// an operation that took one request.
+			out[i].HopsComplete = true
+			continue
+		}
+		out[i].HopsComplete = len(out[i].Hops) == out[i].RoundTrips &&
+			hopServer == out[i].ServerTime && hopClient == out[i].ClientTurnaround
+	}
+	return out
+}
+
+// interactionOf builds the totals of one operation from the call that carries
+// them. The hops are filled in by the walk, since they come from frames.
+func interactionOf(c *call) InteractionView {
+	server, client := c.serverTime, c.clientTime
+	swapped := c.reqDir == proxy.ServerToClient
+	if swapped {
+		// A request the server sent is answered by the client, so the interval
+		// between them is the client's and the gap between hops is the server's.
+		// Every revision from 2026-07-28 routes these through MRTR instead, so this
+		// is an older capture or a deprecated shape, and reporting the client's work
+		// under a field named for the server would be wrong in the one place it is
+		// still possible.
+		server, client = client, server
+	}
+	return InteractionView{
+		CallSeq: c.requestSeq, CallID: c.id, Method: c.method, ToolName: c.toolName,
+		RoundTrips:       c.hops,
+		ServerTime:       server,
+		ClientTurnaround: client,
+		// The span the two intervals cover, not the clock since the request. A chain
+		// nobody finished has an open interval that grows with the current time, and
+		// reporting that would make the total disagree with its own parts.
+		Duration: server + client,
+		Start:    c.start, State: c.state, Errored: c.errored, LateResult: c.lateResult,
+		swapped: swapped,
+	}
+}
+
+// askedOf names what an answer asked the client for, sorted so two captures
+// compare. unknown is true when the frame's body is no longer held, which a live
+// store does to stay inside its byte budget, so a hop whose answer cannot be read
+// is told apart from one that asked for nothing.
+func askedOf(ev *event) (asked []string, unknown bool) {
+	if ev.bodyReleased {
+		return nil, true
+	}
+	if len(ev.raw) == 0 {
+		return nil, false
+	}
+	// A substring scan before a decode. Only an InputRequiredResult can name
+	// anything here, and its resultType is that literal, so a frame without those
+	// bytes cannot be one. Decoding every response instead cost a full unmarshal of
+	// each body, which on a live session of forty thousand frames took longer than
+	// the interval the panel refreshes on, so the panel could never keep up and
+	// held the store's read lock while it failed to. A false positive costs one
+	// decode that correctly answers nothing.
+	if !bytes.Contains(ev.raw, []byte(`"input_required"`)) {
+		return nil, false
+	}
+	msg, ok := proxy.ParseRPC(ev.raw)
+	if !ok {
+		return nil, false
+	}
+	state, ok := parseInputRequired(msg.Result)
+	if !ok || len(state.methods) == 0 {
+		return nil, false
+	}
+	return slices.Clone(state.methods), false
+}

--- a/internal/store/interaction_test.go
+++ b/internal/store/interaction_test.go
@@ -1,0 +1,490 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// mrtrFixture is the capture from issue #201: one book_flight chain of three
+// hops where the server works 0.4s, 0.3s and 0.5s while the user takes 12s and
+// then 25s, followed by an ordinary fast call for contrast.
+func mrtrFixture(t *testing.T, s *Store, upTo int) {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight","arguments":{"to":"JFK"}}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create","params":{"message":"Confirm $840?"}}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","arguments":{"to":"JFK"},"requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create","params":{"message":"Window or aisle?"}}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","arguments":{"to":"JFK"},"requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"booked"}]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	if upTo <= 0 || upTo > len(frames) {
+		upTo = len(frames)
+	}
+	for i, f := range frames[:upTo] {
+		s.Ingest(proxy.Envelope{SessionID: "demo", ServerLabel: "booking", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+	}
+}
+
+func interactionFor(t *testing.T, s *Store, tool string) InteractionView {
+	t.Helper()
+	for _, in := range s.Interactions("demo") {
+		if in.ToolName == tool {
+			return in
+		}
+	}
+	t.Fatalf("no interaction for %q in %+v", tool, s.Interactions("demo"))
+	return InteractionView{}
+}
+
+// TestInteractionsSplitServerTimeFromHumanTime is the whole feature, on the
+// capture the issue is written around. The server spent 1.2s and the user spent
+// 37s, and until now both landed in one 38.2s scalar.
+func TestInteractionsSplitServerTimeFromHumanTime(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 0)
+
+	book := interactionFor(t, s, "book_flight")
+	if book.RoundTrips != 3 {
+		t.Fatalf("round trips = %d, want 3", book.RoundTrips)
+	}
+	if book.ServerTime != 1200*time.Millisecond {
+		t.Fatalf("server time = %v, want 1.2s", book.ServerTime)
+	}
+	if book.ClientTurnaround != 37*time.Second {
+		t.Fatalf("client turnaround = %v, want 37s", book.ClientTurnaround)
+	}
+
+	quick := interactionFor(t, s, "lookup_price")
+	if quick.RoundTrips != 1 || quick.ServerTime != 200*time.Millisecond || quick.ClientTurnaround != 0 {
+		t.Fatalf("an ordinary call = %d trips, %v server, %v client; want 1, 200ms, 0",
+			quick.RoundTrips, quick.ServerTime, quick.ClientTurnaround)
+	}
+}
+
+// TestTheTwoSharesAlwaysAddUp is the invariant that makes the split trustworthy.
+// It holds by construction rather than by arithmetic anyone has to check, since
+// the intervals telescope from the first request to the last response.
+func TestTheTwoSharesAlwaysAddUp(t *testing.T) {
+	for _, upTo := range []int{2, 4, 6, 8} {
+		t.Run(fmt.Sprintf("through frame %d", upTo), func(t *testing.T) {
+			s := New()
+			mrtrFixture(t, s, upTo)
+			for _, in := range s.Interactions("demo") {
+				if got := in.ServerTime + in.ClientTurnaround; got != in.Duration {
+					t.Fatalf("%s: %v server + %v client = %v, want the %v duration",
+						in.ToolName, in.ServerTime, in.ClientTurnaround, got, in.Duration)
+				}
+			}
+		})
+	}
+}
+
+// TestEveryHopIsMeasuredSeparately covers the breakdown underneath the totals.
+func TestEveryHopIsMeasuredSeparately(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 0)
+	book := interactionFor(t, s, "book_flight")
+	if !book.HopsComplete || len(book.Hops) != 3 {
+		t.Fatalf("hops = %d complete=%v, want all three", len(book.Hops), book.HopsComplete)
+	}
+	for i, want := range []struct {
+		id     string
+		server time.Duration
+		wait   time.Duration
+		asked  int
+	}{
+		{"1", 400 * time.Millisecond, 0, 1},
+		{"2", 300 * time.Millisecond, 12 * time.Second, 1},
+		{"3", 500 * time.Millisecond, 25 * time.Second, 0},
+	} {
+		got := book.Hops[i]
+		if got.RequestID != want.id || got.ServerTime != want.server || got.ClientTurnaround != want.wait {
+			t.Fatalf("hop %d = id %s, %v server, %v wait; want id %s, %v, %v",
+				i+1, got.RequestID, got.ServerTime, got.ClientTurnaround, want.id, want.server, want.wait)
+		}
+		if len(got.Asked) != want.asked {
+			t.Fatalf("hop %d asked %v, want %d entries", i+1, got.Asked, want.asked)
+		}
+		if got.Pending {
+			t.Fatalf("hop %d reads as unanswered", i+1)
+		}
+	}
+	// The per-hop shares are the totals, taken apart.
+	var server, client time.Duration
+	for _, h := range book.Hops {
+		server += h.ServerTime
+		client += h.ClientTurnaround
+	}
+	if server != book.ServerTime || client != book.ClientTurnaround {
+		t.Fatalf("hops sum to %v/%v against totals %v/%v", server, client, book.ServerTime, book.ClientTurnaround)
+	}
+}
+
+// TestAnAbandonedChainReportsWhatItSaw covers the fixture cut after the second
+// answer. MRTR makes an abandoned chain ordinary, since a server must not assume
+// a client will retry, so the view reports the hops observed and invents none.
+func TestAnAbandonedChainReportsWhatItSaw(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 4)
+	book := interactionFor(t, s, "book_flight")
+	if book.RoundTrips != 2 {
+		t.Fatalf("round trips = %d, want the 2 that happened", book.RoundTrips)
+	}
+	if book.State != Pending {
+		t.Fatalf("state = %v, want pending", book.State)
+	}
+	if len(book.Hops) != 2 {
+		t.Fatalf("hops = %d, want 2 with none invented", len(book.Hops))
+	}
+	if book.Hops[1].Pending {
+		t.Fatalf("the second hop was answered, it is the third that never happened")
+	}
+	// 400ms plus 300ms of server, 12s of client, and nothing beyond what was seen.
+	if book.ServerTime != 700*time.Millisecond || book.ClientTurnaround != 12*time.Second {
+		t.Fatalf("server %v client %v, want 700ms and 12s", book.ServerTime, book.ClientTurnaround)
+	}
+}
+
+// TestAnUnlinkedRetryIsItsOwnInteraction keeps the view from filling in a link
+// matchRetry refused. A wrong link silently attributes one operation's timing to
+// another and leaves no symptom, which is why the refusal exists.
+func TestAnUnlinkedRetryIsItsOwnInteraction(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	// Two identical stateless questions in flight at once, so the retry fits both.
+	for i, id := range []string{"1", "2"} {
+		s.Ingest(req(uint64(2*i+1), t0, proxy.ClientToServer, id, "tools/call", `{"name":"book"}`))
+		s.Ingest(resp(uint64(2*i+2), t0.Add(time.Second), proxy.ServerToClient, id,
+			`"result":{"resultType":"input_required","inputRequests":{"who":{"method":"elicitation/create"}}}`))
+	}
+	s.Ingest(req(9, t0.Add(2*time.Second), proxy.ClientToServer, "3", "tools/call",
+		`{"name":"book","inputResponses":{"who":{"action":"accept"}}}`))
+
+	var single, chained int
+	for _, in := range s.Interactions("s1") {
+		if in.RoundTrips == 1 {
+			single++
+		} else {
+			chained++
+		}
+	}
+	if chained != 0 {
+		t.Fatalf("an ambiguous retry was folded into a chain: %+v", s.Interactions("s1"))
+	}
+	if single != 3 {
+		t.Fatalf("interactions = %d, want three separate one hop ones", single)
+	}
+}
+
+// TestAStateViolationStillReportsItsHops keeps a requestState violation from
+// also destroying the timing view. The link was still made, so the hops are
+// still known.
+func TestAStateViolationStillReportsItsHops(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","requestState":"issued","inputRequests":{"who":{"method":"elicitation/create"}}}`))
+	// The retry echoes something else, which is the violation.
+	ev := s.Ingest(req(3, t0.Add(5*time.Second), proxy.ClientToServer, "2", "tools/call",
+		`{"name":"book","requestState":"tampered","inputResponses":{"who":{"action":"accept"}}}`))
+	if ev.MRTRStateIssue != MRTRStateChanged {
+		t.Fatalf("the violation was not detected: %q", ev.MRTRStateIssue)
+	}
+	s.Ingest(resp(4, t0.Add(6*time.Second), proxy.ServerToClient, "2", `"result":{"content":[]}`))
+
+	in := interactionForSession(t, s, "s1", "book")
+	if in.RoundTrips != 2 || len(in.Hops) != 2 {
+		t.Fatalf("a chain carrying a state violation lost its hops: %+v", in)
+	}
+	if in.ServerTime != 2*time.Second || in.ClientTurnaround != 4*time.Second {
+		t.Fatalf("server %v client %v, want 2s and 4s", in.ServerTime, in.ClientTurnaround)
+	}
+}
+
+func interactionForSession(t *testing.T, s *Store, session, tool string) InteractionView {
+	t.Helper()
+	for _, in := range s.Interactions(session) {
+		if in.ToolName == tool {
+			return in
+		}
+	}
+	t.Fatalf("no interaction for %q", tool)
+	return InteractionView{}
+}
+
+// TestTheChainStillCountsOnce keeps this a view rather than a re-split of the
+// operation, which is what correlating MRTR was written to prevent.
+func TestTheChainStillCountsOnce(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 0)
+	if n := len(s.Calls("demo")); n != 2 {
+		t.Fatalf("calls = %d, want one per operation", n)
+	}
+	summary, ok := s.ToolSummary("demo")
+	if !ok {
+		t.Fatal("no tool summary")
+	}
+	for _, tool := range summary.Tools {
+		if tool.Calls != 1 {
+			t.Fatalf("%s counted %d calls, want 1", tool.Name, tool.Calls)
+		}
+		want := 1
+		if tool.Name == "book_flight" {
+			want = 3
+		}
+		if tool.MaxRoundTrips != want {
+			t.Fatalf("%s round trips = %d, want %d", tool.Name, tool.MaxRoundTrips, want)
+		}
+	}
+}
+
+// TestTheTotalsSurviveEviction is why the counts are accumulated as frames
+// arrive rather than derived from the timeline. A live store releases old frames
+// to stay inside its budget, so a derived answer would silently be a window.
+func TestTheTotalsSurviveEviction(t *testing.T) {
+	s := NewBounded(64<<10, 5) // a window smaller than the chain
+	mrtrFixture(t, s, 6)       // the chain alone, no trailing call to evict it
+	book := interactionForSession(t, s, "demo", "book_flight")
+	if book.RoundTrips != 3 {
+		t.Fatalf("round trips = %d, want the 3 that happened even though the frames are gone", book.RoundTrips)
+	}
+	if book.ServerTime != 1200*time.Millisecond || book.ClientTurnaround != 37*time.Second {
+		t.Fatalf("server %v client %v, want 1.2s and 37s", book.ServerTime, book.ClientTurnaround)
+	}
+	if book.HopsComplete {
+		t.Fatalf("a partial breakdown claims to be whole: %d hops of %d", len(book.Hops), book.RoundTrips)
+	}
+	if len(book.Hops) >= book.RoundTrips {
+		t.Fatalf("hops = %d, want fewer than the %d round trips once frames are released", len(book.Hops), book.RoundTrips)
+	}
+}
+
+// ingestFrames feeds a session one capture, given as direction, offset in
+// milliseconds and raw body.
+func ingestFrames(t *testing.T, s *Store, frames [][3]any) {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	for i, f := range frames {
+		s.Ingest(proxy.Envelope{SessionID: "demo", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f[1].(int)) * time.Millisecond), Direction: f[0].(proxy.Direction),
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f[2].(string))})
+	}
+}
+
+// TestServerTimeIsClosedOnEverySettlement covers the paths that settle a call
+// outside the ordinary terminal branch. Each of them left the server's share at
+// zero while the call itself reported a duration, so the interaction contradicted
+// the call it describes.
+func TestServerTimeIsClosedOnEverySettlement(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		frames [][3]any
+		server time.Duration
+	}{
+		{
+			// A tools/call answered with a task handle, finished through the task.
+			name: "task handle",
+			frames: [][3]any{
+				{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"long_job"}}`},
+				{proxy.ServerToClient, 100, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"task","taskId":"t-1","status":"working"}}`},
+				{proxy.ClientToServer, 29000, `{"jsonrpc":"2.0","id":"2","method":"tasks/get","params":{"taskId":"t-1"}}`},
+				{proxy.ServerToClient, 30050, `{"jsonrpc":"2.0","id":"2","result":{"taskId":"t-1","status":"completed","result":{"content":[]}}}`},
+			},
+			server: 30050 * time.Millisecond,
+		},
+		{
+			// Cancelled, then answered anyway.
+			name: "late result after a cancel",
+			frames: [][3]any{
+				{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"slow"}}`},
+				{proxy.ClientToServer, 2000, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"1"}}`},
+				{proxy.ServerToClient, 9000, `{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`},
+			},
+			server: 9 * time.Second,
+		},
+		{
+			// A long-lived stream closed gracefully.
+			name: "graceful stream close",
+			frames: [][3]any{
+				{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"subscriptions/listen","params":{}}`},
+				{proxy.ServerToClient, 4000, `{"jsonrpc":"2.0","id":"1","result":{}}`},
+			},
+			server: 4 * time.Second,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			ingestFrames(t, s, tc.frames)
+			all := s.Interactions("demo")
+			if len(all) == 0 {
+				t.Fatal("no interaction")
+			}
+			in := all[0]
+			if in.ServerTime != tc.server {
+				t.Fatalf("server time = %v, want %v; the interval was never closed", in.ServerTime, tc.server)
+			}
+			if in.Duration != tc.server {
+				t.Fatalf("duration = %v, want %v", in.Duration, tc.server)
+			}
+			// And the view agrees with the call it describes.
+			for _, c := range s.Calls("demo") {
+				if c.RequestSeq == in.CallSeq && c.Done() && c.Duration() != in.Duration {
+					t.Fatalf("the interaction says %v and the call says %v", in.Duration, c.Duration())
+				}
+			}
+		})
+	}
+}
+
+// TestAResentResultIsNotAHop keeps the gap between two copies of one answer off
+// the server's account. Parking leaves the call Pending, so the duplicate guard
+// cannot catch a server that repeats itself.
+func TestAResentResultIsNotAHop(t *testing.T) {
+	const asked = `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 400, asked},
+		{proxy.ServerToClient, 10000, asked}, // the same answer again, nine and a half seconds later
+		{proxy.ClientToServer, 20000, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t","requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 20500, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if in.RoundTrips != 2 {
+		t.Fatalf("round trips = %d, want 2; a resend is not a hop", in.RoundTrips)
+	}
+	if in.ServerTime != 900*time.Millisecond {
+		t.Fatalf("server time = %v, want 900ms; the idle gap between two copies is not server work", in.ServerTime)
+	}
+	if in.ClientTurnaround != 19600*time.Millisecond {
+		t.Fatalf("client turnaround = %v, want 19.6s", in.ClientTurnaround)
+	}
+	if in.ServerTime+in.ClientTurnaround != in.Duration {
+		t.Fatalf("the shares do not add up: %+v", in)
+	}
+}
+
+// TestAFrameOutOfOrderIsDroppedNotDeferred covers a log that was hand-edited or
+// two captures concatenated. Skipping the interval but moving the mark charged
+// the skew to whichever hop closed next, which is worse than declining to
+// measure the one that was wrong.
+func TestAFrameOutOfOrderIsDroppedNotDeferred(t *testing.T) {
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 5000, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`},
+		// The retry claims to have happened before the answer it answers.
+		{proxy.ClientToServer, 3000, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t","requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`},
+		// And the operation then finishes normally, which is where a mark left on the
+		// backwards frame would surface: the last hop would be measured from 3000
+		// rather than from 5000 and report seven seconds of server work that never
+		// happened.
+		{proxy.ServerToClient, 10000, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if in.ClientTurnaround != 0 {
+		t.Fatalf("client turnaround = %v, want none; the retry went backwards", in.ClientTurnaround)
+	}
+	// Five seconds to the answer, then five more to the final result, and nothing
+	// from the frame that went backwards.
+	if in.ServerTime != 10*time.Second {
+		t.Fatalf("server time = %v, want 10s, with the skew dropped rather than charged to the next hop", in.ServerTime)
+	}
+	if in.ServerTime+in.ClientTurnaround != in.Duration {
+		t.Fatalf("the shares do not add up: %+v", in)
+	}
+}
+
+// TestAServerInitiatedRequestDoesNotBlameTheServer covers the deprecated shape
+// that 2026-07-28 replaced with MRTR. The peer that answers a server's request
+// is the client, so the interval between them is not the server's time.
+func TestAServerInitiatedRequestDoesNotBlameTheServer(t *testing.T) {
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ServerToClient, 0, `{"jsonrpc":"2.0","id":"1","method":"sampling/createMessage","params":{"messages":[]}}`},
+		{proxy.ClientToServer, 3000, `{"jsonrpc":"2.0","id":"1","result":{"role":"assistant"}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if in.ServerTime != 0 {
+		t.Fatalf("server time = %v, want none; the client is what answered", in.ServerTime)
+	}
+	if in.ClientTurnaround != 3*time.Second {
+		t.Fatalf("client turnaround = %v, want 3s", in.ClientTurnaround)
+	}
+	if in.ServerTime+in.ClientTurnaround != in.Duration {
+		t.Fatalf("the shares do not add up: %+v", in)
+	}
+}
+
+// TestAOneHopInteractionCarriesNoRedundantBreakdown keeps the common case cheap.
+// One hop's breakdown is the totals word for word, and producing one allocated a
+// slice per call under the read lock a live panel holds.
+func TestAOneHopInteractionCarriesNoRedundantBreakdown(t *testing.T) {
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 200, `{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if len(in.Hops) != 0 {
+		t.Fatalf("hops = %+v, want none for a single request", in.Hops)
+	}
+	if !in.HopsComplete {
+		t.Fatal("a one hop interaction has nothing to be incomplete about")
+	}
+	if in.RoundTrips != 1 || in.ServerTime != 200*time.Millisecond {
+		t.Fatalf("the totals are still the whole description: %+v", in)
+	}
+}
+
+// TestAnUnreadableAnswerIsNotAnEmptyOne keeps the two apart. A live store
+// releases frame bodies to stay inside its byte budget, and a hop whose answer is
+// gone did not ask for nothing.
+func TestAnUnreadableAnswerIsNotAnEmptyOne(t *testing.T) {
+	s := NewBounded(1, 0) // one byte of bodies, so everything is released at once
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 5000, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t","requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 5100, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	})
+	all := s.Interactions("demo")
+	if len(all) == 0 {
+		t.Fatal("no interaction")
+	}
+	in := all[0]
+	if in.RoundTrips != 2 {
+		t.Fatalf("round trips = %d, want 2", in.RoundTrips)
+	}
+	var unknown int
+	for _, h := range in.Hops {
+		if h.AskedUnknown {
+			unknown++
+		}
+		if h.AskedUnknown && len(h.Asked) > 0 {
+			t.Fatalf("a hop is both unreadable and readable: %+v", h)
+		}
+	}
+	if unknown == 0 {
+		t.Fatalf("a released body reads as a hop that asked for nothing: %+v", in.Hops)
+	}
+	// The timings are exact regardless, so the breakdown is not incomplete.
+	if in.ServerTime != 500*time.Millisecond || in.ClientTurnaround != 4600*time.Millisecond {
+		t.Fatalf("releasing a body changed a timing: %+v", in)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -415,6 +415,14 @@ func (s *Store) Delete(sessionID string) {
 	if _, ok := s.sessions[sessionID]; !ok {
 		return
 	}
+	// The budget is store-wide, so a session leaving has to give back what it
+	// was holding. Without this, deleting a large session left its bytes on the
+	// budget for the life of the process and every frame ingested afterwards was
+	// released immediately, which is the inspector showing no payload at all.
+	if sess := s.sessions[sessionID]; sess != nil && s.bounded {
+		s.payloadBytes -= sess.bodyBytes
+		s.frames -= len(sess.events)
+	}
 	delete(s.sessions, sessionID)
 	for i, id := range s.order {
 		if id == sessionID {
@@ -949,7 +957,7 @@ func (s *Store) appendEvent(sess *session, ev *event) {
 		if oldest == nil {
 			break
 		}
-		oldest.dropOldestFrame()
+		s.payloadBytes -= oldest.dropOldestFrame()
 		s.frames--
 	}
 }
@@ -974,10 +982,15 @@ func (s *Store) oldestSession() *session {
 // folding whatever it says about a tool call into the running statistics. The
 // call itself goes with it when nothing else refers to it, since a settled call
 // that no frame points at is only holding memory.
-func (sess *session) dropOldestFrame() {
+// It returns the body weight that went with the frame, which the caller takes
+// off the store total. A frame the byte budget had already reached weighs
+// nothing here; one the frame cap reached first still carries its body, and
+// leaving that on the budget made the store believe it was fuller than it was.
+func (sess *session) dropOldestFrame() int {
 	ev := sess.events[0]
 	sess.toolStats.fold(ev)
-	sess.bodyBytes -= bodyWeight(ev)
+	dropped := bodyWeight(ev)
+	sess.bodyBytes -= dropped
 	sess.events[0] = nil // do not pin the frame through the slice's own array
 	sess.events = sess.events[1:]
 	sess.dropped++
@@ -991,6 +1004,7 @@ func (sess *session) dropOldestFrame() {
 			}
 		}
 	}
+	return dropped
 }
 
 // oldestRetained returns the session whose next unreleased frame is the oldest

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -521,6 +521,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.ConnID, e.TS, msg, e.Redacted)
 		ev.call = c
+		if note := responseContentTypeWarning(e.Direction, e.TransportHeaders); note != "" {
+			ev.warning = appendWarning(ev.warning, note)
+		}
 		// A task handle is the server reaching for the extension. It is judged
 		// against what the client declared, since the client is the side that has
 		// to understand the handle it is being given.
@@ -638,6 +641,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			if note := sess.unnegotiatedTasksWarning(e.Direction, requestProtocolVersion(msg.Params, ev.mcpProtocolVersion)); note != "" {
 				ev.warning = appendWarning(ev.warning, strconv.Quote(msg.Method)+" "+note)
 			}
+		}
+		if note := acceptWarning(e.Direction, e.TransportHeaders); note != "" {
+			ev.warning = appendWarning(ev.warning, note)
 		}
 		var reused bool
 		if root, stateIssue := sess.matchRetry(msg); root != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -286,7 +286,13 @@ type session struct {
 
 	command []string
 	cwd     string
-	calls   map[callKey]*call
+	// target is the MCP endpoint of an HTTP session, already stripped of anything
+	// credential-shaped by the proxy that wrote it. transport is the channel the
+	// session was captured on, taken from the first envelope that named one, so a
+	// reader knows whether an absent target means stdio or an older HTTP log.
+	target    string
+	transport string
+	calls     map[callKey]*call
 	// evictCursor is how far a bounded store's release has reached in this
 	// session's timeline, and bodyBytes is what the frames from there on weigh.
 	evictCursor int
@@ -298,9 +304,13 @@ type session struct {
 	toolStats toolStats
 	tasks     map[string]*call
 	// awaiting holds operations that answered with an InputRequiredResult and are
-	// waiting for the client to retry. It stays tiny, only in-flight ones live here.
-	awaiting []*call
-	events   []*event
+	// waiting for the client to retry, and retiredExchanges counts the ones the
+	// parking cap dropped. A dropped operation can no longer be linked to, so a
+	// retry that does arrive for it reads as its own call, and a reader comparing
+	// counts deserves to be told rather than left to wonder.
+	awaiting         []*call
+	retiredExchanges int
+	events           []*event
 
 	requests, responses, notifications, errors, pending, lateResults int
 
@@ -456,6 +466,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		if json.Unmarshal(e.Raw, &meta) == nil {
 			sess.command = meta.Command
 			sess.cwd = meta.CWD
+			sess.target = meta.Target
 		}
 		return EventView{Kind: EventOther} // control frame, not shown in the stream
 	}
@@ -1094,6 +1105,11 @@ func (s *Store) sessionFor(e proxy.Envelope) *session {
 	}
 	if e.ServerLabel != "" {
 		sess.label = e.ServerLabel
+	}
+	// First writer wins, so a log that somehow mixes channels is described by the
+	// one it opened on rather than by whichever frame happened to arrive last.
+	if sess.transport == "" {
+		sess.transport = e.Transport
 	}
 	sess.last = e.TS
 	return sess
@@ -1737,6 +1753,22 @@ func sortedKeySet(m map[string]json.RawMessage) string {
 	return strings.Join(keys, "\x00")
 }
 
+// awaitingKept caps how many parked operations one session keeps as candidates
+// for a retry. MRTR makes abandonment normal rather than exceptional, since the
+// specification tells servers they "MUST NOT assume that clients will fulfill
+// the inputRequests or retry the original request", and an abandoned operation
+// produces no frame at all to retire it by. Without a cap the list is append
+// only for the life of the session, and matchRetry walks it on every request
+// that carries retry signals.
+//
+// The number is set so that only staleness can reach it. A client gathering
+// input for sixty-four operations at once is not a client anyone has, so a
+// session at the cap is one holding dozens of exchanges nobody is going to
+// finish, and the oldest goes first because it is the one whose requestState the
+// server itself is likeliest to have expired. The specification tells servers to
+// put "a short expiry (TTL)" inside that state and to reject it afterwards.
+const awaitingKept = 64
+
 func (sess *session) park(c *call) {
 	for _, p := range sess.awaiting {
 		if p == c {
@@ -1744,6 +1776,37 @@ func (sess *session) park(c *call) {
 		}
 	}
 	sess.awaiting = append(sess.awaiting, c)
+	sess.pruneAwaiting()
+}
+
+// pruneAwaiting retires parked operations that can no longer be continued, and
+// then bounds what is left. A settled call is not awaiting anything: the client
+// cancelled the operation, or it was superseded, and matchRetry already refuses
+// to link anything but a Pending one, so dropping it changes no verdict and only
+// stops a dead operation from being carried and re-walked for the rest of the
+// session. Growth only happens here, so this is the only place that has to run.
+func (sess *session) pruneAwaiting() {
+	kept := 0
+	for _, c := range sess.awaiting {
+		if c.state == Pending {
+			sess.awaiting[kept] = c
+			kept++
+		}
+	}
+	if excess := kept - awaitingKept; excess > 0 {
+		copy(sess.awaiting, sess.awaiting[excess:kept])
+		kept -= excess
+		// Counted, never silent. Retiring a settled operation above loses nothing,
+		// but these were still open, so a retry arriving for one of them will read
+		// as its own call and the operation will be counted and timed as two. That
+		// is the very thing correlating MRTR exists to prevent, so a session it
+		// happened in has to be able to say so.
+		sess.retiredExchanges += excess
+	}
+	// The tail still points at the retired calls, so clear it rather than only
+	// reslicing, or the backing array keeps every one of them alive.
+	clear(sess.awaiting[kept:])
+	sess.awaiting = sess.awaiting[:kept]
 }
 
 func (sess *session) unpark(c *call) {
@@ -1774,20 +1837,51 @@ func (sess *session) matchRetry(msg proxy.RPCMessage) (*call, MRTRStateIssue) {
 		}
 	}
 
+	// Two passes over the same candidates, narrow first. The narrow one only
+	// considers operations whose requestState presence agrees with the retry's,
+	// because the specification makes that agreement a MUST in both directions:
+	// a client that was given state "MUST echo back the exact value", and one
+	// that was not "MUST NOT include one in the retry". So a retry that carries
+	// no state cannot be continuing an operation that issued one, and an
+	// abandoned exchange with state stops making a conforming stateless retry
+	// look ambiguous. One abandoned exchange was enough to do that, and MRTR
+	// makes abandonment normal, so a single declined elicitation silently broke
+	// the correlation for every later exchange on the same tool.
+	//
+	// The wide pass is what reports the violation when the presence disagrees,
+	// and it runs only when the narrow one found nothing, so an exchange that
+	// really is non-conforming still gets its warning. It is a superset, so
+	// nothing that is ambiguous here becomes unambiguous there.
 	name := operationName(msg)
-	var fallback *call
-	matches := 0
-	for _, c := range sess.awaiting {
-		if c.state == Pending && c.mrtrKeys != "" && c.mrtrKeys == keys &&
-			c.method == msg.Method && c.opName == name {
-			fallback = c
-			matches++
-		}
+	if c, matches := sess.fallbackRetryMatch(msg, name, keys, hasState, true); matches == 1 {
+		return c, classifyMRTRState(c, state, hasState)
 	}
-	if matches == 1 {
-		return fallback, classifyMRTRState(fallback, state, hasState)
+	if c, matches := sess.fallbackRetryMatch(msg, name, keys, hasState, false); matches == 1 {
+		return c, classifyMRTRState(c, state, hasState)
 	}
 	return nil, ""
+}
+
+// fallbackRetryMatch counts the parked operations a retry could be continuing by
+// method, operation name and answered key set, returning the last one seen and
+// how many fit. Callers link only on exactly one, since a wrong link silently
+// attributes one operation's timing to another and leaves no symptom, while an
+// unlinked retry is merely two calls where there was one.
+func (sess *session) fallbackRetryMatch(msg proxy.RPCMessage, name, keys string, hasState, agreeOnState bool) (*call, int) {
+	var found *call
+	matches := 0
+	for _, c := range sess.awaiting {
+		if c.state != Pending || c.mrtrKeys == "" || c.mrtrKeys != keys ||
+			c.method != msg.Method || c.opName != name {
+			continue
+		}
+		if agreeOnState && c.mrtrHasState != hasState {
+			continue
+		}
+		found = c
+		matches++
+	}
+	return found, matches
 }
 
 // classifyMRTRState compares the state a retry carried with the one the server

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -521,6 +521,14 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.ConnID, e.TS, msg, e.Redacted)
 		ev.call = c
+		// A task handle is the server reaching for the extension. It is judged
+		// against what the client declared, since the client is the side that has
+		// to understand the handle it is being given.
+		if state, ok := parseTaskState(msg.Result); ok && state.ResultType == "task" {
+			if note := sess.unnegotiatedTasksWarning(e.Direction, ev.mcpProtocolVersion); note != "" {
+				ev.warning = appendWarning(ev.warning, "a task handle "+note)
+			}
+		}
 		if matched && c != nil && c.lateResult {
 			// One-for-one with sess.lateResults++: completeCall returns matched for the
 			// frame that incremented it and false for any further response to the same
@@ -626,6 +634,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.method = msg.Method
 		ev.id = string(msg.ID)
 		ev.warning = validationWarning(msg)
+		if isTaskMethod(msg.Method) {
+			if note := sess.unnegotiatedTasksWarning(e.Direction, requestProtocolVersion(msg.Params, ev.mcpProtocolVersion)); note != "" {
+				ev.warning = appendWarning(ev.warning, strconv.Quote(msg.Method)+" "+note)
+			}
+		}
 		var reused bool
 		if root, stateIssue := sess.matchRetry(msg); root != nil {
 			// A continuation, not a new call. Mapping the retry id onto the same
@@ -708,6 +721,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			}
 		}
 		if msg.Method == "notifications/tasks" {
+			if note := sess.unnegotiatedTasksWarning(e.Direction, ev.mcpProtocolVersion); note != "" {
+				ev.warning = appendWarning(ev.warning, "notifications/tasks "+note)
+			}
 			if state, ok := parseTaskState(msg.Params); ok {
 				ev.taskID = state.TaskID
 				if parent, failed := sess.applyParsedTaskState(state, e.TS); parent != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -157,9 +157,13 @@ type call struct {
 	// covers a cancelled task, work the user stopped on purpose that delivered no
 	// result but is not an error. One place (completeCall, applyParsedTaskState)
 	// decides this so every consumer reads the same answer.
-	errored    bool
-	taskID     string
-	taskStatus string
+	errored bool
+	// releasedResultBytes is how big the result was when a bounded store dropped
+	// it, so the context-cost figures the tool summary reports stay exact rather
+	// than reading zero once the bytes are gone.
+	releasedResultBytes int
+	taskID              string
+	taskStatus          string
 	// opName is the tool, prompt or resource this call names, kept so a retry can
 	// be matched back to it without re-parsing the original params.
 	opName string
@@ -219,6 +223,10 @@ type event struct {
 	// a task failure is counted on its terminal frame rather than on the call's
 	// first response, so call.errored alone cannot stand in for this.
 	errored bool
+	// bodyReleased is set when a bounded store dropped this frame's observed body
+	// to stay inside its budget. The frame keeps everything else, so it is still a
+	// row in the stream with its own verdict, and only its bytes are gone.
+	bodyReleased bool
 	// lateResult marks the frame this session counted a late result on, the same
 	// way errored marks a counted error. call.lateResult stays true for the rest
 	// of the capture and is visible from the request frame too, so it cannot
@@ -279,7 +287,16 @@ type session struct {
 	command []string
 	cwd     string
 	calls   map[callKey]*call
-	tasks   map[string]*call
+	// evictCursor is how far a bounded store's release has reached in this
+	// session's timeline, and bodyBytes is what the frames from there on weigh.
+	evictCursor int
+	bodyBytes   int
+	// dropped counts the frames a bounded store has removed from this timeline
+	// entirely, and toolStats holds the statistics of the calls they carried, so
+	// the summary still describes every call the session made.
+	dropped   int
+	toolStats toolStats
+	tasks     map[string]*call
 	// awaiting holds operations that answered with an InputRequiredResult and are
 	// waiting for the client to retry. It stays tiny, only in-flight ones live here.
 	awaiting []*call
@@ -316,14 +333,79 @@ type Store struct {
 	mu       sync.RWMutex
 	sessions map[string]*session
 	order    []string // session ids in first-seen order
+	// payloadLimit caps the observed bodies a live store keeps in memory, zero
+	// for no cap, and payloadBytes is what those bodies currently weigh.
+	//
+	// The frames themselves are the queue. Each session carries a cursor into its
+	// own timeline marking how far the release has reached, so a capture that
+	// never approaches the budget pays nothing for the mechanism.
+	payloadLimit int
+	payloadBytes int
+	// frameLimit caps how many frames a live store keeps at all, and frames is
+	// how many it currently holds. A frame with its body released still costs its
+	// own struct, so the bytes budget alone does not bound a chatty session of
+	// small frames.
+	frameLimit int
+	frames     int
+	// bounded separates a live store from the batch one. Either limit may be left
+	// unset on its own, so the flag rather than a zero limit is what says whether
+	// this store forgets at all.
+	bounded bool
 }
 
-// New returns an empty store.
+// New returns an empty store that keeps every observed body.
+//
+// This is the batch store, the one check, export, diff and open build. They read
+// a finite log once and every byte of it has to be there, since a bounded store
+// would make check under-report on a large capture, which is the one thing a
+// gate must never do.
 func New() *Store {
 	return &Store{
 		sessions: make(map[string]*session),
 	}
 }
+
+// DefaultLiveBodyLimit is how many bytes of observed bodies the live TUI keeps.
+//
+// It is a memory bound, not a history bound: every frame stays in the timeline
+// whatever this is set to, and only the bodies of the oldest ones are dropped.
+// 64 MiB is a few tens of thousands of ordinary frames, far more than anyone
+// scrolls back through, while a day-long capture of a chatty server used to
+// reach that in minutes and keep going.
+const DefaultLiveBodyLimit = 64 << 20
+
+// DefaultLiveFrameLimit is how many frames the live TUI keeps at all.
+//
+// Bodies are the bulk of a large-payload capture and this is the other half: a
+// frame whose body is gone still costs its own struct, so a chatty stream of
+// small notifications grew without ever reaching the byte budget. 200,000 is a
+// long scrollback and about 80 MiB of frames, and the log on disk still holds
+// everything past it.
+const DefaultLiveFrameLimit = 200_000
+
+// NewBounded returns a store that keeps at most limit bytes of observed bodies,
+// releasing the oldest first. A limit of zero behaves like New.
+//
+// Only the live TUI builds one. A hub left watching a chatty server grows until
+// it is killed, because nothing bounded what the store kept, and every frame is
+// already durable on disk. What is released is the body alone: the frame stays
+// in the timeline with its sequence, direction, method, status and warning, so
+// every count, every row and the whole tool summary stay exact and only the
+// inspector for an old frame has less to show. mcpsnoop open on the log is
+// still the way to see all of it.
+func NewBounded(bodyBytes, frames int) *Store {
+	s := New()
+	s.bounded = true
+	s.payloadLimit = bodyBytes
+	s.frameLimit = frames
+	return s
+}
+
+// BodyLimit reports the byte budget this store keeps observed bodies within,
+// zero when it keeps every one. It exists so the choice between the bounded live
+// store and the unbounded batch store is readable from outside the package,
+// which is the difference between check being exact and check under-reporting.
+func (s *Store) BodyLimit() int { return s.payloadLimit }
 
 // Delete drops a session from the store. A still-live shim will recreate it on
 // its next frame. Callers that want it gone for good should also delete its log.
@@ -374,7 +456,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 
 	if e.Direction == proxy.ServerStderr {
 		ev.kind = EventStderr
-		sess.events = append(sess.events, ev)
+		s.appendEvent(sess, ev)
 		return ev.view(sess)
 	}
 
@@ -393,7 +475,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			// traffic was correct in both directions.
 			sess.truncatedRequests++
 		}
-		sess.events = append(sess.events, ev)
+		s.appendEvent(sess, ev)
 		return ev.view(sess)
 	}
 
@@ -407,7 +489,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			sess.errors++
 			ev.errored = true
 		}
-		sess.events = append(sess.events, ev)
+		s.appendEvent(sess, ev)
 		return ev.view(sess)
 	}
 
@@ -809,8 +891,152 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		ev.mismatch = true
 	}
 
-	sess.events = append(sess.events, ev)
+	s.appendEvent(sess, ev)
 	return ev.view(sess)
+}
+
+// appendEvent records a frame and, on a bounded store, releases the oldest
+// bodies until the budget is met. Caller holds the write lock.
+//
+// Every branch of Ingest goes through here rather than appending directly, so a
+// branch added later cannot quietly opt out of the bound.
+func (s *Store) appendEvent(sess *session, ev *event) {
+	sess.events = append(sess.events, ev)
+	if !s.bounded {
+		return
+	}
+	n := bodyWeight(ev)
+	sess.bodyBytes += n
+	s.payloadBytes += n
+	s.frames++
+	for s.payloadLimit > 0 && s.payloadBytes > s.payloadLimit {
+		oldest := s.oldestRetained()
+		if oldest == nil {
+			break // nothing left to release, which the budget cannot fix
+		}
+		released := oldest.releaseOldestBody()
+		oldest.bodyBytes -= released
+		s.payloadBytes -= released
+	}
+	// Releasing bodies bounds the bytes but not the count, and a frame with no
+	// body still costs its own struct. A day of small notifications reached
+	// hundreds of megabytes of those alone, so the oldest frames go entirely once
+	// there are too many of them.
+	for s.frameLimit > 0 && s.frames > s.frameLimit {
+		oldest := s.oldestSession()
+		if oldest == nil {
+			break
+		}
+		oldest.dropOldestFrame()
+		s.frames--
+	}
+}
+
+// oldestSession returns the session holding the oldest frame in the store, so
+// frames go in arrival order across every session a hub carries.
+func (s *Store) oldestSession() *session {
+	var pick *session
+	for _, id := range s.order {
+		sess := s.sessions[id]
+		if sess == nil || len(sess.events) == 0 {
+			continue
+		}
+		if pick == nil || sess.events[0].ts.Before(pick.events[0].ts) {
+			pick = sess
+		}
+	}
+	return pick
+}
+
+// dropOldestFrame removes this session's oldest frame from the timeline, after
+// folding whatever it says about a tool call into the running statistics. The
+// call itself goes with it when nothing else refers to it, since a settled call
+// that no frame points at is only holding memory.
+func (sess *session) dropOldestFrame() {
+	ev := sess.events[0]
+	sess.toolStats.fold(ev)
+	sess.bodyBytes -= bodyWeight(ev)
+	sess.events[0] = nil // do not pin the frame through the slice's own array
+	sess.events = sess.events[1:]
+	sess.dropped++
+	if sess.evictCursor > 0 {
+		sess.evictCursor--
+	}
+	if ev.call != nil && ev.call.state != Pending && ev.call.state != Streaming {
+		for key, c := range sess.calls {
+			if c == ev.call {
+				delete(sess.calls, key)
+			}
+		}
+	}
+}
+
+// oldestRetained returns the session whose next unreleased frame is the oldest
+// in the store, so release is oldest-first across every session a hub carries
+// rather than per session. A hub holds a handful of sessions, so the scan is
+// cheaper than keeping a second index of every frame in the store.
+func (s *Store) oldestRetained() *session {
+	var pick *session
+	for _, id := range s.order {
+		sess := s.sessions[id]
+		if sess == nil || sess.evictCursor >= len(sess.events) {
+			continue
+		}
+		if pick == nil || sess.events[sess.evictCursor].ts.Before(pick.events[pick.evictCursor].ts) {
+			pick = sess
+		}
+	}
+	return pick
+}
+
+// releaseOldestBody drops the body of this session's oldest frame that still has
+// one and returns the bytes freed. Frames that never carried a body are stepped
+// over, so the cursor only ever moves forward.
+func (sess *session) releaseOldestBody() int {
+	for sess.evictCursor < len(sess.events) {
+		ev := sess.events[sess.evictCursor]
+		sess.evictCursor++
+		if n := bodyWeight(ev); n > 0 {
+			releaseBody(ev)
+			return n
+		}
+	}
+	return 0
+}
+
+// bodyWeight is what a frame's observed bytes cost, the frame's own copy plus
+// the call's. json.Unmarshal copies rather than aliasing, so a request holds its
+// params twice over and releasing one half frees nothing.
+func bodyWeight(ev *event) int {
+	n := len(ev.raw) + len(ev.text)
+	if ev.call == nil {
+		return n
+	}
+	switch ev.kind {
+	case EventRequest:
+		n += len(ev.call.params)
+	case EventResponse:
+		n += len(ev.call.result)
+	}
+	return n
+}
+
+// releaseBody drops a frame's observed body and the call's copy of the same
+// bytes. The result size is remembered first, because the tool summary measures
+// what a server costs in context from it and that figure must not shrink just
+// because the bytes are no longer held.
+func releaseBody(ev *event) {
+	ev.raw, ev.text, ev.bodyReleased = nil, "", true
+	if ev.call == nil {
+		return
+	}
+	switch ev.kind {
+	case EventRequest:
+		ev.call.params = nil
+	case EventResponse:
+		ev.call.releasedResultBytes = len(ev.call.result)
+		ev.call.result = nil
+	}
 }
 
 // sessionFor returns (creating if needed) the session for an envelope and bumps

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -551,7 +551,7 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			sess.closeProgressToken(c.progressToken)
 		}
 		if state, ok := parseInputRequired(msg.Result); ok {
-			for _, note := range inputRequiredWarnings(state, c) {
+			for _, note := range inputRequiredWarnings(state, c, e.Redacted) {
 				ev.warning = appendWarning(ev.warning, note)
 			}
 			for _, note := range undeclaredInputRequestWarnings(state, c) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -182,6 +182,13 @@ type call struct {
 	mrtrState    string
 	mrtrHasState bool
 	mrtrKeys     string
+	// elicitations are the questions this operation put to the user, in the order
+	// the rounds arrived. A chain answered with a further InputRequiredResult adds
+	// to the same slice, so every round of one operation stays on the call it
+	// belongs to. elicitRound is where the newest round starts, since a retry can
+	// only be answering the round it was issued from.
+	elicitations []*elicitation
+	elicitRound  int
 	// progressToken is what this request asked progress to be reported under,
 	// remembered so completion can close it and a later notification under the
 	// same token is read as reuse rather than a violation.
@@ -665,11 +672,28 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			ev.warning = appendWarning(ev.warning, note)
 		}
 		var reused bool
-		if root, stateIssue := sess.matchRetry(msg); root != nil {
+		if root, stateIssue, actions := sess.matchRetry(msg); root != nil {
 			// A continuation, not a new call. Mapping the retry id onto the same
 			// call object lets completeCall find it, so the operation keeps one
 			// pending slot and one duration however many round trips it takes.
 			sess.calls[requestCallKey(ev.id, msg.ID, e)] = root
+			// Only the newest round. A retry is matched on the requestState and the
+			// key set of the InputRequiredResult it was issued from, so that is the
+			// round it answers, and reaching further back would answer a question this
+			// client never answered.
+			//
+			// That case is ordinary rather than exotic. MRTR tells a server that when a
+			// client omits some of what was asked it "SHOULD respond with a new
+			// InputRequiredResult requesting the missing information again", so an
+			// earlier round holding an unanswered key beside an answered one is the
+			// specification's own recovery path. Answering it from the later round
+			// reported a decline the user never gave, with a think-time spanning the
+			// round in between.
+			for _, el := range root.elicitations[root.elicitRound:] {
+				if action, ok := actions[el.key]; ok {
+					el.answer(action, e.TS)
+				}
+			}
 			root.mrtrState, root.mrtrKeys = "", ""
 			root.mrtrHasState = false
 			sess.unpark(root)
@@ -1225,6 +1249,19 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		c.mrtrState = state.requestState
 		c.mrtrHasState = state.hasRequestState
 		c.mrtrKeys = state.keys
+		// Recorded here rather than derived on read, because a bounded live store
+		// releases frame bodies as it goes and the question would be gone by the
+		// time anyone asked. What is kept is names, types and a url, so a chain of
+		// them costs a few strings rather than the frames they came from.
+		//
+		// A repeat of the same result on one id is not a new round. The duplicate
+		// guard above cannot catch it, because parking deliberately leaves the call
+		// Pending, so a server resending its InputRequiredResult would otherwise
+		// append every question again and report one answer as two.
+		if round := parseElicitations(state.requests, ts); !sameElicitRound(c.elicitations[c.elicitRound:], round) {
+			c.elicitRound = len(c.elicitations)
+			c.elicitations = append(c.elicitations, round...)
+		}
 		sess.park(c)
 		return c, true
 	}
@@ -1682,6 +1719,10 @@ type inputRequired struct {
 	// The 2026-07-28 revision routes sampling and roots exclusively through this
 	// map, so it is the only place their method names still appear.
 	methods []string
+	// requests is the map itself, so a caller that wants more than the method
+	// names can read them without parsing the result a second time. matchRetry
+	// keys on keys and requestState alone and is unaffected by this.
+	requests map[string]json.RawMessage
 }
 
 // parseInputRequired recognises the result a server sends when it needs more
@@ -1714,6 +1755,7 @@ func parseInputRequired(raw json.RawMessage) (inputRequired, bool) {
 		hasRequestState: r.RequestState != nil,
 		keys:            sortedKeySet(r.InputRequests),
 		methods:         methods,
+		requests:        r.InputRequests,
 	}
 	if r.RequestState != nil {
 		state.requestState = *r.RequestState
@@ -1722,22 +1764,26 @@ func parseInputRequired(raw json.RawMessage) (inputRequired, bool) {
 }
 
 // retrySignals reads the two things a retry carries that can tie it back to the
-// request it continues.
-func retrySignals(params json.RawMessage) (state string, hasState bool, keys string) {
+// request it continues, plus what it answered.
+//
+// The link is inferred from keys and requestState alone, exactly as before.
+// actions rides along because the same bytes hold it and parsing the params
+// twice to reach it would be reading the same frame for two halves of one fact.
+func retrySignals(params json.RawMessage) (state string, hasState bool, keys string, actions map[string]string) {
 	if len(params) == 0 {
-		return "", false, ""
+		return "", false, "", nil
 	}
 	var p struct {
 		RequestState   *string                    `json:"requestState"`
 		InputResponses map[string]json.RawMessage `json:"inputResponses"`
 	}
 	if json.Unmarshal(params, &p) != nil {
-		return "", false, ""
+		return "", false, "", nil
 	}
 	if p.RequestState != nil {
 		state, hasState = *p.RequestState, true
 	}
-	return state, hasState, sortedKeySet(p.InputResponses)
+	return state, hasState, sortedKeySet(p.InputResponses), elicitActions(p.InputResponses)
 }
 
 // sortedKeySet renders a key set so two of them can be compared as strings.
@@ -1824,15 +1870,15 @@ func (sess *session) unpark(c *call) {
 // match is conclusive on its own. Otherwise the fallback needs the method, the
 // operation name and the full set of answered keys to agree, and gives up when
 // more than one parked operation fits, since a wrong link is worse than no link.
-func (sess *session) matchRetry(msg proxy.RPCMessage) (*call, MRTRStateIssue) {
-	state, hasState, keys := retrySignals(msg.Params)
+func (sess *session) matchRetry(msg proxy.RPCMessage) (*call, MRTRStateIssue, map[string]string) {
+	state, hasState, keys, actions := retrySignals(msg.Params)
 	if !hasState && keys == "" {
-		return nil, ""
+		return nil, "", nil
 	}
 	if hasState {
 		for _, c := range sess.awaiting {
 			if c.state == Pending && c.mrtrHasState && c.mrtrState == state {
-				return c, ""
+				return c, "", actions
 			}
 		}
 	}
@@ -1854,12 +1900,12 @@ func (sess *session) matchRetry(msg proxy.RPCMessage) (*call, MRTRStateIssue) {
 	// nothing that is ambiguous here becomes unambiguous there.
 	name := operationName(msg)
 	if c, matches := sess.fallbackRetryMatch(msg, name, keys, hasState, true); matches == 1 {
-		return c, classifyMRTRState(c, state, hasState)
+		return c, classifyMRTRState(c, state, hasState), actions
 	}
 	if c, matches := sess.fallbackRetryMatch(msg, name, keys, hasState, false); matches == 1 {
-		return c, classifyMRTRState(c, state, hasState)
+		return c, classifyMRTRState(c, state, hasState), actions
 	}
-	return nil, ""
+	return nil, "", nil
 }
 
 // fallbackRetryMatch counts the parked operations a retry could be continuing by

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -189,6 +189,11 @@ type call struct {
 	// only be answering the round it was issued from.
 	elicitations []*elicitation
 	elicitRound  int
+	// retired marks an operation the parking cap dropped. Nothing can continue it
+	// any more, so a bounded store may forget it even though it is still Pending,
+	// which it is: no response ever came, and saying otherwise would change what
+	// check reports about a session rather than only what the store holds.
+	retired bool
 	// progressToken is what this request asked progress to be reported under,
 	// remembered so completion can close it and a later notification under the
 	// same token is read as reuse rather than a violation.
@@ -1032,7 +1037,10 @@ func (sess *session) dropOldestFrame() int {
 	if sess.evictCursor > 0 {
 		sess.evictCursor--
 	}
-	if ev.call != nil && ev.call.state != Pending && ev.call.state != Streaming {
+	// A retired operation is released too. It is still Pending, and stays Pending
+	// in every count and verdict, but nothing can answer it, so holding the map
+	// entry keeps a call alive that no reader can reach.
+	if ev.call != nil && (ev.call.retired || ev.call.state != Pending && ev.call.state != Streaming) {
 		for key, c := range sess.calls {
 			if c == ev.call {
 				delete(sess.calls, key)
@@ -1840,6 +1848,15 @@ func (sess *session) pruneAwaiting() {
 		}
 	}
 	if excess := kept - awaitingKept; excess > 0 {
+		// Marked before they go. An operation off this list can never be linked to a
+		// retry, so it is finished as far as the store is concerned, and a bounded
+		// store is free to release it once its frames have gone. Without that a
+		// parked call stays Pending for ever, dropOldestFrame refuses to forget a
+		// Pending one, and sess.calls grows with every exchange nobody finished:
+		// measured at five thousand entries against a two hundred frame window.
+		for _, c := range sess.awaiting[:excess] {
+			c.retired = true
+		}
 		copy(sess.awaiting, sess.awaiting[excess:kept])
 		kept -= excess
 		// Counted, never silent. Retiring a settled operation above loses nothing,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -189,6 +189,24 @@ type call struct {
 	// only be answering the round it was issued from.
 	elicitations []*elicitation
 	elicitRound  int
+	// hops, serverTime and clientTime describe a multi round-trip operation as it
+	// is observed, and hopMark is the frame the current interval started at.
+	//
+	// Accumulated at ingest rather than derived from the timeline on read. The
+	// specification puts no bound on how many hops a chain may take, so a slice of
+	// them would grow without one, but three scalars do not. Deriving was the other
+	// option and a bounded live store rules it out: with a window of four frames a
+	// three hop chain shows two request frames and no call at all, so the answer
+	// would silently be a window rather than a chain. These survive eviction.
+	//
+	// The intervals alternate, so one mark is enough. A request starts the server's
+	// interval, its response ends it and starts the client's, and the retry ends
+	// that and starts the next. They telescope, so serverTime + clientTime is
+	// exactly the span from the first request to the last response.
+	hops       int
+	serverTime time.Duration
+	clientTime time.Duration
+	hopMark    time.Time
 	// retired marks an operation the parking cap dropped. Nothing can continue it
 	// any more, so a bounded store may forget it even though it is still Pending,
 	// which it is: no response ever came, and saying otherwise would change what
@@ -702,6 +720,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			root.mrtrState, root.mrtrKeys = "", ""
 			root.mrtrHasState = false
 			sess.unpark(root)
+			// The client's interval ends where the retry starts, and this is the hop
+			// the answers belong to. Counted here rather than from the timeline, since
+			// a bounded store evicts the frames a derived count would need.
+			root.markHop(e.TS, &root.clientTime)
+			root.hops++
 			ev.call = root
 			ev.kind = EventRequest
 			ev.method = msg.Method
@@ -1178,6 +1201,8 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		params:     msg.Params,
 		start:      e.TS,
 		state:      Pending,
+		hops:       1,
+		hopMark:    e.TS,
 	}
 	if isStreamOpeningMethod(msg.Method) {
 		c.state = Streaming
@@ -1221,11 +1246,13 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		// late result nor the duplicate this branch used to report.
 		if c.method == "subscriptions/listen" {
 			c.end = ts
+			c.markHop(ts, &c.serverTime)
 			c.result = msg.Result
 			c.err = msg.Error
 			return c, true
 		}
 		c.end = ts
+		c.markHop(ts, &c.serverTime)
 		c.result = msg.Result
 		c.err = msg.Error
 		c.toolErr = isToolError(msg.Result)
@@ -1269,6 +1296,11 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		if round := parseElicitations(state.requests, ts); !sameElicitRound(c.elicitations[c.elicitRound:], round) {
 			c.elicitRound = len(c.elicitations)
 			c.elicitations = append(c.elicitations, round...)
+			// This hop's server interval ends here and the client's begins. Inside the
+			// fresh-round test on purpose: a server resending the same result on one id
+			// is not a new hop, and charging the gap between the two copies to the
+			// server made the totals contradict the breakdown printed under them.
+			c.markHop(ts, &c.serverTime)
 		}
 		sess.park(c)
 		return c, true
@@ -1285,6 +1317,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 	c.end = ts
 	c.result = msg.Result
 	c.err = msg.Error
+	c.markHop(ts, &c.serverTime)
 	wasPending := c.state == Pending
 	switch {
 	case msg.Error != nil:
@@ -1403,6 +1436,7 @@ func (sess *session) applyParsedTaskState(state taskState, ts time.Time) (*call,
 		return c, false
 	}
 	c.end = ts
+	c.markHop(ts, &c.serverTime)
 	c.errored = countsAsError // the failed and completed-with-isError cases, not cancelled
 	sess.pending--
 	return c, countsAsError
@@ -2016,6 +2050,7 @@ func (sess *session) cancelCall(id string, dir proxy.Direction, conn string, ts 
 	c.state = Cancelled
 	c.cancelledAt = ts
 	c.cancelReason = reason
+	c.markHop(ts, &c.serverTime)
 	sess.pending--
 	return c
 }
@@ -2035,6 +2070,7 @@ func (sess *session) closeStreamingCall(id, conn string, ts time.Time, reason st
 		c := sess.calls[key]
 		if c != nil && c.state == Streaming {
 			c.end = ts
+			c.markHop(ts, &c.serverTime)
 			c.state = Cancelled
 			c.cancelledAt = ts
 			c.cancelReason = reason
@@ -2317,4 +2353,27 @@ func opposite(d proxy.Direction) proxy.Direction {
 		return proxy.ServerToClient
 	}
 	return proxy.ClientToServer
+}
+
+// markHop closes the interval that began at the last mark, adding it to into,
+// and starts the next one at ts.
+//
+// A frame out of order adds nothing rather than a negative interval. Envelope
+// sequence is monotonic per session and the proxy holds a lock across the emit,
+// so this is the log being edited or two captures being concatenated, and a
+// negative hop would make serverTime and clientTime disagree with the wall clock
+// they are supposed to add up to.
+func (c *call) markHop(ts time.Time, into *time.Duration) {
+	if c.hopMark.IsZero() {
+		c.hopMark = ts
+		return
+	}
+	if !ts.After(c.hopMark) {
+		// The mark stays where it was. Moving it to a frame that went backwards
+		// would drop nothing and instead charge the skew to whichever hop closed
+		// next, which is worse than declining to measure the one that was wrong.
+		return
+	}
+	*into += ts.Sub(c.hopMark)
+	c.hopMark = ts
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3182,3 +3182,88 @@ func TestTheParkingCapSaysWhatItRetired(t *testing.T) {
 		}
 	})
 }
+
+// TestARetiredOperationStopsBeingHeld is the other half of the parking cap. The
+// cap stops an abandoned exchange from being a match candidate, but the call
+// itself stayed in the session's call map, because dropOldestFrame refuses to
+// forget a Pending one and a parked multi round-trip operation is Pending by
+// design, so its duration can span the whole exchange.
+//
+// The result was a bounded store that was not bounded: a server answering every
+// call with an input request grew it with each one, however small the frame
+// window was. Measured before the fix at five thousand calls held against a two
+// hundred frame window.
+func TestARetiredOperationStopsBeingHeld(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	const frames = 200
+	const exchanges = 2000
+	s := NewBounded(64<<10, frames)
+	seq := uint64(0)
+	emit := func(dir proxy.Direction, raw string) {
+		seq++
+		s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "d", Seq: seq,
+			TS: t0.Add(time.Duration(seq) * time.Millisecond), Direction: dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)})
+	}
+	for i := range exchanges {
+		id := fmt.Sprintf("c%d", i)
+		emit(proxy.ClientToServer, fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":"t"}}`, id))
+		emit(proxy.ServerToClient, fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":%q,"result":{"resultType":"input_required","requestState":"s%d","inputRequests":{"k":{"method":"elicitation/create","params":{"message":"m"}}}}}`, id, i))
+	}
+
+	sess := s.sessions["s1"]
+	// Bounded by the frame window and the parking cap, not by how many exchanges
+	// went unfinished. The window holds two frames per exchange, so a hundred
+	// calls are still reachable through it.
+	if held := len(sess.calls); held > frames {
+		t.Fatalf("calls held = %d after %d abandoned exchanges, want no more than the %d-frame window",
+			held, exchanges, frames)
+	}
+	if len(sess.awaiting) > awaitingKept {
+		t.Fatalf("awaiting = %d, want at most the cap of %d", len(sess.awaiting), awaitingKept)
+	}
+
+	// Nothing about the session's verdict moved. Releasing a call the store can no
+	// longer reach is a memory decision, and a reader is told what happened by the
+	// pending count and by RetiredExchanges, both of which still count every one.
+	header := s.Sessions()[0]
+	if header.Pending != exchanges {
+		t.Fatalf("pending = %d, want %d; forgetting a call must not change what the session reports",
+			header.Pending, exchanges)
+	}
+	if header.RetiredExchanges != exchanges-awaitingKept {
+		t.Fatalf("RetiredExchanges = %d, want %d", header.RetiredExchanges, exchanges-awaitingKept)
+	}
+}
+
+// TestAPendingCallIsStillHeldWhileItCanBeAnswered keeps the release narrow. Only
+// an operation the cap has retired may be forgotten, because only that one can
+// never be continued. An ordinary call still waiting for its response has to stay
+// reachable, or the response that arrives will open a second call instead of
+// settling the first.
+func TestAPendingCallIsStillHeldWhileItCanBeAnswered(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	s := NewBounded(64<<10, 4) // a window far smaller than the exchange
+	seq := uint64(0)
+	emit := func(dir proxy.Direction, raw string) {
+		seq++
+		s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "d", Seq: seq,
+			TS: t0.Add(time.Duration(seq) * time.Millisecond), Direction: dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)})
+	}
+	emit(proxy.ClientToServer, `{"jsonrpc":"2.0","id":"slow","method":"tools/call","params":{"name":"t"}}`)
+	// Enough traffic to push the request frame out of the window entirely.
+	for range 10 {
+		emit(proxy.ClientToServer, `{"jsonrpc":"2.0","method":"notifications/progress","params":{}}`)
+	}
+	emit(proxy.ServerToClient, `{"jsonrpc":"2.0","id":"slow","result":{"content":[]}}`)
+
+	header := s.Sessions()[0]
+	if header.Pending != 0 {
+		t.Fatalf("pending = %d, want 0; the response could not find the call it answers", header.Pending)
+	}
+	if header.Responses != 1 {
+		t.Fatalf("responses = %d, want 1", header.Responses)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2729,3 +2729,108 @@ func TestBothBoundsHoldTogether(t *testing.T) {
 		t.Fatalf("summary = %+v, want all 300 calls", sum.Tools)
 	}
 }
+
+// storeBudgetHolds checks the accounting against the frames that are actually
+// there. The two counters are store-wide while the work that changes them is
+// per session, so every path that moves a frame has to settle both, and the way
+// this goes wrong is silent: the store believes it is fuller than it is and
+// starts releasing bodies it did not need to.
+func storeBudgetHolds(t *testing.T, s *Store, where string) {
+	t.Helper()
+	bytes, frames := 0, 0
+	for _, sess := range s.sessions {
+		sessBytes := 0
+		for _, ev := range sess.events {
+			sessBytes += bodyWeight(ev)
+		}
+		if sess.bodyBytes != sessBytes {
+			t.Fatalf("%s: session %s accounts %d bytes, its frames weigh %d", where, sess.id, sess.bodyBytes, sessBytes)
+		}
+		bytes += sessBytes
+		frames += len(sess.events)
+	}
+	if s.payloadBytes != bytes {
+		t.Fatalf("%s: store accounts %d bytes, the frames weigh %d, %d phantom", where, s.payloadBytes, bytes, s.payloadBytes-bytes)
+	}
+	if s.frames != frames {
+		t.Fatalf("%s: store counts %d frames, holds %d", where, s.frames, frames)
+	}
+}
+
+// TestBoundedStoreGivesTheBudgetBack. Both counters are store-wide, so any path
+// that removes a frame without settling them leaves budget nothing can ever
+// release. The two that did were deleting a session, which the TUI does on
+// ctrl+d, and the frame cap dropping a frame the byte budget had not reached
+// yet. Neither had a test: the existing ones either delete from an unbounded
+// store or set a byte budget so tight that the release always runs first.
+func TestBoundedStoreGivesTheBudgetBack(t *testing.T) {
+	// A roomy byte budget with a frame cap that bites, which is the shape the
+	// live TUI actually runs (64 MiB against 200,000 frames) and the shape no
+	// other test covers.
+	s := NewBounded(1<<30, 12)
+	t0 := time.Now()
+	frame := func(session string, seq uint64, size int) proxy.Envelope {
+		return proxy.Envelope{
+			SessionID: session, ServerLabel: "srv", Seq: seq,
+			TS:        t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/progress","params":{"t":"` +
+				strings.Repeat("x", size) + `"}}`),
+		}
+	}
+
+	for i := range 40 {
+		s.Ingest(frame("a", uint64(i+1), 200))
+		storeBudgetHolds(t, s, "ingest into one session")
+	}
+	// The cap is doing the work here, not the byte budget, or the case this test
+	// exists for is not the case being run.
+	if got := len(s.Timeline("a")); got != 12 {
+		t.Fatalf("timeline holds %d frames, want the cap of 12", got)
+	}
+	if s.payloadBytes == 0 {
+		t.Fatal("every body was released, so the byte budget bit and the frame cap did not")
+	}
+
+	// A second session, so the cap starts moving frames between sessions.
+	for i := range 20 {
+		s.Ingest(frame("b", uint64(i+41), 300))
+		storeBudgetHolds(t, s, "ingest into a second session")
+	}
+
+	// Deleting a session has to hand back what it was holding.
+	s.Delete("a")
+	storeBudgetHolds(t, s, "after deleting a session")
+	s.Delete("b")
+	storeBudgetHolds(t, s, "after deleting the last session")
+	if s.payloadBytes != 0 || s.frames != 0 {
+		t.Fatalf("an empty store still accounts %d bytes and %d frames", s.payloadBytes, s.frames)
+	}
+
+	// And the store still works afterwards. This is the symptom that made it
+	// worth finding: with the budget still spent on a deleted session, every
+	// frame ingested next was released the moment it arrived and the inspector
+	// showed no payload at all for the rest of the process.
+	for i := range 5 {
+		s.Ingest(frame("c", uint64(i+100), 200))
+	}
+	storeBudgetHolds(t, s, "after reusing the store")
+	for _, ev := range s.Timeline("c") {
+		if ev.BodyReleased {
+			t.Fatal("a fresh frame was released immediately, so the budget never came back")
+		}
+	}
+}
+
+// TestDeleteOnAnUnboundedStoreTouchesNoBudget. check, export, diff and open all
+// build an unbounded store, and giving back budget it never took would make the
+// counters negative.
+func TestDeleteOnAnUnboundedStoreTouchesNoBudget(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{}`))
+	s.Delete("s1")
+	if s.payloadBytes != 0 || s.frames != 0 {
+		t.Fatalf("an unbounded store moved its budget counters to %d/%d", s.payloadBytes, s.frames)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -2461,5 +2463,269 @@ func TestPercentilesSkipCallsThatNeverAnswered(t *testing.T) {
 		if slow.Duration < 0 {
 			t.Fatalf("slowest calls carry a negative duration: %+v", slow)
 		}
+	}
+}
+
+// TestBoundedStoreReleasesOldBodiesAndKeepsEveryCount. A hub left watching a
+// chatty server grew until it was killed, because nothing bounded what the store
+// kept and every event held the full observed frame. The bound is on bytes, not
+// on history: every frame keeps its row and its verdict, and only the bodies of
+// the oldest ones go.
+func TestBoundedStoreReleasesOldBodiesAndKeepsEveryCount(t *testing.T) {
+	const pairs = 200
+	const limit = 8 << 10
+
+	t0 := time.Now() // shared, so the two headers differ only if a count does
+	build := func(s *Store) *Store {
+		big := strings.Repeat("x", 512)
+		for i := range pairs {
+			id := strconv.Itoa(i + 1)
+			s.Ingest(req(uint64(2*i+1), t0, proxy.ClientToServer, id, "tools/call",
+				`{"name":"echo","arguments":{"text":"`+big+`"}}`))
+			s.Ingest(resp(uint64(2*i+2), t0, proxy.ServerToClient, id,
+				`"result":{"content":[{"type":"text","text":"`+big+`"}]}`))
+		}
+		return s
+	}
+	held := func(s *Store) int {
+		n := 0
+		for _, sess := range s.sessions {
+			for _, ev := range sess.events {
+				n += len(ev.raw) + len(ev.text)
+			}
+			for _, c := range sess.calls {
+				n += len(c.params) + len(c.result)
+			}
+		}
+		return n
+	}
+
+	full, bounded := build(New()), build(NewBounded(limit, 0))
+
+	if held(bounded) > limit {
+		t.Fatalf("bounded store holds %d bytes of bodies, over its %d budget", held(bounded), limit)
+	}
+	if held(full) <= limit {
+		t.Fatalf("the fixture does not exceed the budget, so it proves nothing: %d bytes", held(full))
+	}
+
+	// Nothing a reader counts may move. The frames, the calls, the session
+	// counters and the context-cost figures all have to match the unbounded store
+	// exactly, or a bound has quietly turned into an under-report.
+	a, b := full.Timeline("s1"), bounded.Timeline("s1")
+	if len(a) != len(b) {
+		t.Fatalf("frames = %d bounded against %d unbounded", len(b), len(a))
+	}
+	if len(full.Calls("s1")) != len(bounded.Calls("s1")) {
+		t.Fatalf("calls = %d bounded against %d unbounded", len(bounded.Calls("s1")), len(full.Calls("s1")))
+	}
+	if got, want := bounded.Sessions()[0], full.Sessions()[0]; got != want {
+		t.Fatalf("session header differs:\n%+v\n%+v", got, want)
+	}
+	fullSum, _ := full.ToolSummary("s1")
+	boundSum, _ := bounded.ToolSummary("s1")
+	if !reflect.DeepEqual(fullSum.Tools, boundSum.Tools) {
+		t.Fatalf("tool statistics differ once bodies were released:\n%+v\n%+v", boundSum.Tools, fullSum.Tools)
+	}
+
+	// The oldest frames say their body is gone rather than reading as a server
+	// that sent nothing, and the newest still carry theirs.
+	released := 0
+	for _, e := range b {
+		if e.BodyReleased {
+			released++
+			if len(e.Raw) != 0 || e.Text != "" {
+				t.Fatal("a frame marked released still holds its body")
+			}
+		}
+	}
+	if released == 0 {
+		t.Fatal("nothing was released, so the budget was never enforced")
+	}
+	if b[len(b)-1].BodyReleased {
+		t.Fatal("the newest frame lost its body, so eviction is not oldest-first")
+	}
+}
+
+// TestUnboundedStoreIsWhatCheckAndExportBuild. check reads a finite log once and
+// gates on what it finds, so a bound there would make it under-report on a large
+// capture, which is the one thing a gate must never do.
+func TestUnboundedStoreIsWhatCheckAndExportBuild(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	big := strings.Repeat("y", 4096)
+	for i := range 50 {
+		id := strconv.Itoa(i + 1)
+		s.Ingest(req(uint64(2*i+1), t0, proxy.ClientToServer, id, "tools/call", `{"name":"echo","arguments":{"t":"`+big+`"}}`))
+		s.Ingest(resp(uint64(2*i+2), t0, proxy.ServerToClient, id, `"result":{"content":[{"type":"text","text":"`+big+`"}]}`))
+	}
+	for _, e := range s.Timeline("s1") {
+		if e.BodyReleased {
+			t.Fatal("an unbounded store released a body")
+		}
+		if len(e.Raw) == 0 {
+			t.Fatal("an unbounded store dropped a frame's bytes")
+		}
+	}
+}
+
+// TestBoundedStoreAccountingStaysConsistent. The release walks a cursor per
+// session while one running total decides when to stop, so the two have to agree
+// or the loop either stops early and the budget is a lie, or runs off the end of
+// a timeline. A budget of one byte forces every frame through the path.
+func TestBoundedStoreAccountingStaysConsistent(t *testing.T) {
+	s := NewBounded(1, 0)
+	t0 := time.Now()
+	body := strings.Repeat("z", 256)
+
+	// Two sessions interleaved, since release is oldest-first across the store
+	// rather than within one session, and a hub carries many at once.
+	for i := range 40 {
+		id := strconv.Itoa(i + 1)
+		for _, sid := range []string{"s1", "s2"} {
+			r := req(uint64(2*i+1), t0.Add(time.Duration(i)*time.Millisecond), proxy.ClientToServer, id, "tools/call",
+				`{"name":"echo","arguments":{"t":"`+body+`"}}`)
+			r.SessionID = sid
+			s.Ingest(r)
+			p := resp(uint64(2*i+2), t0.Add(time.Duration(i)*time.Millisecond), proxy.ServerToClient, id,
+				`"result":{"content":[{"type":"text","text":"`+body+`"}]}`)
+			p.SessionID = sid
+			s.Ingest(p)
+		}
+	}
+
+	// Everything but the newest frame is releasable, so the total must come down
+	// to what that one frame weighs and no further.
+	if s.payloadBytes < 0 {
+		t.Fatalf("the running total went negative at %d, so a frame was released twice", s.payloadBytes)
+	}
+	var held int
+	for _, sess := range s.sessions {
+		if sess.evictCursor > len(sess.events) {
+			t.Fatalf("cursor %d is past the %d frames it indexes", sess.evictCursor, len(sess.events))
+		}
+		for _, ev := range sess.events {
+			held += bodyWeight(ev)
+		}
+		if sess.bodyBytes < 0 {
+			t.Fatalf("session total went negative at %d", sess.bodyBytes)
+		}
+	}
+	if held != s.payloadBytes {
+		t.Fatalf("the store says %d bytes are held, the frames hold %d", s.payloadBytes, held)
+	}
+	for _, sid := range []string{"s1", "s2"} {
+		if got := len(s.Timeline(sid)); got != 80 {
+			t.Fatalf("%s has %d frames, want every one of them kept", sid, got)
+		}
+	}
+}
+
+// TestBoundedStoreDropsOldFramesAndKeepsTheToolStatistics. Releasing bodies
+// bounds the bytes but not the count, and a frame whose body is gone still costs
+// its own struct, so a chatty stream of small notifications grew without ever
+// reaching the byte budget. The oldest frames go entirely past a frame limit,
+// and what they said about a tool call is folded into the running statistics
+// first, or the tool summary would quietly describe only recent calls.
+func TestBoundedStoreDropsOldFramesAndKeepsTheToolStatistics(t *testing.T) {
+	const pairs = 300
+	const keepFrames = 100
+
+	t0 := time.Now() // shared, so the two summaries differ only if a figure does
+	build := func(s *Store) *Store {
+		for i := range pairs {
+			id := strconv.Itoa(i + 1)
+			ts := t0.Add(time.Duration(i) * time.Millisecond)
+			s.Ingest(req(uint64(2*i+1), ts, proxy.ClientToServer, id, "tools/call", `{"name":"echo","arguments":{"i":`+id+`}}`))
+			s.Ingest(resp(uint64(2*i+2), ts.Add(time.Millisecond), proxy.ServerToClient, id, `"result":{"content":[{"type":"text","text":"ok"}]}`))
+		}
+		return s
+	}
+
+	full := build(New())
+	bounded := build(NewBounded(0, keepFrames))
+
+	if got := len(bounded.Timeline("s1")); got != keepFrames {
+		t.Fatalf("timeline holds %d frames, want the %d cap", got, keepFrames)
+	}
+	if got := len(full.Timeline("s1")); got != 2*pairs {
+		t.Fatalf("the unbounded store dropped frames: %d", got)
+	}
+
+	// The statistics are the whole point. Every call the session made has to be in
+	// them, whether or not its frames are still held.
+	fullSum, _ := full.ToolSummary("s1")
+	boundSum, _ := bounded.ToolSummary("s1")
+	if !reflect.DeepEqual(fullSum.Tools, boundSum.Tools) {
+		t.Fatalf("tool statistics shrank with the timeline:\n bounded %+v\n full    %+v", boundSum.Tools, fullSum.Tools)
+	}
+	if len(boundSum.Tools) == 0 || boundSum.Tools[0].Calls != pairs {
+		t.Fatalf("the summary counts %+v, want all %d calls", boundSum.Tools, pairs)
+	}
+	if !reflect.DeepEqual(fullSum.Slowest, boundSum.Slowest) {
+		t.Fatalf("the slowest calls differ:\n bounded %+v\n full    %+v", boundSum.Slowest, fullSum.Slowest)
+	}
+
+	// The session counters come from the ingest path, not from the timeline, so
+	// dropping frames must not move them either.
+	if got, want := bounded.Sessions()[0].Requests, full.Sessions()[0].Requests; got != want {
+		t.Fatalf("requests = %d bounded against %d unbounded", got, want)
+	}
+
+	// A settled call nothing points at any more is not left in the map.
+	sess := bounded.sessions["s1"]
+	if len(sess.calls) > keepFrames {
+		t.Fatalf("%d calls retained for %d frames, so the map grows unbounded too", len(sess.calls), keepFrames)
+	}
+}
+
+// TestBothBoundsHoldTogether. The two bounds move the same timeline from both
+// ends, the body release walking a cursor forward and the frame cap removing
+// entries from the front, so the cursor has to be rebased as the slice shifts or
+// it points at a frame that has already moved. This drives both at once and
+// checks the accounting still describes the frames that are actually there.
+func TestBothBoundsHoldTogether(t *testing.T) {
+	s := NewBounded(4<<10, 60)
+	t0 := time.Now()
+	body := strings.Repeat("q", 400)
+
+	for i := range 300 {
+		id := strconv.Itoa(i + 1)
+		ts := t0.Add(time.Duration(i) * time.Millisecond)
+		s.Ingest(req(uint64(2*i+1), ts, proxy.ClientToServer, id, "tools/call",
+			`{"name":"echo","arguments":{"t":"`+body+`"}}`))
+		s.Ingest(resp(uint64(2*i+2), ts.Add(time.Millisecond), proxy.ServerToClient, id,
+			`"result":{"content":[{"type":"text","text":"`+body+`"}]}`))
+
+		sess := s.sessions["s1"]
+		if sess.evictCursor > len(sess.events) {
+			t.Fatalf("after %d pairs the cursor is %d against %d frames", i, sess.evictCursor, len(sess.events))
+		}
+		held := 0
+		for _, ev := range sess.events {
+			held += bodyWeight(ev)
+		}
+		if held != s.payloadBytes {
+			t.Fatalf("after %d pairs the store says %d bytes, the frames hold %d", i, s.payloadBytes, held)
+		}
+		// Everything before the cursor has already given up its body, or the cursor
+		// is not describing what it claims to.
+		for j := range sess.evictCursor {
+			if len(sess.events[j].raw) != 0 {
+				t.Fatalf("frame %d is behind the cursor and still holds its body", j)
+			}
+		}
+	}
+
+	if got := len(s.Timeline("s1")); got != 60 {
+		t.Fatalf("timeline holds %d frames, want the 60 cap", got)
+	}
+	if s.payloadBytes > 4<<10 {
+		t.Fatalf("bodies weigh %d, over the 4 KiB budget", s.payloadBytes)
+	}
+	// Every call still reaches the summary, whichever bound removed its frames.
+	sum, _ := s.ToolSummary("s1")
+	if len(sum.Tools) != 1 || sum.Tools[0].Calls != 300 {
+		t.Fatalf("summary = %+v, want all 300 calls", sum.Tools)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2834,3 +2834,351 @@ func TestDeleteOnAnUnboundedStoreTouchesNoBudget(t *testing.T) {
 		t.Fatalf("an unbounded store moved its budget counters to %d/%d", s.payloadBytes, s.frames)
 	}
 }
+
+// TestSessionCarriesItsTransportAndEndpoint covers the whole path a capture uses
+// to say what it captured. The label cannot say it: the http command defaults it
+// to the target host alone, so two proxies pointed at two paths of one host
+// produce the same one.
+func TestSessionCarriesItsTransportAndEndpoint(t *testing.T) {
+	base := time.Unix(0, 0).UTC()
+	meta, err := json.Marshal(proxy.SessionMeta{Target: "https://api.example.com/tenant-a/mcp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := New()
+	s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "api.example.com", Seq: 1, TS: base, Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta})
+	e := req(2, base.Add(time.Millisecond), proxy.ClientToServer, "1", "tools/list", "")
+	e.Transport = proxy.TransportHTTP
+	s.Ingest(e)
+
+	headers := s.Sessions()
+	if len(headers) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(headers))
+	}
+	if got := headers[0].Transport; got != proxy.TransportHTTP {
+		t.Fatalf("Transport = %q, want %q", got, proxy.TransportHTTP)
+	}
+	if got, want := headers[0].Endpoint, "https://api.example.com/tenant-a/mcp"; got != want {
+		t.Fatalf("Endpoint = %q, want %q", got, want)
+	}
+}
+
+// TestAStdioSessionClaimsNoEndpoint keeps the absence meaningful. A reader that
+// sees an endpoint has to be able to conclude the session was captured over HTTP.
+func TestAStdioSessionClaimsNoEndpoint(t *testing.T) {
+	base := time.Unix(0, 0).UTC()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "server.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := New()
+	s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: base, Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+
+	headers := s.Sessions()
+	if len(headers) != 1 || headers[0].Endpoint != "" {
+		t.Fatalf("stdio session reported endpoint %q, want none", headers[0].Endpoint)
+	}
+	if headers[0].Transport != proxy.TransportStdio {
+		t.Fatalf("Transport = %q, want %q", headers[0].Transport, proxy.TransportStdio)
+	}
+	if cmd, cwd, ok := s.Command("s1"); !ok || len(cmd) != 2 || cwd != "/srv" {
+		t.Fatalf("Command = %v, %q, %v, want the recorded stdio command", cmd, cwd, ok)
+	}
+}
+
+// TestAPreEndpointHTTPLogStaysReadable is the forward-compatibility rule that
+// SessionMeta grows by. A log written before mcpsnoop recorded the target has no
+// target, and that must read as an absence rather than as a decode failure that
+// loses the command beside it.
+func TestAPreEndpointHTTPLogStaysReadable(t *testing.T) {
+	base := time.Unix(0, 0).UTC()
+	s := New()
+	s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: base,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP,
+		Raw: json.RawMessage(`{"command":null,"future_field":{"nested":1}}`),
+	})
+
+	headers := s.Sessions()
+	if len(headers) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(headers))
+	}
+	if headers[0].Endpoint != "" {
+		t.Fatalf("Endpoint = %q, want empty for a log that predates the field", headers[0].Endpoint)
+	}
+	if headers[0].Transport != proxy.TransportHTTP {
+		t.Fatalf("Transport = %q, want the frame's own", headers[0].Transport)
+	}
+}
+
+// TestAFrameWithNoTransportLeavesTheKnownOneAlone is why the transport is taken
+// from the first frame that names one rather than from the latest. Not every
+// envelope carries the field, and an unconditional assignment lets a frame that
+// knows nothing erase what the meta frame already said.
+func TestAFrameWithNoTransportLeavesTheKnownOneAlone(t *testing.T) {
+	base := time.Unix(0, 0).UTC()
+	s := New()
+	s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: base, Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: json.RawMessage(`{}`)})
+	s.Ingest(req(2, base.Add(time.Millisecond), proxy.ClientToServer, "1", "tools/list", "")) // no Transport set
+
+	headers := s.Sessions()
+	if len(headers) != 1 || headers[0].Transport != proxy.TransportHTTP {
+		t.Fatalf("Transport = %q, want it to survive a frame that named none", headers[0].Transport)
+	}
+}
+
+// TestToolSummarySplitsBrokenServerFromReportedFailure covers the reason the two
+// counts exist. A tool answering isError is doing its job, a server answering a
+// JSON-RPC error is broken, and one number for both makes the first look like
+// the second.
+func TestToolSummarySplitsBrokenServerFromReportedFailure(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	// search answers isError twice: it looked, and found nothing.
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"search"}`))
+	s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"result":{"content":[],"isError":true}`))
+	s.Ingest(req(3, t0.Add(2*time.Millisecond), proxy.ClientToServer, "2", "tools/call", `{"name":"search"}`))
+	s.Ingest(resp(4, t0.Add(3*time.Millisecond), proxy.ServerToClient, "2", `"result":{"content":[],"isError":true}`))
+	// write is broken: the server returns a JSON-RPC error.
+	s.Ingest(req(5, t0.Add(4*time.Millisecond), proxy.ClientToServer, "3", "tools/call", `{"name":"write"}`))
+	s.Ingest(resp(6, t0.Add(5*time.Millisecond), proxy.ServerToClient, "3", `"error":{"code":-32603,"message":"boom"}`))
+	// mixed carries one of each.
+	s.Ingest(req(7, t0.Add(6*time.Millisecond), proxy.ClientToServer, "4", "tools/call", `{"name":"mixed"}`))
+	s.Ingest(resp(8, t0.Add(7*time.Millisecond), proxy.ServerToClient, "4", `"result":{"content":[],"isError":true}`))
+	s.Ingest(req(9, t0.Add(8*time.Millisecond), proxy.ClientToServer, "5", "tools/call", `{"name":"mixed"}`))
+	s.Ingest(resp(10, t0.Add(9*time.Millisecond), proxy.ServerToClient, "5", `"error":{"code":-32603,"message":"boom"}`))
+
+	summary, ok := s.ToolSummary("s1")
+	if !ok {
+		t.Fatal("no tool summary")
+	}
+	byName := make(map[string]ToolStats, len(summary.Tools))
+	for _, tool := range summary.Tools {
+		byName[tool.Name] = tool
+	}
+	for _, want := range []ToolStats{
+		{Name: "search", Errors: 2, ProtocolErrors: 0, ToolErrors: 2},
+		{Name: "write", Errors: 1, ProtocolErrors: 1, ToolErrors: 0},
+		{Name: "mixed", Errors: 2, ProtocolErrors: 1, ToolErrors: 1},
+	} {
+		got, found := byName[want.Name]
+		if !found {
+			t.Fatalf("tool %q is missing from the summary", want.Name)
+		}
+		if got.Errors != want.Errors || got.ProtocolErrors != want.ProtocolErrors || got.ToolErrors != want.ToolErrors {
+			t.Fatalf("%s = %d errors (%d protocol, %d tool), want %d (%d, %d)",
+				want.Name, got.Errors, got.ProtocolErrors, got.ToolErrors,
+				want.Errors, want.ProtocolErrors, want.ToolErrors)
+		}
+	}
+}
+
+// TestEveryToolErrorLandsInExactlyOneBucket is the invariant the split is built
+// to hold rather than to be remembered. ProtocolErrors is the complement of
+// ToolErrors, not its own tally, so the third way errored is set, a task that
+// ends failed carrying neither an error object nor isError, is counted without
+// anyone having had to think of it here.
+func TestEveryToolErrorLandsInExactlyOneBucket(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+
+	// A JSON-RPC error and an isError, one of each of the two obvious kinds.
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"t"}`))
+	s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1", `"error":{"code":-32603,"message":"boom"}`))
+	s.Ingest(req(3, t0.Add(2*time.Millisecond), proxy.ClientToServer, "2", "tools/call", `{"name":"t"}`))
+	s.Ingest(resp(4, t0.Add(3*time.Millisecond), proxy.ServerToClient, "2", `"result":{"content":[],"isError":true}`))
+	// A plain success, which must land in neither.
+	s.Ingest(req(5, t0.Add(4*time.Millisecond), proxy.ClientToServer, "3", "tools/call", `{"name":"t"}`))
+	s.Ingest(resp(6, t0.Add(5*time.Millisecond), proxy.ServerToClient, "3", `"result":{"content":[]}`))
+	// The third kind. The call is parked as a task and the task later ends failed
+	// with no error object and no isError, so nothing about it says which bucket
+	// it belongs in.
+	s.Ingest(req(7, t0.Add(6*time.Millisecond), proxy.ClientToServer, "4", "tools/call", `{"name":"t"}`))
+	s.Ingest(resp(8, t0.Add(7*time.Millisecond), proxy.ServerToClient, "4", `"result":{"resultType":"task","taskId":"t1","status":"working"}`))
+	s.Ingest(req(9, t0.Add(8*time.Millisecond), proxy.ClientToServer, "5", "tasks/get", `{"taskId":"t1"}`))
+	s.Ingest(resp(10, t0.Add(9*time.Millisecond), proxy.ServerToClient, "5", `"result":{"taskId":"t1","status":"failed"}`))
+
+	summary, ok := s.ToolSummary("s1")
+	if !ok {
+		t.Fatal("no tool summary")
+	}
+	if len(summary.Tools) != 1 {
+		t.Fatalf("tools = %d, want 1", len(summary.Tools))
+	}
+	got := summary.Tools[0]
+	// Four calls went wrong, and only one of them was the tool saying so.
+	if got.Errors != 3 || got.ToolErrors != 1 || got.ProtocolErrors != 2 {
+		t.Fatalf("errors = %d (%d protocol, %d tool), want 3 (2, 1); the undiagnosed task failure has to land somewhere",
+			got.Errors, got.ProtocolErrors, got.ToolErrors)
+	}
+	if got.ProtocolErrors+got.ToolErrors != got.Errors {
+		t.Fatalf("%d + %d does not add up to the %d total", got.ProtocolErrors, got.ToolErrors, got.Errors)
+	}
+}
+
+// mrtrProbe builds a session with n MRTR exchanges the client walked away from,
+// then one genuine exchange on the same tool that the client does complete. The
+// abandoned ones carry a requestState and the genuine one does not, which is the
+// ordinary shape: a server that mints state for the operations it expects back,
+// and one it answers statelessly.
+func mrtrProbe(t *testing.T, abandoned int) (*Store, *session) {
+	t.Helper()
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	var seq uint64
+	ask := func(id, state string) {
+		seq++
+		s.Ingest(req(seq, t0.Add(time.Duration(seq)*time.Millisecond), proxy.ClientToServer, id, "tools/call", `{"name":"delete_files","arguments":{}}`))
+		seq++
+		s.Ingest(resp(seq, t0.Add(time.Duration(seq)*time.Millisecond), proxy.ServerToClient, id,
+			fmt.Sprintf(`"result":{"resultType":"input_required","requestState":%q,"inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}`, state)))
+	}
+	for i := range abandoned {
+		ask(fmt.Sprintf("%d", i), fmt.Sprintf("state-%d", i))
+	}
+	// The genuine exchange, answered and retried the way the pattern intends.
+	seq++
+	s.Ingest(req(seq, t0.Add(time.Duration(seq)*time.Millisecond), proxy.ClientToServer, "200", "tools/call", `{"name":"delete_files","arguments":{}}`))
+	seq++
+	s.Ingest(resp(seq, t0.Add(time.Duration(seq)*time.Millisecond), proxy.ServerToClient, "200",
+		`"result":{"resultType":"input_required","inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}`))
+	seq++
+	s.Ingest(req(seq, t0.Add(time.Duration(seq)*time.Millisecond), proxy.ClientToServer, "201", "tools/call",
+		`{"name":"delete_files","arguments":{},"inputResponses":{"k1":{"result":{}}}}`))
+	seq++
+	s.Ingest(resp(seq, t0.Add(time.Duration(seq)*time.Millisecond), proxy.ServerToClient, "201", `"result":{"content":[]}`))
+	return s, s.sessions["s1"]
+}
+
+// TestAnAbandonedExchangeDoesNotBreakTheNextOne is the defect the two-pass
+// fallback fixes. MRTR says servers "MUST NOT assume that clients will fulfill
+// the inputRequests or retry the original request", so an abandoned exchange is
+// an ordinary outcome, and one of them was enough to make the next conforming
+// retry on the same tool look ambiguous. The retry then stayed its own call, and
+// the operation was counted and timed as two, which is exactly what correlating
+// MRTR was written to prevent.
+func TestAnAbandonedExchangeDoesNotBreakTheNextOne(t *testing.T) {
+	for _, abandoned := range []int{0, 1, 10} {
+		t.Run(fmt.Sprintf("%d abandoned", abandoned), func(t *testing.T) {
+			s, _ := mrtrProbe(t, abandoned)
+			summary, ok := s.ToolSummary("s1")
+			if !ok {
+				t.Fatal("no tool summary")
+			}
+			var calls int
+			for _, tool := range summary.Tools {
+				if tool.Name == "delete_files" {
+					calls = tool.Calls
+				}
+			}
+			// One call per abandoned root, plus one for the completed exchange. The
+			// retry must not add a second.
+			if want := abandoned + 1; calls != want {
+				t.Fatalf("delete_files calls = %d, want %d; the retry was not linked to the operation it continues", calls, want)
+			}
+		})
+	}
+}
+
+// TestParkedOperationsDoNotAccumulate covers the other half. A settled operation
+// is not awaiting a retry, and an abandoned one produces no frame to retire it
+// by, so the list is append only without both a prune and a cap.
+func TestParkedOperationsDoNotAccumulate(t *testing.T) {
+	t.Run("a settled operation is retired", func(t *testing.T) {
+		t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+		s := New()
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"delete_files","arguments":{}}`))
+		s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
+			`"result":{"resultType":"input_required","requestState":"blob","inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}`))
+		sess := s.sessions["s1"]
+		if len(sess.awaiting) != 1 {
+			t.Fatalf("awaiting = %d, want the operation parked", len(sess.awaiting))
+		}
+		// The user declines, and the client says so.
+		s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: t0.Add(2 * time.Millisecond),
+			Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1,"reason":"user declined"}}`)})
+		if sess.awaiting[0].state != Cancelled {
+			t.Fatalf("the cancel did not settle the call, state = %v", sess.awaiting[0].state)
+		}
+		// A later exchange is what runs the prune, since that is where the list grows.
+		s.Ingest(req(4, t0.Add(3*time.Millisecond), proxy.ClientToServer, "2", "tools/call", `{"name":"other","arguments":{}}`))
+		s.Ingest(resp(5, t0.Add(4*time.Millisecond), proxy.ServerToClient, "2",
+			`"result":{"resultType":"input_required","requestState":"blob2","inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}`))
+		if len(sess.awaiting) != 1 {
+			t.Fatalf("awaiting = %d, want only the live operation; a cancelled one waits for nothing", len(sess.awaiting))
+		}
+		if sess.awaiting[0].state != Pending {
+			t.Fatalf("the retired entry is the wrong one, kept state = %v", sess.awaiting[0].state)
+		}
+	})
+
+	t.Run("abandoned operations are capped", func(t *testing.T) {
+		_, sess := mrtrProbe(t, 3*awaitingKept)
+		if len(sess.awaiting) > awaitingKept {
+			t.Fatalf("awaiting = %d, want at most the cap of %d", len(sess.awaiting), awaitingKept)
+		}
+		if len(sess.awaiting) == 0 {
+			t.Fatal("the cap retired everything, so no retry could ever link again")
+		}
+		for i, c := range sess.awaiting {
+			if c.state != Pending {
+				t.Fatalf("entry %d is %v, so a settled call survived the prune", i, c.state)
+			}
+		}
+		// The oldest go first, since the oldest requestState is the one the server
+		// itself is likeliest to have expired.
+		abandoned := 3 * awaitingKept
+		if got := sess.awaiting[len(sess.awaiting)-1].mrtrState; got != fmt.Sprintf("state-%d", abandoned-1) {
+			t.Fatalf("newest kept = %q, want the most recent exchange to survive", got)
+		}
+		if got := sess.awaiting[0].mrtrState; got == "state-0" {
+			t.Fatalf("oldest kept = %q, want the front of the list to have been retired", got)
+		}
+	})
+}
+
+// TestTheParkingCapSaysWhatItRetired keeps the bound from being silent. Retiring
+// a settled operation loses nothing, but one dropped while still open can no
+// longer be linked to, so a retry that does arrive for it reads as its own call
+// and the operation is counted and timed as two. That is what correlating MRTR
+// exists to prevent, so a session it happened in has to be able to say so.
+func TestTheParkingCapSaysWhatItRetired(t *testing.T) {
+	t.Run("a clean session retires nothing", func(t *testing.T) {
+		s, _ := mrtrProbe(t, 1)
+		if got := s.Sessions()[0].RetiredExchanges; got != 0 {
+			t.Fatalf("RetiredExchanges = %d, want 0; one abandoned exchange is far below the cap", got)
+		}
+	})
+
+	t.Run("the cap reports the open ones it dropped", func(t *testing.T) {
+		abandoned := 3 * awaitingKept
+		s, sess := mrtrProbe(t, abandoned)
+		got := s.Sessions()[0].RetiredExchanges
+		if got == 0 {
+			t.Fatal("the cap dropped open operations and said nothing")
+		}
+		// Everything parked and then dropped is accounted for: what was abandoned,
+		// less what is still held.
+		if want := abandoned - len(sess.awaiting); got != want {
+			t.Fatalf("RetiredExchanges = %d, want %d abandoned less the %d still parked", got, want, len(sess.awaiting))
+		}
+	})
+
+	t.Run("retiring a settled operation is not reported as a loss", func(t *testing.T) {
+		t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+		s := New()
+		s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"a","arguments":{}}`))
+		s.Ingest(resp(2, t0.Add(time.Millisecond), proxy.ServerToClient, "1",
+			`"result":{"resultType":"input_required","requestState":"blob","inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}`))
+		s.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 3, TS: t0.Add(2 * time.Millisecond),
+			Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1,"reason":"user declined"}}`)})
+		s.Ingest(req(4, t0.Add(3*time.Millisecond), proxy.ClientToServer, "2", "tools/call", `{"name":"b","arguments":{}}`))
+		s.Ingest(resp(5, t0.Add(4*time.Millisecond), proxy.ServerToClient, "2",
+			`"result":{"resultType":"input_required","requestState":"blob2","inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}`))
+		if got := s.Sessions()[0].RetiredExchanges; got != 0 {
+			t.Fatalf("RetiredExchanges = %d, want 0; a cancelled operation waits for nothing and losing it costs nothing", got)
+		}
+	})
+}

--- a/internal/store/transportheaders.go
+++ b/internal/store/transportheaders.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"mime"
+	"strings"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// The two content types the Streamable HTTP transport is written in terms of.
+const (
+	contentTypeJSON = "application/json"
+	contentTypeSSE  = "text/event-stream"
+)
+
+// acceptWarning reports a client POST whose Accept header does not offer both
+// types the transport requires.
+//
+// "The client MUST include an `Accept` header listing both `application/json`
+// and `text/event-stream` as supported content types." The same sentence is in
+// 2025-11-25, so unlike the extension rules this one needs no revision gate: a
+// client has owed both types for as long as the transport has existed.
+//
+// A server is free to answer with either, so offering only one is not a
+// preference, it is a client that will reject half the legal answers. The usual
+// symptom is a stream that never opens and no error anywhere.
+func acceptWarning(dir proxy.Direction, headers *proxy.TransportHeaders) string {
+	if dir != proxy.ClientToServer || headers == nil {
+		// nil means the log predates mcpsnoop recording these, not that the client
+		// sent nothing. Reading an old capture must not report every frame in it.
+		return ""
+	}
+	if headers.Accept == "" {
+		return "the request sent no Accept header, and the transport requires one listing " +
+			contentTypeJSON + " and " + contentTypeSSE
+	}
+	var missing []string
+	for _, want := range []string{contentTypeJSON, contentTypeSSE} {
+		if !acceptOffers(headers.Accept, want) {
+			missing = append(missing, want)
+		}
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	return "the request's Accept header does not offer " + strings.Join(missing, " or ") +
+		", which the transport requires a client to list"
+}
+
+// acceptOffers reports whether an Accept header admits a media type, honouring
+// the wildcards HTTP defines. A client sending */* has offered everything, and
+// reporting it would be mcpsnoop inventing a stricter rule than the one written.
+func acceptOffers(accept, want string) bool {
+	wantType, _, _ := strings.Cut(want, "/")
+	for _, part := range strings.Split(accept, ",") {
+		media, _, err := mime.ParseMediaType(strings.TrimSpace(part))
+		if err != nil {
+			// q-values and unknown parameters are handled by ParseMediaType; anything
+			// it cannot read is compared whole rather than dropped, since discarding
+			// it would be the same as the client not having sent it.
+			media = strings.ToLower(strings.TrimSpace(strings.Split(part, ";")[0]))
+		}
+		if media == "*/*" || media == want || media == wantType+"/*" {
+			return true
+		}
+	}
+	return false
+}
+
+// responseContentTypeWarning reports a server answering a JSON-RPC request with
+// a body that is neither of the two types the transport allows.
+//
+// "If the body is a JSON-RPC request, the server MUST return either
+// `Content-Type: application/json` (a single JSON object) or
+// `Content-Type: text/event-stream` (an SSE response stream)." Also unchanged
+// since 2025-11-25.
+//
+// Only answers to a request are judged, which is why this is called from the
+// response branch alone. A 202 acknowledging a notification carries no JSON-RPC
+// body and never reaches it, and neither does a bare transport failure.
+func responseContentTypeWarning(dir proxy.Direction, headers *proxy.TransportHeaders) string {
+	if dir != proxy.ServerToClient || headers == nil {
+		return ""
+	}
+	if headers.ContentType == "" {
+		return "the response to a request carried no Content-Type, and the transport requires " +
+			contentTypeJSON + " or " + contentTypeSSE
+	}
+	media, _, err := mime.ParseMediaType(headers.ContentType)
+	if err != nil {
+		media = strings.ToLower(strings.TrimSpace(strings.Split(headers.ContentType, ";")[0]))
+	}
+	if media == contentTypeJSON || media == contentTypeSSE {
+		return ""
+	}
+	return "the response to a request is " + media + ", and the transport allows only " +
+		contentTypeJSON + " or " + contentTypeSSE
+}

--- a/internal/store/transportheaders_test.go
+++ b/internal/store/transportheaders_test.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// TestAcceptHeaderIsCheckedAgainstWhatTheTransportRequires. The transport says
+// the client MUST list both application/json and text/event-stream, in
+// 2025-11-25 and 2026-07-28 alike, so this needs no revision gate. A client that
+// offers only one will reject half the legal answers, and the symptom is a
+// stream that never opens with no error anywhere.
+func TestAcceptHeaderIsCheckedAgainstWhatTheTransportRequires(t *testing.T) {
+	for name, tc := range map[string]struct {
+		headers *proxy.TransportHeaders
+		want    string
+	}{
+		"both types":         {&proxy.TransportHeaders{Accept: "application/json, text/event-stream"}, ""},
+		"both, reordered":    {&proxy.TransportHeaders{Accept: "text/event-stream, application/json"}, ""},
+		"both with q-values": {&proxy.TransportHeaders{Accept: "text/event-stream;q=0.9, application/json;q=1.0"}, ""},
+		// A client offering everything has offered both, and reporting it would be
+		// mcpsnoop inventing a stricter rule than the one written down.
+		"the */* wildcard": {&proxy.TransportHeaders{Accept: "*/*"}, ""},
+		"type wildcards":   {&proxy.TransportHeaders{Accept: "application/*, text/*"}, ""},
+		"only json":        {&proxy.TransportHeaders{Accept: "application/json"}, "text/event-stream"},
+		"only the stream":  {&proxy.TransportHeaders{Accept: "text/event-stream"}, "application/json"},
+		"neither":          {&proxy.TransportHeaders{Accept: "text/plain"}, "application/json or text/event-stream"},
+		"no Accept at all": {&proxy.TransportHeaders{ContentType: "application/json"}, "sent no Accept header"},
+		// nil is a log written before mcpsnoop recorded these headers. Reading one
+		// back must not report every frame in it for a header nobody wrote down.
+		"a log from before this existed": {nil, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := acceptWarning(proxy.ClientToServer, tc.headers)
+			if tc.want == "" {
+				if got != "" {
+					t.Fatalf("warned about a conforming request: %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("warning = %q, want it to name %q", got, tc.want)
+			}
+		})
+	}
+
+	// The rule is the client's, so a server frame carrying the same header is not
+	// under it.
+	if got := acceptWarning(proxy.ServerToClient, &proxy.TransportHeaders{Accept: "text/plain"}); got != "" {
+		t.Fatalf("a server frame was judged by the client's rule: %q", got)
+	}
+}
+
+// TestResponseContentTypeIsCheckedAgainstTheTwoAllowedTypes. Answering a
+// JSON-RPC request with anything but application/json or text/event-stream is a
+// MUST violation, and the value was already read to pick the SSE branch and then
+// thrown away, so nothing could check the rule it decides.
+func TestResponseContentTypeIsCheckedAgainstTheTwoAllowedTypes(t *testing.T) {
+	for name, tc := range map[string]struct {
+		headers *proxy.TransportHeaders
+		want    string
+	}{
+		"json":            {&proxy.TransportHeaders{ContentType: "application/json"}, ""},
+		"json + charset":  {&proxy.TransportHeaders{ContentType: "application/json; charset=utf-8"}, ""},
+		"an event stream": {&proxy.TransportHeaders{ContentType: "text/event-stream"}, ""},
+		"plain text":      {&proxy.TransportHeaders{ContentType: "text/plain"}, "is text/plain"},
+		// application/xml, not "anything under application", which the transport
+		// does not say. text/html is the shape a proxy error page takes.
+		"another app type": {&proxy.TransportHeaders{ContentType: "application/xml"}, "is application/xml"},
+		"html":             {&proxy.TransportHeaders{ContentType: "text/html"}, "is text/html"},
+		"none at all":      {&proxy.TransportHeaders{}, "carried no Content-Type"},
+		// nil is a log written before mcpsnoop recorded these headers.
+		"an older log": {nil, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := responseContentTypeWarning(proxy.ServerToClient, tc.headers)
+			if tc.want == "" {
+				if got != "" {
+					t.Fatalf("warned about a conforming response: %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("warning = %q, want it to name %q", got, tc.want)
+			}
+		})
+	}
+
+	// The rule is the server's.
+	if got := responseContentTypeWarning(proxy.ClientToServer, &proxy.TransportHeaders{ContentType: "text/plain"}); got != "" {
+		t.Fatalf("a client frame was judged by the server's rule: %q", got)
+	}
+}
+
+// TestTransportHeaderChecksNeverFireOnStdio. stdio has no HTTP headers at all,
+// and these warnings fail a default check run, so a stdio capture reporting one
+// would turn every such CI job red for a rule that does not apply to it.
+func TestTransportHeaderChecksNeverFireOnStdio(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{}`))
+	for _, ev := range s.Timeline("s1") {
+		if ev.Warning != "" {
+			t.Fatalf("a stdio frame was warned about: %q", ev.Warning)
+		}
+	}
+	// The response half too.
+	got := s.Ingest(resp(2, t0, proxy.ServerToClient, "1", `"result":{"tools":[]}`))
+	if got.Warning != "" {
+		t.Fatalf("a stdio response was warned about: %q", got.Warning)
+	}
+}
+
+// TestTransportHeaderChecksReachTheStream drives the ingest path rather than the
+// two functions, since a check nothing calls is a check that does not exist.
+func TestTransportHeaderChecksReachTheStream(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	request := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+		Raw:              json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"ping"}`),
+		TransportHeaders: &proxy.TransportHeaders{Accept: "application/json", ContentType: "application/json"},
+	})
+	if !strings.Contains(request.Warning, "text/event-stream") {
+		t.Fatalf("the Accept rule never reached the stream: %q", request.Warning)
+	}
+	response := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0, Status: 200,
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP,
+		Raw:              json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`),
+		TransportHeaders: &proxy.TransportHeaders{ContentType: "text/html"},
+	})
+	if !strings.Contains(response.Warning, "text/html") {
+		t.Fatalf("the Content-Type rule never reached the stream: %q", response.Warning)
+	}
+	if h := s.Sessions()[0]; h.Errors != 0 {
+		t.Fatalf("a header rule was counted as an error, not a warning: %+v", h)
+	}
+}

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -380,9 +380,14 @@ type ToolStats struct {
 	ProtocolErrors int
 	ToolErrors     int
 	Pending        int
-	P50            time.Duration
-	P95            time.Duration
-	P99            time.Duration
+	// MaxRoundTrips is the most requests any one call of this tool took. One means
+	// no call of it was ever retried. It is the maximum rather than a total,
+	// because the question it answers is whether this tool is chatty, and a total
+	// only says the tool was called a lot.
+	MaxRoundTrips int
+	P50           time.Duration
+	P95           time.Duration
+	P99           time.Duration
 	// ResultBytes totals this tool's results and MaxResultBytes is the largest
 	// single one, both as observed on the wire. Unlike the definition cost this
 	// half is paid per call, so a tool that is cheap to advertise can still be
@@ -906,6 +911,7 @@ func foldToolCall(byName map[string]*toolAggregate, slowest *[]SlowToolCall, cal
 		byName[c.toolName] = agg
 	}
 	agg.stats.Calls++
+	agg.stats.MaxRoundTrips = max(agg.stats.MaxRoundTrips, c.hops)
 	if c.state == Pending {
 		agg.stats.Pending++
 		return

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -138,8 +138,16 @@ type EventView struct {
 
 // SessionHeader is a lightweight per-session summary for the left panel.
 type SessionHeader struct {
-	ID                   string
-	Label                string
+	ID    string
+	Label string
+	// Transport is the channel the session was captured on, "stdio" or "http",
+	// and is empty only for a log whose frames named none. Endpoint is the MCP
+	// endpoint of an HTTP session as EndpointForLog wrote it down, which is
+	// stripped of userinfo, query values and the fragment, so it identifies the
+	// server without being an address to dial. Empty on stdio, and empty on an
+	// HTTP log captured before mcpsnoop recorded it.
+	Transport            string
+	Endpoint             string
 	First                time.Time
 	Last                 time.Time
 	Requests             int
@@ -156,7 +164,14 @@ type SessionHeader struct {
 	// observed and are still in the log on disk, so the capture is complete and
 	// only this view of it is not.
 	DroppedFromMemory int
-	LateResults       int
+	// RetiredExchanges counts multi round-trip operations dropped at the parking
+	// cap while still open. MRTR tells servers not to assume a client will ever
+	// retry, so abandoned exchanges accumulate with no frame to settle them, and
+	// the cap is what stops the list growing for the life of the session. A
+	// non-zero count means a retry arriving for one of those would no longer link,
+	// so the operation would read as two calls with two durations.
+	RetiredExchanges int
+	LateResults      int
 }
 
 // ToolDefinition is the contract a server advertised for one MCP tool.
@@ -346,13 +361,28 @@ func (e ExtensionView) Agreed() bool { return e.Client && e.Server }
 
 // ToolStats summarizes calls to one MCP tool within a session.
 type ToolStats struct {
-	Name    string
-	Calls   int
-	Errors  int
-	Pending int
-	P50     time.Duration
-	P95     time.Duration
-	P99     time.Duration
+	Name  string
+	Calls int
+	// Errors is every call that went wrong, and ProtocolErrors and ToolErrors
+	// split it into the two things that word covers. They are very different
+	// findings. A tool that answers isError is doing its job, reporting that the
+	// search found nothing or the input failed validation, and a server returning
+	// a JSON-RPC error is broken. Reading one number for both means a well-behaved
+	// tool that reports domain failures looks exactly like a broken server, and in
+	// the summary it also sorts above one.
+	//
+	// ToolErrors counts result.isError. ProtocolErrors counts everything else that
+	// was an error, which is a JSON-RPC error object and a task that ended failed
+	// without one. It is deliberately the complement rather than its own tally, so
+	// the two always add up to Errors and a failure mode added later lands in it
+	// instead of disappearing from both.
+	Errors         int
+	ProtocolErrors int
+	ToolErrors     int
+	Pending        int
+	P50            time.Duration
+	P95            time.Duration
+	P99            time.Duration
 	// ResultBytes totals this tool's results and MaxResultBytes is the largest
 	// single one, both as observed on the wire. Unlike the definition cost this
 	// half is paid per call, so a tool that is cheap to advertise can still be
@@ -460,6 +490,8 @@ func (s *Store) Sessions() []SessionHeader {
 		out = append(out, SessionHeader{
 			ID:                   sess.id,
 			Label:                sess.label,
+			Transport:            sess.transport,
+			Endpoint:             sess.target,
 			First:                sess.first,
 			Last:                 sess.last,
 			Requests:             sess.requests,
@@ -472,6 +504,7 @@ func (s *Store) Sessions() []SessionHeader {
 			HasToolBaselineError: sess.toolDrift.BaselineError != "",
 			MissingFrames:        sess.missing,
 			DroppedFromMemory:    sess.dropped,
+			RetiredExchanges:     sess.retiredExchanges,
 			LateResults:          sess.lateResults,
 		})
 	}
@@ -882,6 +915,11 @@ func foldToolCall(byName map[string]*toolAggregate, slowest *[]SlowToolCall, cal
 	}
 	if c.errored {
 		agg.stats.Errors++
+		if c.toolErr {
+			agg.stats.ToolErrors++
+		} else {
+			agg.stats.ProtocolErrors++
+		}
 	}
 	// max, not len, so a result whose bytes a bounded store released still counts
 	// what it cost. This figure is the whole point of the cost panel.

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -123,6 +123,11 @@ type EventView struct {
 	// LateResults. Call.LateResult says the call ever got one, which stays true
 	// for the rest of the capture and is visible from the request frame too.
 	LateResult bool
+	// BodyReleased is true when a bounded store dropped this frame's observed
+	// body to stay inside its memory budget. Everything else about the frame is
+	// still here, so it keeps its row and its verdict; only Raw and Text are gone
+	// and the log on disk still holds them.
+	BodyReleased bool
 	// MRTRRoot is the id of the request this one continues, set when a multi
 	// round-trip retry was recognised (SEP-2322). Empty on an ordinary request.
 	MRTRRoot string
@@ -146,7 +151,12 @@ type SessionHeader struct {
 	HasToolDrift         bool
 	HasToolBaselineError bool
 	MissingFrames        uint64 // envelopes dropped upstream, inferred from Seq gaps
-	LateResults          int
+	// DroppedFromMemory counts frames a bounded live store removed from the
+	// timeline to stay inside its budget. Unlike MissingFrames these were
+	// observed and are still in the log on disk, so the capture is complete and
+	// only this view of it is not.
+	DroppedFromMemory int
+	LateResults       int
 }
 
 // ToolDefinition is the contract a server advertised for one MCP tool.
@@ -403,6 +413,7 @@ func (e *event) view(_ *session) EventView {
 		MRTRStateIssue:     e.mrtrStateIssue,
 		Errored:            e.errored,
 		LateResult:         e.lateResult,
+		BodyReleased:       e.bodyReleased,
 	}
 	if e.call != nil {
 		cv := e.call.view()
@@ -460,6 +471,7 @@ func (s *Store) Sessions() []SessionHeader {
 			HasToolDrift:         sess.toolDrift.Count() > 0,
 			HasToolBaselineError: sess.toolDrift.BaselineError != "",
 			MissingFrames:        sess.missing,
+			DroppedFromMemory:    sess.dropped,
 			LateResults:          sess.lateResults,
 		})
 	}
@@ -763,54 +775,13 @@ func (s *Store) ToolSummary(sessionID string) (SessionToolSummary, bool) {
 		return SessionToolSummary{}, false
 	}
 
-	type aggregate struct {
-		stats     ToolStats
-		durations []time.Duration
-	}
-	byName := make(map[string]*aggregate)
-	var slowest []SlowToolCall
-	callIndex := 0
+	// Seeded from whatever a bounded store already released, so the statistics
+	// describe every tool call the session made rather than only the calls whose
+	// frames are still held.
+	byName, slowest, callIndex := sess.toolStats.clone()
 	for _, ev := range sess.events {
-		// Skipping a continuation matters twice over: it would count one logical
-		// operation as several calls, and feed the same duration into the
-		// percentiles once per round trip.
-		if ev.kind != EventRequest || ev.call == nil || ev.mrtrRoot != "" {
-			continue
-		}
-		c := ev.call
-		index := callIndex
-		callIndex++
-		if !c.isTool {
-			continue
-		}
-		agg := byName[c.toolName]
-		if agg == nil {
-			agg = &aggregate{stats: ToolStats{Name: c.toolName}}
-			byName[c.toolName] = agg
-		}
-		agg.stats.Calls++
-		if c.state == Pending {
-			agg.stats.Pending++
-			continue
-		}
-		if c.state == Superseded || (c.state == Cancelled && !c.lateResult) {
-			continue
-		}
-		if c.errored {
-			agg.stats.Errors++
-		}
-		if n := len(c.result); n > 0 {
-			agg.stats.ResultBytes += int64(n)
-			agg.stats.MaxResultBytes = max(agg.stats.MaxResultBytes, n)
-		}
-		duration := c.end.Sub(c.start)
-		agg.durations = append(agg.durations, duration)
-		slowest = append(slowest, SlowToolCall{
-			CallIndex: index, ID: c.id, ToolName: c.toolName,
-			Duration: duration, Failed: c.errored, Start: c.start,
-		})
+		foldToolCall(byName, &slowest, &callIndex, ev)
 	}
-
 	tools := make([]ToolStats, 0, len(byName))
 	for _, agg := range byName {
 		slices.Sort(agg.durations)
@@ -830,6 +801,100 @@ func (s *Store) ToolSummary(sessionID string) (SessionToolSummary, bool) {
 		slowest = slowest[:5]
 	}
 	return SessionToolSummary{Tools: tools, Slowest: slowest}, true
+}
+
+// toolAggregate is one tool's running statistics. durations are kept whole
+// rather than summarised, because the percentiles are exact and eight bytes a
+// call is nothing beside the frame it came from.
+type toolAggregate struct {
+	stats     ToolStats
+	durations []time.Duration
+}
+
+// toolStats accumulates the calls a bounded store has already dropped the frames
+// for. An unbounded store never writes to it, so its summary is built exactly as
+// it always was.
+type toolStats struct {
+	byName    map[string]*toolAggregate
+	slowest   []SlowToolCall
+	callIndex int
+}
+
+func (t toolStats) clone() (map[string]*toolAggregate, []SlowToolCall, int) {
+	byName := make(map[string]*toolAggregate, len(t.byName))
+	for name, agg := range t.byName {
+		byName[name] = &toolAggregate{stats: agg.stats, durations: slices.Clone(agg.durations)}
+	}
+	return byName, slices.Clone(t.slowest), t.callIndex
+}
+
+// fold adds one call to the accumulator, through the same arithmetic the summary
+// uses, so a released call counts exactly as it would have while it was held.
+func (t *toolStats) fold(ev *event) {
+	if t.byName == nil {
+		t.byName = make(map[string]*toolAggregate)
+	}
+	foldToolCall(t.byName, &t.slowest, &t.callIndex, ev)
+	if len(t.slowest) > slowestKept {
+		slices.SortStableFunc(t.slowest, func(a, b SlowToolCall) int {
+			if c := cmp.Compare(b.Duration, a.Duration); c != 0 {
+				return c
+			}
+			return a.Start.Compare(b.Start)
+		})
+		t.slowest = t.slowest[:slowestKept]
+	}
+}
+
+// slowestKept is how many slow calls survive in the accumulator. The summary
+// shows five, and keeping only those five would be wrong the moment a sixth
+// released call was slower than one already dropped, so a margin is held.
+const slowestKept = 64
+
+// foldToolCall is the one place a call turns into statistics. ToolSummary walks
+// the frames it still holds through it and a bounded store walks the frames it
+// is about to drop through it, so the two can never drift.
+func foldToolCall(byName map[string]*toolAggregate, slowest *[]SlowToolCall, callIndex *int, ev *event) {
+	// Skipping a continuation matters twice over: it would count one logical
+	// operation as several calls, and feed the same duration into the percentiles
+	// once per round trip.
+	if ev.kind != EventRequest || ev.call == nil || ev.mrtrRoot != "" {
+		return
+	}
+	c := ev.call
+	index := *callIndex
+	*callIndex++
+	if !c.isTool {
+		return
+	}
+	agg := byName[c.toolName]
+	if agg == nil {
+		agg = &toolAggregate{stats: ToolStats{Name: c.toolName}}
+		byName[c.toolName] = agg
+	}
+	agg.stats.Calls++
+	if c.state == Pending {
+		agg.stats.Pending++
+		return
+	}
+	if c.state == Superseded || (c.state == Cancelled && !c.lateResult) {
+		return
+	}
+	if c.errored {
+		agg.stats.Errors++
+	}
+	// max, not len, so a result whose bytes a bounded store released still counts
+	// what it cost. This figure is the whole point of the cost panel.
+	if n := max(len(c.result), c.releasedResultBytes); n > 0 {
+		agg.stats.ResultBytes += int64(n)
+		agg.stats.MaxResultBytes = max(agg.stats.MaxResultBytes, n)
+	}
+	duration := c.end.Sub(c.start)
+	agg.durations = append(agg.durations, duration)
+	*slowest = append(*slowest, SlowToolCall{
+		CallIndex: index, ID: c.id, ToolName: c.toolName,
+		Duration: duration, Failed: c.errored, Start: c.start,
+	})
 }
 
 func nearestRank(sorted []time.Duration, percentile float64) time.Duration {

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -942,3 +942,37 @@ func nearestRank(sorted []time.Duration, percentile float64) time.Duration {
 	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
 	return sorted[max(index, 0)]
 }
+
+// Elicitations returns every question this session's servers put to the user,
+// oldest first, each paired with the answer that came back.
+//
+// Rounds are read from the calls rather than from the timeline, because a chain
+// folds into one call and the timeline no longer holds the interim results: the
+// retry overwrites them. Ordering is by when the question was asked, which is
+// the order a reader watched them happen.
+func (s *Store) Elicitations(sessionID string) []ElicitationView {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil
+	}
+	var out []ElicitationView
+	seen := make(map[*call]struct{})
+	for _, ev := range sess.events {
+		// Walked through the timeline so the calls arrive in the order they opened,
+		// and deduplicated because a chain maps several request frames onto one call.
+		if ev.kind != EventRequest || ev.call == nil {
+			continue
+		}
+		if _, done := seen[ev.call]; done {
+			continue
+		}
+		seen[ev.call] = struct{}{}
+		for _, el := range ev.call.elicitations {
+			out = append(out, el.view(ev.call))
+		}
+	}
+	slices.SortStableFunc(out, func(a, b ElicitationView) int { return a.Asked.Compare(b.Asked) })
+	return out
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -23,6 +23,7 @@ type keyMap struct {
 	EditReplay key.Binding
 	Caps       key.Binding
 	Summary    key.Binding
+	Elicit     key.Binding
 	Pause      key.Binding
 	Follow     key.Binding
 	Copy       key.Binding
@@ -51,6 +52,7 @@ func defaultKeys() keyMap {
 		EditReplay: key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "edit + replay")),
 		Caps:       key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
 		Summary:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
+		Elicit:     key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "elicitations")),
 		Pause:      key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
 		Follow:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
 		Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -27,6 +27,7 @@ type keyMap struct {
 	Copy    key.Binding
 	Export  key.Binding
 	Delete  key.Binding
+	Search  key.Binding
 
 	Quit key.Binding
 }
@@ -54,6 +55,7 @@ func defaultKeys() keyMap {
 		Copy:    key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
 		Export:  key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
 		Delete:  key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
+		Search:  key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "web search")),
 
 		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp(":q", "quit")),
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -30,6 +30,7 @@ type keyMap struct {
 	Copy       key.Binding
 	Export     key.Binding
 	Delete     key.Binding
+	Search     key.Binding
 
 	Quit key.Binding
 }
@@ -60,6 +61,7 @@ func defaultKeys() keyMap {
 		Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
 		Export:     key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
 		Delete:     key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
+		Search:     key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "web search")),
 
 		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp(":q", "quit")),
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -19,14 +19,15 @@ type keyMap struct {
 	Command key.Binding
 	Help    key.Binding
 
-	Replay  key.Binding
-	Caps    key.Binding
-	Summary key.Binding
-	Pause   key.Binding
-	Follow  key.Binding
-	Copy    key.Binding
-	Export  key.Binding
-	Delete  key.Binding
+	Replay     key.Binding
+	EditReplay key.Binding
+	Caps       key.Binding
+	Summary    key.Binding
+	Pause      key.Binding
+	Follow     key.Binding
+	Copy       key.Binding
+	Export     key.Binding
+	Delete     key.Binding
 
 	Quit key.Binding
 }
@@ -46,14 +47,15 @@ func defaultKeys() keyMap {
 		Command: key.NewBinding(key.WithKeys(":"), key.WithHelp(":", "command")),
 		Help:    key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 
-		Replay:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "replay")),
-		Caps:    key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
-		Summary: key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
-		Pause:   key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
-		Follow:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
-		Copy:    key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
-		Export:  key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
-		Delete:  key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
+		Replay:     key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "replay")),
+		EditReplay: key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "edit + replay")),
+		Caps:       key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
+		Summary:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
+		Pause:      key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
+		Follow:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
+		Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
+		Export:     key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
+		Delete:     key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
 
 		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp(":q", "quit")),
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -24,6 +24,7 @@ type keyMap struct {
 	Caps       key.Binding
 	Summary    key.Binding
 	Elicit     key.Binding
+	Interact   key.Binding
 	Pause      key.Binding
 	Follow     key.Binding
 	Copy       key.Binding
@@ -53,6 +54,7 @@ func defaultKeys() keyMap {
 		Caps:       key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
 		Summary:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
 		Elicit:     key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "elicitations")),
+		Interact:   key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "interactions")),
 		Pause:      key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
 		Follow:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
 		Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"cmp"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -135,8 +136,15 @@ type Model struct {
 	paused bool
 
 	overlay        overlayMode
-	replayReq      store.CallView // last request sent to replay, so r can re-run it from the result
-	replaying      bool           // an async replay is in flight; a footer spinner shows until the result lands
+	replayReq      store.CallView  // last user-supplied request sent to replay, so r can re-run it from the result
+	replayCaptured json.RawMessage // immutable params from the observed request behind the current replay loop
+	replayEdited   bool            // the user-supplied params differ semantically from replayCaptured
+	replaying      bool            // an async replay is in flight; a footer spinner shows until the result lands
+	// replayToken numbers each run. replaying alone only says that some replay is
+	// in flight, so an abandoned run's result was rendered against whatever had
+	// started since, putting one request's captured params over another's answer
+	// and dropping the answer the user was waiting for.
+	replayToken    uint64
 	vp             viewport.Model
 	overlayRaw     string // overlay body before styling (re-rendered on resize)
 	overlayDisplay string // styled body shown in the viewport (highlight, numbers)
@@ -287,9 +295,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setFlash(fmt.Sprintf("loaded newest %d of %d sessions; older traces stay on disk", msg.loaded, msg.total))
 		return m, nil
 
+	case replayEditDoneMsg:
+		if msg.err != nil {
+			m.setFlash("edit replay aborted: " + msg.err.Error())
+			return m, nil
+		}
+		edited := !replayParamsEquivalent(msg.captured, msg.call.Params)
+		return m, m.runReplay(msg.call, msg.captured, edited)
+
 	case replayDoneMsg:
-		if !m.replaying {
-			return m, nil // the replay was abandoned by navigating away
+		if !m.replaying || msg.token != m.replayToken {
+			return m, nil // abandoned by navigating away, or belongs to an earlier run
 		}
 		m.replaying = false
 		m.openOverlay(overlayReplay, m.replayContent(msg))
@@ -354,8 +370,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 			if cmd := m.startReplay(); cmd != nil {
 				return m, cmd
 			}
+		case m.overlay == overlayInspector && key.Matches(msg, m.keys.EditReplay):
+			if cmd := m.startEditReplay(); cmd != nil {
+				return m, cmd
+			}
 		case m.overlay == overlayReplay && key.Matches(msg, m.keys.Replay):
 			if cmd := m.replayAgain(); cmd != nil {
+				return m, cmd
+			}
+		case m.overlay == overlayReplay && key.Matches(msg, m.keys.EditReplay):
+			if cmd := m.startEditReplay(); cmd != nil {
 				return m, cmd
 			}
 		case key.Matches(msg, m.keys.Copy):
@@ -420,6 +444,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 	case key.Matches(msg, m.keys.Replay):
 		if cmd := m.startReplay(); cmd != nil {
+			return m, cmd
+		}
+	case key.Matches(msg, m.keys.EditReplay):
+		if cmd := m.startEditReplay(); cmd != nil {
 			return m, cmd
 		}
 
@@ -744,8 +772,8 @@ func (m Model) focusedFrame() (store.EventView, bool) {
 }
 
 // canReplay reports whether the focused frame is a request this session can
-// actually replay (its server command was captured), so r is only offered, and
-// acted on, when it will work.
+// actually replay (its server command was captured), so the replay keys are
+// only offered, and acted on, when they will work.
 func (m Model) canReplay() bool {
 	ev, ok := m.focusedFrame()
 	if !ok || ev.Call == nil || ev.Kind != store.EventRequest {
@@ -755,9 +783,9 @@ func (m Model) canReplay() bool {
 }
 
 // sessionReplayable reports whether the streamed session recorded the server
-// command a replay needs. It gates r at the session level, stable with no
-// per-frame flicker, so replay is never offered for a session that can never run
-// it (for example a log opened without its meta frame).
+// command a replay needs. It gates r/R at the session level, stable with no
+// per-frame flicker, so replay is never offered for a session that can never
+// run it (for example a log opened without its meta frame).
 func (m Model) sessionReplayable() bool {
 	_, _, ok := m.store.Command(m.streamSessionID)
 	return ok
@@ -772,7 +800,7 @@ func (m *Model) startReplay() tea.Cmd {
 		m.setFlash("replay needs a request frame")
 		return nil
 	}
-	return m.runReplay(*ev.Call)
+	return m.runReplay(*ev.Call, ev.Call.Params, false)
 }
 
 // replayAgain re-runs the last replayed request, so r works straight from the
@@ -781,10 +809,45 @@ func (m *Model) replayAgain() tea.Cmd {
 	if m.replayReq.Method == "" {
 		return nil
 	}
-	return m.runReplay(m.replayReq)
+	return m.runReplay(m.replayReq, m.replayCaptured, m.replayEdited)
 }
 
-func (m *Model) runReplay(call store.CallView) tea.Cmd {
+// startEditReplay opens the focused request, or the current replay candidate,
+// in the user's editor. The callback validates the file before runReplay ever
+// reaches the existing recorded-command confirmation gate.
+func (m *Model) startEditReplay() tea.Cmd {
+	if m.replaying {
+		return nil
+	}
+
+	var call store.CallView
+	var captured json.RawMessage
+	if m.overlay == overlayReplay && m.replayReq.Method != "" {
+		call = m.replayReq
+		captured = m.replayCaptured
+	} else {
+		ev, ok := m.focusedFrame()
+		if !ok || ev.Call == nil || ev.Kind != store.EventRequest {
+			m.setFlash("edit replay needs a request frame")
+			return nil
+		}
+		call = *ev.Call
+		captured = ev.Call.Params
+	}
+
+	if !m.sessionReplayable() {
+		m.setFlash("no recorded server command to replay")
+		return nil
+	}
+	cmd, err := editReplayCmd(call, captured)
+	if err != nil {
+		m.setFlash("edit replay aborted: " + err.Error())
+		return nil
+	}
+	return cmd
+}
+
+func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited bool) tea.Cmd {
 	if m.replaying {
 		return nil // a replay is already in flight; ignore until it lands or is abandoned
 	}
@@ -800,13 +863,24 @@ func (m *Model) runReplay(call store.CallView) tea.Cmd {
 	start := func(m *Model) tea.Cmd {
 		m.replayConfirmed = m.streamSessionID
 		m.replayReq = call
+		m.replayReq.Params = append(json.RawMessage(nil), call.Params...)
+		m.replayCaptured = append(json.RawMessage(nil), captured...)
+		m.replayEdited = edited
 		m.replaying = true
-		return replayCmd(command, cwd, call.Method, call.Params)
+		m.replayToken++
+		return replayCmd(m.replayToken, command, cwd, call.Method, call.Params)
 	}
 	if m.replayConfirmed == m.streamSessionID {
 		return start(m)
 	}
-	m.ask("replay runs: "+strings.Join(command, " ")+"  y/n", start)
+	// The prompt names the edit, so answering n is unambiguously declining to send
+	// the params the user just wrote rather than declining some replay they have
+	// lost track of. The candidate is dropped either way.
+	what := "replay runs: "
+	if edited {
+		what = "replay your edited params through: "
+	}
+	m.ask(what+strings.Join(command, " ")+"  y/n", start)
 	return nil
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/replay"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 )
 
@@ -137,6 +138,14 @@ type Model struct {
 
 	paused bool
 
+	// httpReplay is where a replay of an HTTP session goes, supplied by whoever
+	// opened the capture. Empty means this build of the session cannot replay one.
+	httpReplay replay.HTTPTarget
+	// replayRouting is the request metadata of the frame a replay came from, kept
+	// so repeating one, or sending it again after an edit, carries the same
+	// headers as the first attempt rather than none.
+	replayRouting replay.Routing
+
 	overlay        overlayMode
 	replayReq      store.CallView  // last user-supplied request sent to replay, so r can re-run it from the result
 	replayCaptured json.RawMessage // immutable params from the observed request behind the current replay loop
@@ -227,7 +236,18 @@ func (m Model) flashActive() bool {
 // its own version resolution, so New stays test friendly.
 var Version = "dev"
 
-func New(st *store.Store) Model {
+// Option configures a Model at construction. It is variadic so the callers that
+// need nothing keep their call sites.
+type Option func(*Model)
+
+// WithHTTPReplay says where a replay of an HTTP-captured session goes. Without
+// it such a session is not replayable, because what a capture records is the
+// endpoint stripped of anything credential-shaped and is not an address to dial.
+func WithHTTPReplay(target replay.HTTPTarget) Option {
+	return func(m *Model) { m.httpReplay = target }
+}
+
+func New(st *store.Store, opts ...Option) Model {
 	ti := textinput.New()
 	ti.Prompt = ""
 
@@ -240,6 +260,10 @@ func New(st *store.Store) Model {
 		view:   viewSessions,
 		follow: true,
 		input:  ti,
+	}
+
+	for _, opt := range opts {
+		opt(&m)
 	}
 
 	m.refresh()
@@ -306,7 +330,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		edited := !replayParamsEquivalent(msg.captured, msg.call.Params)
-		return m, m.runReplay(msg.call, msg.captured, edited)
+		routing := m.replayRouting
+		routing.Edited = edited
+		return m, m.runReplay(msg.call, msg.captured, edited, routing)
 
 	case replayDoneMsg:
 		if !m.replaying || msg.token != m.replayToken {
@@ -815,8 +841,23 @@ func (m Model) canReplay() bool {
 // per-frame flicker, so replay is never offered for a session that can never
 // run it (for example a log opened without its meta frame).
 func (m Model) sessionReplayable() bool {
-	_, _, ok := m.store.Command(m.streamSessionID)
-	return ok
+	if _, _, ok := m.store.Command(m.streamSessionID); ok {
+		return true
+	}
+	// An HTTP session records no command to run, because mcpsnoop launched
+	// nothing, and the endpoint it does record is deliberately not an address to
+	// dial. So it is replayable only once somebody has said where a replay goes.
+	return m.httpReplay.URL != "" && m.sessionTransport() == proxy.TransportHTTP
+}
+
+// sessionTransport is the channel the streamed session was captured on.
+func (m Model) sessionTransport() string {
+	for _, h := range m.allSessions {
+		if h.ID == m.streamSessionID {
+			return h.Transport
+		}
+	}
+	return ""
 }
 
 func (m *Model) startReplay() tea.Cmd {
@@ -832,7 +873,8 @@ func (m *Model) startReplay() tea.Cmd {
 		m.setFlash("this frame's body was released to stay inside the live memory budget; reopen the session log to replay it")
 		return nil
 	}
-	return m.runReplay(*ev.Call, ev.Call.Params, false)
+	m.replayRouting = routingOf(ev)
+	return m.runReplay(*ev.Call, ev.Call.Params, false, m.replayRouting)
 }
 
 // replayAgain re-runs the last replayed request, so r works straight from the
@@ -841,7 +883,7 @@ func (m *Model) replayAgain() tea.Cmd {
 	if m.replayReq.Method == "" {
 		return nil
 	}
-	return m.runReplay(m.replayReq, m.replayCaptured, m.replayEdited)
+	return m.runReplay(m.replayReq, m.replayCaptured, m.replayEdited, m.replayRouting)
 }
 
 // startEditReplay opens the focused request, or the current replay candidate,
@@ -863,6 +905,7 @@ func (m *Model) startEditReplay() tea.Cmd {
 			m.setFlash("edit replay needs a request frame")
 			return nil
 		}
+		m.replayRouting = routingOf(ev)
 		if ev.BodyReleased {
 			m.setFlash("this frame's body was released to stay inside the live memory budget; reopen the session log to edit it")
 			return nil
@@ -872,7 +915,7 @@ func (m *Model) startEditReplay() tea.Cmd {
 	}
 
 	if !m.sessionReplayable() {
-		m.setFlash("no recorded server command to replay")
+		m.setFlash(m.unreplayableReason())
 		return nil
 	}
 	cmd, err := editReplayCmd(call, captured)
@@ -883,14 +926,13 @@ func (m *Model) startEditReplay() tea.Cmd {
 	return cmd
 }
 
-func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited bool) tea.Cmd {
+func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited bool, routing replay.Routing) tea.Cmd {
 	if m.replaying {
 		return nil // a replay is already in flight; ignore until it lands or is abandoned
 	}
 	command, cwd, ok := m.store.Command(m.streamSessionID)
 	if !ok {
-		m.setFlash("no recorded server command to replay")
-		return nil
+		return m.runHTTPReplay(call, captured, edited, routing)
 	}
 	// The command comes out of the log's meta frame, so replaying runs whatever
 	// that file says. A log is data people hand around, and the hub backfills any
@@ -906,7 +948,10 @@ func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited 
 		m.replayToken++
 		return replayCmd(m.replayToken, command, cwd, call.Method, call.Params)
 	}
-	if m.replayConfirmed == m.streamSessionID {
+	// An empty session id is not a session anybody confirmed. A log whose frames
+	// carry no session_id decodes to one, and the zero value of replayConfirmed
+	// would otherwise match it, so the first r would send unprompted.
+	if m.streamSessionID != "" && m.replayConfirmed == m.streamSessionID {
 		return start(m)
 	}
 	// The prompt names the edit, so answering n is unambiguously declining to send
@@ -918,6 +963,68 @@ func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited 
 	}
 	m.ask(what+strings.Join(command, " ")+"  y/n", start)
 	return nil
+}
+
+// unreplayableReason says why this session cannot replay, in its own terms. An
+// HTTP capture has no command and never had one, so telling its reader that a
+// command is missing describes a transport they are not using.
+func (m Model) unreplayableReason() string {
+	if m.sessionTransport() == proxy.TransportHTTP {
+		return "this session was captured over HTTP, so replay needs an address: reopen with --replay-target"
+	}
+	return "no recorded server command to replay"
+}
+
+// runHTTPReplay sends a captured request to a live endpoint over HTTP.
+//
+// The address is not the one in the capture. What a capture records is the
+// endpoint with its userinfo and every query value removed, so it names the
+// server without being dialable, and a replay reaches something real that may be
+// production. The person replaying says where it goes, with --replay-target, and
+// still answers for it once per session the way a recorded command is answered
+// for before it is run.
+func (m *Model) runHTTPReplay(call store.CallView, captured json.RawMessage, edited bool, routing replay.Routing) tea.Cmd {
+	if m.sessionTransport() != proxy.TransportHTTP {
+		m.setFlash(m.unreplayableReason())
+		return nil
+	}
+	if m.httpReplay.URL == "" {
+		m.setFlash(m.unreplayableReason())
+		return nil
+	}
+	start := func(m *Model) tea.Cmd {
+		m.replayConfirmed = m.streamSessionID
+		m.replayReq = call
+		m.replayReq.Params = append(json.RawMessage(nil), call.Params...)
+		m.replayCaptured = append(json.RawMessage(nil), captured...)
+		m.replayEdited = edited
+		m.replaying = true
+		m.replayToken++
+		return replayHTTPCmd(m.replayToken, m.httpReplay, call.Method, call.Params, routing)
+	}
+	if m.streamSessionID != "" && m.replayConfirmed == m.streamSessionID {
+		return start(m)
+	}
+	what := "replay posts to: "
+	if edited {
+		what = "replay your edited params to: "
+	}
+	m.ask(what+m.httpReplay.URL+"  y/n", start)
+	return nil
+}
+
+// routingOf reads the request metadata a captured frame carried, so a replay
+// re-sends what the client sent rather than deriving it again. The transport
+// makes these mandatory and a server rejects a mismatch, so re-deriving would be
+// a second chance to get them wrong. A value outside the safe ASCII set travels
+// base64-wrapped, and the capture holds whatever the client sent, so re-sending
+// it needs no encoder and cannot disagree with the body.
+//
+// Read off the frame rather than looked up by call, because the timeline is a
+// window on the current view and the frame is already in hand where replay
+// starts.
+func routingOf(ev store.EventView) replay.Routing {
+	return replay.Routing{Name: ev.MCPName, ParamHeaders: ev.MCPParamHeaders}
 }
 
 // applySortKey maps a shift+<letter> to a column sort for the current view.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -62,6 +62,7 @@ const (
 	overlayCaps
 	overlaySummary
 	overlayElicit
+	overlayInteract
 	overlayReplay
 )
 
@@ -273,14 +274,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// The spinner advances every tick, the store refresh only every fifth and
 			// only when a frame arrived since, so a burst of traffic cannot force a
 			// refresh per envelope (which is quadratic over a session).
+			changed := m.dirty
 			if m.spin%refreshEvery == 0 && m.dirty {
 				m.refresh()
 				m.dirty = false
 			}
-			// An open live overlay rebuilds every tick so a pending spinner animates
-			// at the tick cadence. The content-diff guard makes this a no-op when
-			// nothing changed.
-			m.refreshLiveOverlay()
+			// An open live overlay rebuilds so a pending spinner animates at the tick
+			// cadence, but only the panels that animate pay for it every tick. The
+			// content-diff guard below is downstream of building the content, so a
+			// panel that walks the whole window was doing that walk, under the store's
+			// read lock, twelve times a second whether or not a frame had arrived.
+			m.refreshLiveOverlay(changed)
 		}
 		return m, tick()
 
@@ -386,7 +390,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Copy):
 			m.copyCurrent()
 		case key.Matches(msg, m.keys.Enter, m.keys.Back, m.keys.Quit),
-			key.Matches(msg, m.keys.Caps, m.keys.Summary, m.keys.Elicit):
+			key.Matches(msg, m.keys.Caps, m.keys.Summary, m.keys.Elicit, m.keys.Interact):
 			m.closeOverlay()
 		default:
 			var cmd tea.Cmd
@@ -446,6 +450,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Elicit):
 		if m.currentSessionID() != "" {
 			m.openOverlay(overlayElicit, m.elicitContent())
+		}
+	case key.Matches(msg, m.keys.Interact):
+		if m.currentSessionID() != "" {
+			m.openOverlay(overlayInteract, m.interactContent())
 		}
 	case key.Matches(msg, m.keys.Replay):
 		if cmd := m.startReplay(); cmd != nil {
@@ -559,6 +567,11 @@ func (m Model) runCommand(cmd string) (Model, tea.Cmd) {
 	case "elicitations":
 		if m.currentSessionID() != "" {
 			m.openOverlay(overlayElicit, m.elicitContent())
+		}
+		return m, nil
+	case "interactions":
+		if m.currentSessionID() != "" {
+			m.openOverlay(overlayInteract, m.interactContent())
 		}
 		return m, nil
 	case "export":
@@ -996,19 +1009,37 @@ func (m *Model) refresh() {
 }
 
 // refreshLiveOverlay rebuilds an open live overlay from the current store state,
-// so a capabilities or tool-summary view left open keeps up with the session
-// instead of going stale until it is closed and reopened. It reads the store
-// directly, so it works in any view, and it re-renders only when the content
-// actually changed so the scroll position never jumps on an idle tick.
-func (m *Model) refreshLiveOverlay() {
+// so a panel left open keeps up with the session instead of going stale until it
+// is closed and reopened. It reads the store directly, so it works in any view,
+// and it re-renders only when the content actually changed so the scroll
+// position never jumps on an idle tick.
+//
+// storeChanged says whether a frame has arrived since the last rebuild. Only the
+// panel that animates ignores it, because the content diff below cannot save the
+// cost of producing the content, and producing it means walking the window under
+// the store's read lock while ingest waits for the write one.
+func (m *Model) refreshLiveOverlay(storeChanged bool) {
 	var content string
 	switch m.overlay {
-	case overlayCaps:
-		content = m.capsContent()
 	case overlaySummary:
+		// The only one that animates: a tool whose calls are all in flight shows a
+		// live spinner, so it rebuilds whether or not the store moved.
 		content = m.summaryContent()
+	case overlayCaps:
+		if !storeChanged {
+			return
+		}
+		content = m.capsContent()
 	case overlayElicit:
+		if !storeChanged {
+			return
+		}
 		content = m.elicitContent()
+	case overlayInteract:
+		if !storeChanged {
+			return
+		}
+		content = m.interactContent()
 	default:
 		return
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,6 +62,7 @@ const (
 	overlayCaps
 	overlaySummary
 	overlayReplay
+	overlaySearch
 )
 
 // inputMode is the active bottom prompt ("/" filter and ":" command).
@@ -170,6 +172,11 @@ type Model struct {
 	ready         bool
 	spin          int  // shared spinner frame, advanced by tickMsg
 	dirty         bool // a frame arrived since the last refresh, set by frameMsg
+
+	// You.com search client (optional)
+	searchClient interface {
+		Search(ctx context.Context, query string) (interface{ FormatResults() string }, error)
+	}
 }
 
 // ask puts a yes-or-no question in the status bar and holds the action until it
@@ -218,18 +225,26 @@ func (m Model) flashActive() bool {
 var Version = "dev"
 
 func New(st *store.Store) Model {
+	return NewWithSearchClient(st, nil)
+}
+
+// NewWithSearchClient creates a new Model with optional You.com search integration.
+func NewWithSearchClient(st *store.Store, searchClient interface {
+	Search(ctx context.Context, query string) (interface{ FormatResults() string }, error)
+}) Model {
 	ti := textinput.New()
 	ti.Prompt = ""
 
 	th := newTheme()
 	m := Model{
-		store:  st,
-		keys:   defaultKeys(),
-		theme:  th,
-		styles: newStyles(th),
-		view:   viewSessions,
-		follow: true,
-		input:  ti,
+		store:        st,
+		keys:         defaultKeys(),
+		theme:        th,
+		styles:       newStyles(th),
+		view:         viewSessions,
+		follow:       true,
+		input:        ti,
+		searchClient: searchClient,
 	}
 
 	m.refresh()
@@ -294,6 +309,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.replaying = false
 		m.openOverlay(overlayReplay, m.replayContent(msg))
 		m.vp.GotoTop()
+		return m, nil
+
+	case searchMsg:
+		m.handleSearchMsg(msg)
 		return m, nil
 
 	case tea.KeyMsg:
@@ -434,6 +453,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 				return nil
 			})
 		}
+	case key.Matches(msg, m.keys.Search):
+		m.promptForSearch()
 
 	case key.Matches(msg, m.keys.Up):
 		m.step(-1)
@@ -523,6 +544,12 @@ func (m Model) runCommand(cmd string) (Model, tea.Cmd) {
 			m.openOverlay(overlaySummary, m.summaryContent())
 		}
 		return m, nil
+	case "search", "web":
+		query := ""
+		if len(fields) > 1 {
+			query = strings.Join(fields[1:], " ")
+		}
+		return m, m.performSearch(query)
 	case "export":
 		format, out := "", ""
 		if len(fields) > 1 {
@@ -1436,4 +1463,61 @@ func clamp(v, lo, hi int) int {
 		return lo
 	}
 	return min(max(v, lo), hi)
+}
+
+// promptForSearch opens a prompt asking for a search query.
+func (m *Model) promptForSearch() {
+	if m.searchClient == nil {
+		m.setFlash("web search not configured — set YOUCOM_API_KEY or youcom-api-key in .mcpsnoop.toml")
+		return
+	}
+	m.ask("web search query:", func(model *Model) tea.Cmd {
+		return model.performSearch(model.input.Value())
+	})
+}
+
+// searchMsg carries the result of an async You.com search.
+type searchMsg struct {
+	query  string
+	result string
+	err    error
+}
+
+// performSearch executes a You.com web search asynchronously.
+func (m *Model) performSearch(query string) tea.Cmd {
+	if m.searchClient == nil {
+		m.setFlash("web search not configured")
+		return nil
+	}
+
+	if query == "" {
+		m.setFlash("empty search query")
+		return nil
+	}
+
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		result, err := m.searchClient.Search(ctx, query)
+		if err != nil {
+			return searchMsg{query: query, err: err}
+		}
+
+		return searchMsg{
+			query:  query,
+			result: result.FormatResults(),
+		}
+	}
+}
+
+// handleSearchMsg processes the result of a web search.
+func (m *Model) handleSearchMsg(msg searchMsg) {
+	if msg.err != nil {
+		m.setFlash(fmt.Sprintf("search failed: %v", msg.err))
+		return
+	}
+
+	m.openOverlay(overlaySearch, msg.result)
+	m.setFlash(fmt.Sprintf("searched: %s", msg.query))
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -61,6 +61,7 @@ const (
 	overlayInspector
 	overlayCaps
 	overlaySummary
+	overlayElicit
 	overlayReplay
 )
 
@@ -385,7 +386,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Copy):
 			m.copyCurrent()
 		case key.Matches(msg, m.keys.Enter, m.keys.Back, m.keys.Quit),
-			key.Matches(msg, m.keys.Caps, m.keys.Summary):
+			key.Matches(msg, m.keys.Caps, m.keys.Summary, m.keys.Elicit):
 			m.closeOverlay()
 		default:
 			var cmd tea.Cmd
@@ -441,6 +442,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Summary):
 		if m.currentSessionID() != "" {
 			m.openOverlay(overlaySummary, m.summaryContent())
+		}
+	case key.Matches(msg, m.keys.Elicit):
+		if m.currentSessionID() != "" {
+			m.openOverlay(overlayElicit, m.elicitContent())
 		}
 	case key.Matches(msg, m.keys.Replay):
 		if cmd := m.startReplay(); cmd != nil {
@@ -549,6 +554,11 @@ func (m Model) runCommand(cmd string) (Model, tea.Cmd) {
 	case "summary":
 		if m.currentSessionID() != "" {
 			m.openOverlay(overlaySummary, m.summaryContent())
+		}
+		return m, nil
+	case "elicitations":
+		if m.currentSessionID() != "" {
+			m.openOverlay(overlayElicit, m.elicitContent())
 		}
 		return m, nil
 	case "export":
@@ -997,6 +1007,8 @@ func (m *Model) refreshLiveOverlay() {
 		content = m.capsContent()
 	case overlaySummary:
 		content = m.summaryContent()
+	case overlayElicit:
+		content = m.elicitContent()
 	default:
 		return
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"cmp"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -65,6 +66,7 @@ const (
 	overlayElicit
 	overlayInteract
 	overlayReplay
+	overlaySearch
 )
 
 // inputMode is the active bottom prompt ("/" filter and ":" command).
@@ -189,6 +191,11 @@ type Model struct {
 	ready         bool
 	spin          int  // shared spinner frame, advanced by tickMsg
 	dirty         bool // a frame arrived since the last refresh, set by frameMsg
+
+	// You.com search client (optional)
+	searchClient interface {
+		Search(ctx context.Context, query string) (interface{ FormatResults() string }, error)
+	}
 }
 
 // ask puts a yes-or-no question in the status bar and holds the action until it
@@ -245,6 +252,15 @@ type Option func(*Model)
 // endpoint stripped of anything credential-shaped and is not an address to dial.
 func WithHTTPReplay(target replay.HTTPTarget) Option {
 	return func(m *Model) { m.httpReplay = target }
+}
+
+// WithSearchClient attaches an optional web search client (You.com). Without it
+// the search key binding and :search/:web commands report that search is not
+// configured instead of making a call.
+func WithSearchClient(searchClient interface {
+	Search(ctx context.Context, query string) (interface{ FormatResults() string }, error)
+}) Option {
+	return func(m *Model) { m.searchClient = searchClient }
 }
 
 func New(st *store.Store, opts ...Option) Model {
@@ -341,6 +357,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.replaying = false
 		m.openOverlay(overlayReplay, m.replayContent(msg))
 		m.vp.GotoTop()
+		return m, nil
+
+	case searchMsg:
+		m.handleSearchMsg(msg)
 		return m, nil
 
 	case tea.KeyMsg:
@@ -501,6 +521,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 				return nil
 			})
 		}
+	case key.Matches(msg, m.keys.Search):
+		m.promptForSearch()
 
 	case key.Matches(msg, m.keys.Up):
 		m.step(-1)
@@ -600,6 +622,13 @@ func (m Model) runCommand(cmd string) (Model, tea.Cmd) {
 			m.openOverlay(overlayInteract, m.interactContent())
 		}
 		return m, nil
+	case "search", "web":
+		// Only a query-bearing :search/:web is a web search; a bare one may be a
+		// session-name jump (for example a session labeled "search-api"), so it
+		// falls through to the jump loop below.
+		if len(fields) > 1 {
+			return m, m.performSearch(strings.Join(fields[1:], " "))
+		}
 	case "export":
 		format, out := "", ""
 		if len(fields) > 1 {
@@ -1704,4 +1733,61 @@ func clamp(v, lo, hi int) int {
 		return lo
 	}
 	return min(max(v, lo), hi)
+}
+
+// promptForSearch opens a prompt asking for a search query.
+func (m *Model) promptForSearch() {
+	if m.searchClient == nil {
+		m.setFlash("web search not configured — set YOUCOM_API_KEY or youcom-api-key in .mcpsnoop.toml")
+		return
+	}
+	m.ask("web search query:", func(model *Model) tea.Cmd {
+		return model.performSearch(model.input.Value())
+	})
+}
+
+// searchMsg carries the result of an async You.com search.
+type searchMsg struct {
+	query  string
+	result string
+	err    error
+}
+
+// performSearch executes a You.com web search asynchronously.
+func (m *Model) performSearch(query string) tea.Cmd {
+	if m.searchClient == nil {
+		m.setFlash("web search not configured")
+		return nil
+	}
+
+	if query == "" {
+		m.setFlash("empty search query")
+		return nil
+	}
+
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		result, err := m.searchClient.Search(ctx, query)
+		if err != nil {
+			return searchMsg{query: query, err: err}
+		}
+
+		return searchMsg{
+			query:  query,
+			result: result.FormatResults(),
+		}
+	}
+}
+
+// handleSearchMsg processes the result of a web search.
+func (m *Model) handleSearchMsg(msg searchMsg) {
+	if msg.err != nil {
+		m.setFlash(fmt.Sprintf("search failed: %v", msg.err))
+		return
+	}
+
+	m.openOverlay(overlaySearch, msg.result)
+	m.setFlash(fmt.Sprintf("searched: %s", msg.query))
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -779,6 +779,11 @@ func (m Model) canReplay() bool {
 	if !ok || ev.Call == nil || ev.Kind != store.EventRequest {
 		return false
 	}
+	// A frame whose body the live store released has no params left to send.
+	// Replaying it would quietly send a different request from the one on screen.
+	if ev.BodyReleased {
+		return false
+	}
 	return m.sessionReplayable()
 }
 
@@ -798,6 +803,10 @@ func (m *Model) startReplay() tea.Cmd {
 	}
 	if ev.Call == nil || ev.Kind != store.EventRequest {
 		m.setFlash("replay needs a request frame")
+		return nil
+	}
+	if ev.BodyReleased {
+		m.setFlash("this frame's body was released to stay inside the live memory budget; reopen the session log to replay it")
 		return nil
 	}
 	return m.runReplay(*ev.Call, ev.Call.Params, false)
@@ -829,6 +838,10 @@ func (m *Model) startEditReplay() tea.Cmd {
 		ev, ok := m.focusedFrame()
 		if !ok || ev.Call == nil || ev.Kind != store.EventRequest {
 			m.setFlash("edit replay needs a request frame")
+			return nil
+		}
+		if ev.BodyReleased {
+			m.setFlash("this frame's body was released to stay inside the live memory budget; reopen the session log to edit it")
 			return nil
 		}
 		call = *ev.Call
@@ -1365,6 +1378,37 @@ func (m *Model) copyCurrent() {
 }
 
 // exportCurrent writes the selected/open session to a portable file.
+// exportData builds the export for a session. The live store releases the bodies
+// of old frames to stay inside its memory budget, so building from it would
+// write an artifact whose oldest frames have no payload and say nothing about
+// it. The log on disk is complete, so a bounded store exports from that instead
+// and only falls back to memory when no log can be read, which is the one case
+// where the store really is all there is.
+func (m *Model) exportData(id string) (exporter.SessionExport, error) {
+	if m.store.BodyLimit() > 0 {
+		if path, err := exporter.ResolveSessionPath(id); err == nil {
+			if st, sid, err := exporter.LoadFile(path); err == nil {
+				return exporter.Build(st, sid)
+			}
+		}
+		if m.anyBodyReleased(id) {
+			return exporter.SessionExport{}, fmt.Errorf("this session's oldest frames are no longer held in memory and its log could not be read, so an export would be missing them")
+		}
+	}
+	return exporter.Build(m.store, id)
+}
+
+// anyBodyReleased reports whether the budget has actually dropped anything for
+// this session yet. Under the budget there is nothing to warn about.
+func (m Model) anyBodyReleased(id string) bool {
+	for _, e := range m.store.Timeline(id) {
+		if e.BodyReleased {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Model) exportCurrent(formatArg, outPath string) {
 	id := m.currentSessionID()
 	if id == "" {
@@ -1379,7 +1423,7 @@ func (m *Model) exportCurrent(formatArg, outPath string) {
 			return
 		}
 	}
-	data, err := exporter.Build(m.store, id)
+	data, err := m.exportData(id)
 	if err != nil {
 		m.setFlash("export failed: " + err.Error())
 		return

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2304,3 +2304,229 @@ func TestStreamSaysWhenOlderFramesAreOnlyOnDisk(t *testing.T) {
 		t.Fatalf("dropped frames are being reported as a hole in the capture:\n%s", view)
 	}
 }
+
+// httpSessionStore builds a capture of an HTTP session with its meta frame and
+// one tools/call carrying the routing headers the transport requires.
+func httpSessionStore(t *testing.T) *store.Store {
+	t.Helper()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Target: "https://api.example.com/mcp?key=[stripped]"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "httpdemo", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "httpdemo", Seq: 2, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+		MCPMethod: "tools/call", MCPName: "echo",
+		MCPParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}},
+		Raw:             json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`)})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "httpdemo", Seq: 3, TS: t0.Add(10 * time.Millisecond),
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`)})
+	return st
+}
+
+// TestHTTPSessionIsReplayableOnlyWithATarget is the gate. An HTTP capture
+// records no command to run, and the endpoint it does record is stripped of
+// anything credential-shaped, so it is not an address to dial. Replay is offered
+// once somebody has said where it goes and not before.
+func TestHTTPSessionIsReplayableOnlyWithATarget(t *testing.T) {
+	st := httpSessionStore(t)
+
+	without := New(st)
+	without.streamSessionID = "s1"
+	without.allSessions = st.Sessions()
+	if without.sessionReplayable() {
+		t.Fatal("an HTTP session with no target should not offer replay")
+	}
+
+	with := New(st, WithHTTPReplay(replay.HTTPTarget{URL: "https://api.example.com/mcp?key=real"}))
+	with.streamSessionID = "s1"
+	with.allSessions = st.Sessions()
+	if !with.sessionReplayable() {
+		t.Fatal("an HTTP session with a target should offer replay")
+	}
+}
+
+// TestHTTPReplayWithoutATargetSaysWhy keeps the key from failing silently, and
+// keeps the stdio message off a session that never had a command to begin with.
+func TestHTTPReplayWithoutATargetSaysWhy(t *testing.T) {
+	st := httpSessionStore(t)
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	if cmd := m.runReplay(call, nil, false, replay.Routing{}); cmd != nil {
+		t.Fatal("a replay was started with nowhere to send it")
+	}
+	if !strings.Contains(m.flash, "--replay-target") {
+		t.Fatalf("flash = %q, want it to name the flag", m.flash)
+	}
+	if strings.Contains(m.flash, "no recorded server command") {
+		t.Fatalf("an HTTP session was told it is missing a command it never had: %q", m.flash)
+	}
+}
+
+// TestHTTPReplayAsksBeforeItSends keeps the once-per-session confirmation that
+// a recorded command already gets, because a replay reaches a live server that
+// may be the production one.
+func TestHTTPReplayAsksBeforeItSends(t *testing.T) {
+	st := httpSessionStore(t)
+	const target = "https://api.example.com/mcp?key=real"
+	m := New(st, WithHTTPReplay(replay.HTTPTarget{URL: target}))
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	if cmd := m.runReplay(call, nil, false, replay.Routing{}); cmd != nil {
+		t.Fatal("a replay was sent before it was answered for")
+	}
+	if !strings.Contains(m.confirm, target) {
+		t.Fatalf("the prompt does not name where it posts: %q", m.confirm)
+	}
+	if m.replaying {
+		t.Fatal("the replay is already in flight")
+	}
+}
+
+// TestHTTPReplayReusesTheCapturedRoutingHeaders keeps a replay from deriving the
+// request metadata a second time. The capture holds what the client sent,
+// including any base64 sentinel form, so re-sending it cannot disagree with the
+// body the way a re-derivation could.
+func TestHTTPReplayReusesTheCapturedRoutingHeaders(t *testing.T) {
+	st := httpSessionStore(t)
+	m := New(st, WithHTTPReplay(replay.HTTPTarget{URL: "https://h/mcp"}))
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	_ = call
+	// Read off the frame where a replay starts, which is where the headers are.
+	m.view = viewStream
+	m.refresh()
+	ev, ok := m.focusedFrameByMethod("tools/call")
+	if !ok {
+		t.Fatalf("no request frame in the timeline: %d frames", len(m.timeline))
+	}
+	routing := routingOf(ev)
+	if routing.Name != "echo" {
+		t.Fatalf("Mcp-Name = %q, want the captured one", routing.Name)
+	}
+	if len(routing.ParamHeaders) != 1 || routing.ParamHeaders[0].Name != "Mcp-Param-Region" ||
+		routing.ParamHeaders[0].Value != "us-west1" {
+		t.Fatalf("param headers = %+v, want the captured one", routing.ParamHeaders)
+	}
+}
+
+// TestAStdioSessionStillReplaysItsCommand keeps the transport that already
+// worked working, and keeps its prompt naming the command rather than an address.
+func TestAStdioSessionStillReplaysItsCommand(t *testing.T) {
+	st := store.New()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "server.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`)})
+
+	m := New(st, WithHTTPReplay(replay.HTTPTarget{URL: "https://h/mcp"}))
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+	if !m.sessionReplayable() {
+		t.Fatal("a stdio session lost its replay")
+	}
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	m.runReplay(call, nil, false, replay.Routing{})
+	if !strings.Contains(m.confirm, "node server.js") {
+		t.Fatalf("the prompt should still name the command it runs: %q", m.confirm)
+	}
+	if strings.Contains(m.confirm, "https://h/mcp") {
+		t.Fatalf("a stdio session was offered an HTTP target: %q", m.confirm)
+	}
+}
+
+// focusedFrameByMethod finds a request frame in the current timeline, so a test
+// can read the routing headers a replay would send without driving the cursor.
+func (m Model) focusedFrameByMethod(method string) (store.EventView, bool) {
+	for _, ev := range m.timeline {
+		if ev.Kind == store.EventRequest && ev.Method == method {
+			return ev, true
+		}
+	}
+	return store.EventView{}, false
+}
+
+// TestEditReplayOnAnHTTPSessionSaysWhy keeps R from telling an HTTP reader that
+// a command is missing. It never had one, and the message describes a transport
+// they are not using.
+func TestEditReplayOnAnHTTPSessionSaysWhy(t *testing.T) {
+	st := httpSessionStore(t)
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.view = viewStream
+	m.refresh()
+	for i, ev := range m.timeline {
+		if ev.Kind == store.EventRequest {
+			m.selEvent = i
+		}
+	}
+
+	if cmd := m.startEditReplay(); cmd != nil {
+		t.Fatal("an editor was opened for a session with nowhere to send the result")
+	}
+	if !strings.Contains(m.flash, "--replay-target") {
+		t.Fatalf("flash = %q, want it to name the flag", m.flash)
+	}
+	if strings.Contains(m.flash, "no recorded server command") {
+		t.Fatalf("an HTTP session was told it is missing a command it never had: %q", m.flash)
+	}
+}
+
+// TestAnEmptySessionIdStillAsksBeforeReplaying keeps the once-per-session
+// confirmation from being satisfied by a zero value. A log whose frames carry no
+// session_id decodes to a session whose id is empty, which the unset
+// replayConfirmed matched.
+func TestAnEmptySessionIdStillAsksBeforeReplaying(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "server.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	st.Ingest(proxy.Envelope{ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+	st.Ingest(proxy.Envelope{ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`)})
+
+	m := New(st)
+	m.streamSessionID = ""
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	if cmd := m.runReplay(call, nil, false, replay.Routing{}); cmd != nil {
+		t.Fatal("a replay was sent without being answered for")
+	}
+	if m.confirm == "" {
+		t.Fatal("no confirmation was asked for")
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1474,6 +1474,42 @@ func summaryHasRow(styled, name, cell string) bool {
 	return false
 }
 
+// summaryCell reads one column of a tool's row by the header above it, so an
+// assertion names the column it means. Searching the whole row for a marker
+// worked only while exactly one column could produce it, and a column added
+// later silently broke that.
+func summaryCell(t *testing.T, styled, name, column string) string {
+	t.Helper()
+	lines := strings.Split(ansi.Strip(styled), "\n")
+	header := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "TOOL") && strings.Contains(ln, "CALLS") {
+			header = i
+			break
+		}
+	}
+	if header < 0 {
+		t.Fatalf("no summary header in:\n%s", ansi.Strip(styled))
+	}
+	// Indexed in runes, not bytes. The header is ASCII so the two agree there, but
+	// a row can hold a multi-byte rune before the column, and slicing by byte cut
+	// one in half.
+	start := strings.Index(lines[header], column)
+	if start < 0 {
+		t.Fatalf("no %s column in %q", column, lines[header])
+	}
+	end := start + len([]rune(column))
+	for _, ln := range lines[header+1:] {
+		row := []rune(ln)
+		if !strings.HasPrefix(strings.TrimSpace(ln), name+" ") || len(row) < start {
+			continue
+		}
+		return strings.TrimSpace(string(row[start:min(end, len(row))]))
+	}
+	t.Fatalf("no row for %q in:\n%s", name, ansi.Strip(styled))
+	return ""
+}
+
 func TestSummaryHeaderShowsOnlyCallsAndSort(t *testing.T) {
 	st := store.New()
 	base := time.Now()
@@ -1501,11 +1537,14 @@ func TestSummaryHeaderShowsOnlyCallsAndSort(t *testing.T) {
 			t.Fatalf("header should show only calls, found %q: %q", banned, header)
 		}
 	}
-	// The clean tool shows · for zero errors; the erroring tool shows a count.
-	// This works because an empty SCHEMA cell is blank, so the only · in a row
-	// is the ERR one.
-	if !summaryHasRow(out, "good", "·") || summaryHasRow(out, "bad", "·") {
-		t.Fatalf("ERR column should show · only for the clean tool\n%s", out)
+	// The clean tool shows · for zero errors and the erroring tool shows a count,
+	// read from the ERR column by name rather than by hunting the row for a marker
+	// that another column could also produce.
+	if got := summaryCell(t, out, "good", "ERR"); got != "·" {
+		t.Fatalf("clean tool ERR = %q, want ·\n%s", got, out)
+	}
+	if got := summaryCell(t, out, "bad", "ERR"); got != "1" {
+		t.Fatalf("erroring tool ERR = %q, want 1\n%s", got, out)
 	}
 	// The erroring tool sorts above the clean one, not alphabetically.
 	if strings.Index(out, "bad") > strings.Index(out, "good") {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2128,5 +2129,139 @@ func TestAnAbandonedReplayResultIsNotAdoptedByTheNextOne(t *testing.T) {
 	}
 	if !strings.Contains(ansi.Strip(m.overlayRaw), "live") {
 		t.Fatalf("the overlay shows the wrong run:\n%s", ansi.Strip(m.overlayRaw))
+	}
+}
+
+// TestReplayRefusesAFrameWhoseBodyWasReleased. The live store drops the bodies
+// of old frames to stay inside its memory budget, and a request with no params
+// left would replay as {}, quietly sending a different request from the one the
+// row on screen describes.
+func TestReplayRefusesAFrameWhoseBodyWasReleased(t *testing.T) {
+	st := store.New()
+	meta, _ := json.Marshal(proxy.SessionMeta{Command: []string{"true"}, CWD: "/tmp"})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 0, TS: time.Now(), Direction: proxy.DirectionMeta, Raw: meta})
+	seed(st)
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = typeRunes(t, m, "x") // onto the request
+
+	if !m.canReplay() {
+		t.Fatal("the fixture must be replayable before the body goes, or this proves nothing")
+	}
+	for i := range m.full {
+		m.full[i].BodyReleased = true
+	}
+	if m.canReplay() {
+		t.Fatal("replay is still offered for a frame with no params left to send")
+	}
+
+	m = typeRunes(t, m, "r")
+	if m.replaying {
+		t.Fatal("r replayed a frame whose params are gone")
+	}
+	if !strings.Contains(m.flash, "released") {
+		t.Fatalf("r must say why it refused, flash = %q", m.flash)
+	}
+	m = typeRunes(t, m, "R")
+	if !strings.Contains(m.flash, "released") {
+		t.Fatalf("R must say why it refused, flash = %q", m.flash)
+	}
+}
+
+// TestExportFromABoundedStoreReadsTheLog. The live store releases the bodies of
+// old frames, so building an export from it writes an artifact whose oldest
+// frames have no payload and says nothing about it. The log on disk is complete,
+// so that is what a bounded store exports.
+func TestExportFromABoundedStoreReadsTheLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("MCPSNOOP_HOME", home)
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// One frame carrying a payload, written to the log the way the hub writes it,
+	// and fed to a store so tight that its body is released immediately.
+	const secret = "PAYLOAD-ONLY-IN-THE-LOG"
+	env := proxy.Envelope{
+		SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: time.Now(), Direction: proxy.ClientToServer,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"t":"` + secret + `"}}}`),
+	}
+	line, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessions, "s1.jsonl"), append(line, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	st := store.NewBounded(1, 0)
+	st.Ingest(env)
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: time.Now(),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`)})
+	m := ready(t, st)
+	if !m.anyBodyReleased("s1") {
+		t.Fatal("the fixture must release a body, or this proves nothing")
+	}
+
+	data, err := m.exportData("s1")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), secret) {
+		t.Fatal("the export was built from the bounded store, so the released payload is missing from it")
+	}
+}
+
+// TestExportRefusesRatherThanWriteATruncatedArtifact. When the bodies are gone
+// and the log cannot be read there is nothing complete to export, and writing
+// the remains under the usual success message would be the quiet lie.
+func TestExportRefusesRatherThanWriteATruncatedArtifact(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir()) // no log for this session
+	st := store.NewBounded(1, 0)
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: time.Now(),
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"t":"aaaaaaaaaa"}}}`)})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: time.Now(),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`)})
+
+	m := ready(t, st)
+	if _, err := m.exportData("s1"); err == nil {
+		t.Fatal("an export missing its oldest frames was written without a word")
+	}
+}
+
+// TestStreamSaysWhenOlderFramesAreOnlyOnDisk. The memory budget removes the
+// oldest frames from the timeline, so the top of the stream stops being the
+// start of the session. Saying nothing would let a reader believe they were
+// looking at the whole thing.
+func TestStreamSaysWhenOlderFramesAreOnlyOnDisk(t *testing.T) {
+	st := store.NewBounded(0, 4)
+	now := time.Now()
+	for i := range 20 {
+		st.Ingest(proxy.Envelope{
+			SessionID: "s1", ServerLabel: "demo", Seq: uint64(i + 1),
+			TS: now.Add(time.Duration(i) * time.Millisecond), Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":` + strconv.Itoa(i) + `}}`),
+		})
+	}
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // into the stream
+
+	if got := m.currentDroppedFrames(); got != 16 {
+		t.Fatalf("dropped = %d, want the 16 frames past the cap", got)
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "16 older on disk") {
+		t.Fatalf("the stream does not say frames were dropped:\n%s", view)
+	}
+	// It is not the same thing as a gap in the capture, which means bytes nobody
+	// ever saw, so it must not borrow that word.
+	if strings.Contains(view, "16 missing") {
+		t.Fatalf("dropped frames are being reported as a hole in the capture:\n%s", view)
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -933,6 +933,31 @@ func TestReplayFromInspector(t *testing.T) {
 	}
 }
 
+func TestEditReplayFromInspector(t *testing.T) {
+	st := store.New()
+	st.Ingest(metaEnv("s1", []string{"true"}))
+	seed(st)
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // stream
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // inspector on the response
+	m = typeRunes(t, m, "x")                        // paired request
+
+	// Keep any editor fixture in the test's private directory even though this
+	// fail-before test only needs to prove that R launches an editor command.
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "true")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	got := next.(Model)
+	if cmd == nil {
+		t.Fatal("R on a replayable request should launch the edit-and-replay editor")
+	}
+	if got.replaying {
+		t.Fatal("editing must finish and validate before a replay can start")
+	}
+}
+
 func TestInspectorFooterConditionalKeys(t *testing.T) {
 	st := store.New()
 	meta, _ := json.Marshal(proxy.SessionMeta{Command: []string{"true"}, CWD: "/tmp"})
@@ -986,7 +1011,7 @@ func TestReplayAgainFromResult(t *testing.T) {
 	}
 
 	// The result lands and opens the replay overlay.
-	m = drive(t, m, replayDoneMsg{res: replay.Result{Method: "get_sum", Response: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`)}})
+	m = drive(t, m, replayDoneMsg{token: m.replayToken, res: replay.Result{Method: "get_sum", Response: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`)}})
 	if m.overlay != overlayReplay || m.replaying {
 		t.Fatalf("the result should open the replay overlay, overlay=%d replaying=%v", m.overlay, m.replaying)
 	}
@@ -1002,6 +1027,142 @@ func TestReplayAgainFromResult(t *testing.T) {
 	m = typeRunes(t, m, "r")
 	if !m.replaying || m.replayReq.Method != before {
 		t.Fatalf("r in the replay overlay should re-run the same replay, replaying=%v method=%q", m.replaying, m.replayReq.Method)
+	}
+}
+
+func TestEditedReplayKeepsConfirmationAndThreeParamLayers(t *testing.T) {
+	st := store.New()
+	st.Ingest(metaEnv("s1", []string{"safe-server", "--stdio"}))
+	seed(st)
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // stream
+
+	var captured store.CallView
+	for _, ev := range m.full {
+		if ev.Kind == store.EventRequest && ev.Call != nil && ev.Call.Method == "tools/call" {
+			captured = *ev.Call
+			break
+		}
+	}
+	if captured.Method == "" {
+		t.Fatal("test request not found")
+	}
+	edited := captured
+	edited.Params = json.RawMessage(`{"x":"edited"}`)
+	beforeTimeline := len(st.Timeline("s1"))
+
+	next, cmd := m.Update(replayEditDoneMsg{call: edited, captured: captured.Params})
+	m = next.(Model)
+	if cmd != nil || m.confirm == "" {
+		t.Fatal("a valid edit must enter the existing command confirmation before replay")
+	}
+	if m.replaying || m.replayReq.Method != "" {
+		t.Fatal("editor completion must not mutate replay state before confirmation")
+	}
+
+	m = typeRunes(t, m, "y")
+	if !m.replaying {
+		t.Fatal("confirmed edited replay did not start")
+	}
+	if !m.replayEdited || string(m.replayCaptured) != string(captured.Params) || string(m.replayReq.Params) != string(edited.Params) {
+		t.Fatalf("replay param layers were not retained: captured=%s candidate=%s edited=%v", m.replayCaptured, m.replayReq.Params, m.replayEdited)
+	}
+	if got := len(st.Timeline("s1")); got != beforeTimeline {
+		t.Fatalf("starting an edited replay changed the observed store: got %d want %d", got, beforeTimeline)
+	}
+
+	actual := json.RawMessage(`{"x":"edited","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`)
+	m = drive(t, m, replayDoneMsg{token: m.replayToken, res: replay.Result{
+		Method:   "echo",
+		Params:   actual,
+		Response: json.RawMessage(`{"jsonrpc":"2.0","id":2,"result":{"isError":true}}`),
+		ToolErr:  true,
+	}})
+	out := ansi.Strip(m.overlayRaw)
+	for _, want := range []string{"REPLAY · EDITED · echo", "ERROR tool reported an error", "captured params", "params sent", "2026-07-28"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("edited replay overlay missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "ok  (") {
+		t.Fatalf("a tool-level error must not render as ok:\n%s", out)
+	}
+	if got := len(st.Timeline("s1")); got != beforeTimeline {
+		t.Fatalf("an edited replay result entered the observed store: got %d want %d", got, beforeTimeline)
+	}
+
+	// Lowercase r repeats the candidate, not the captured bytes or the system
+	// metadata added to the prior wire request.
+	m = typeRunes(t, m, "r")
+	if !m.replaying || string(m.replayReq.Params) != string(edited.Params) {
+		t.Fatalf("r did not repeat the edited candidate: %s", m.replayReq.Params)
+	}
+}
+
+func TestReplayEditFailureLeavesCurrentLoopUntouched(t *testing.T) {
+	m := New(store.New())
+	m.replayReq = store.CallView{Method: "tools/call", Params: json.RawMessage(`{"old":true}`)}
+	m.replayCaptured = json.RawMessage(`{"captured":true}`)
+	m.replayEdited = true
+
+	next, cmd := m.Update(replayEditDoneMsg{err: os.ErrInvalid})
+	got := next.(Model)
+	if cmd != nil || got.replaying {
+		t.Fatal("an invalid edit must not start a replay")
+	}
+	if got.replayReq.Method != m.replayReq.Method || string(got.replayReq.Params) != string(m.replayReq.Params) || string(got.replayCaptured) != string(m.replayCaptured) || got.replayEdited != m.replayEdited {
+		t.Fatal("an invalid edit partially changed the current replay loop")
+	}
+	if !strings.Contains(got.flash, "edit replay aborted") {
+		t.Fatalf("invalid edit flash = %q", got.flash)
+	}
+}
+
+func TestReplayContentSeparatesProtocolMetadataFromUserEdits(t *testing.T) {
+	m := New(store.New())
+	m.replayCaptured = json.RawMessage(`{"name":"echo"}`)
+	m.replayEdited = false
+	out := ansi.Strip(m.replayContent(replayDoneMsg{res: replay.Result{
+		Method:   "tools/call",
+		Params:   json.RawMessage(`{"name":"echo","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`),
+		Response: json.RawMessage(`{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
+	}}))
+	if strings.Contains(out, "EDITED") || strings.Contains(out, "captured params") {
+		t.Fatalf("protocol-required metadata must not masquerade as a user edit:\n%s", out)
+	}
+	for _, want := range []string{"REPLAY · tools/call", "request params", "2026-07-28"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("actual stateless wire params missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestEditReplayKeyFromStreamAndReplayOverlay(t *testing.T) {
+	st := store.New()
+	st.Ingest(metaEnv("s1", []string{"true"}))
+	st.Ingest(env(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`))
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "true")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("R in the stream should launch the editor for the selected request")
+	}
+
+	m.overlay = overlayReplay
+	m.replayReq = store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo","arguments":{"text":"edited"}}`)}
+	m.replayCaptured = json.RawMessage(`{"name":"echo","arguments":{"text":"captured"}}`)
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("R in the replay overlay should reopen the editor on the current candidate")
+	}
+	if string(m.replayReq.Params) != `{"name":"echo","arguments":{"text":"edited"}}` {
+		t.Fatal("opening the editor must not mutate the current candidate")
 	}
 }
 
@@ -1026,7 +1187,7 @@ func TestReplayAbandonedOnNavigation(t *testing.T) {
 	if m.replaying {
 		t.Fatal("closing the overlay should abandon the in-flight replay")
 	}
-	m = drive(t, m, replayDoneMsg{res: replay.Result{Method: "x", Response: json.RawMessage("{}")}})
+	m = drive(t, m, replayDoneMsg{token: m.replayToken, res: replay.Result{Method: "x", Response: json.RawMessage("{}")}})
 	if m.overlay == overlayReplay {
 		t.Fatal("an abandoned replay result should not open an overlay")
 	}
@@ -1523,6 +1684,13 @@ func TestSortSessions(t *testing.T) {
 	if m.sessions[0].Label != "gamma" {
 		t.Fatalf("shift+N twice should be desc, got %s first", m.sessions[0].Label)
 	}
+	// R remains the request-count sort in the sessions view; edit-and-replay is
+	// only reachable after drilling into a request frame.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	m = next.(Model)
+	if cmd != nil || m.sessionSort.col != "req" {
+		t.Fatalf("R in sessions should sort requests, cmd=%v sort=%q", cmd != nil, m.sessionSort.col)
+	}
 }
 
 func TestWrapAroundNavigation(t *testing.T) {
@@ -1909,5 +2077,56 @@ func TestCancelAndLateRowsAreSelectableByWhatTheySay(t *testing.T) {
 				t.Fatal("the cancellation frame is missing from the timeline")
 			}
 		})
+	}
+}
+
+// TestAnAbandonedReplayResultIsNotAdoptedByTheNextOne. replaying is a bare bool,
+// so it only said that some replay was in flight. Walking away from one replay
+// clears it, the spawned server keeps running, and when that first result finally
+// landed it was rendered against whatever run had started since: one request's
+// captured params over another request's answer, with the second run's own result
+// then dropped because the same line clears the flag.
+func TestAnAbandonedReplayResultIsNotAdoptedByTheNextOne(t *testing.T) {
+	st := store.New()
+	meta, _ := json.Marshal(proxy.SessionMeta{Command: []string{"true"}, CWD: "/tmp"})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 0, TS: time.Now(), Direction: proxy.DirectionMeta, Raw: meta})
+	seed(st)
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = typeRunes(t, m, "x")
+
+	// First replay, then walk away from it the way opening any overlay does.
+	m = typeRunes(t, m, "r")
+	m = typeRunes(t, m, "y")
+	first := m.replayToken
+	if !m.replaying {
+		t.Fatal("the first replay did not start")
+	}
+	m.dismissTransient()
+
+	// Second replay, of the same session, which is what the user is now watching.
+	m = typeRunes(t, m, "r")
+	second := m.replayToken
+	if first == second {
+		t.Fatal("the two runs share a token, so nothing can tell them apart")
+	}
+
+	// The abandoned run answers late.
+	m = drive(t, m, replayDoneMsg{token: first, res: replay.Result{Method: "stale", Response: json.RawMessage(`{"stale":true}`)}})
+	if m.overlay == overlayReplay {
+		t.Fatal("a result from an abandoned replay was rendered over the current one")
+	}
+	if !m.replaying {
+		t.Fatal("the abandoned result cleared the flag the live run needs")
+	}
+
+	// The run the user is actually waiting for still lands.
+	m = drive(t, m, replayDoneMsg{token: second, res: replay.Result{Method: "live", Response: json.RawMessage(`{"live":true}`)}})
+	if m.overlay != overlayReplay {
+		t.Fatal("the live result never reached the screen")
+	}
+	if !strings.Contains(ansi.Strip(m.overlayRaw), "live") {
+		t.Fatalf("the overlay shows the wrong run:\n%s", ansi.Strip(m.overlayRaw))
 	}
 }

--- a/internal/tui/replay.go
+++ b/internal/tui/replay.go
@@ -256,3 +256,14 @@ func indentJSON(raw json.RawMessage) string {
 	}
 	return buf.String()
 }
+
+// replayHTTPCmd sends a captured request to a live endpoint over HTTP, off the
+// UI goroutine, and reports the outcome under the token of the run that asked
+// for it so a result the user walked away from cannot be rendered against the
+// run that replaced it.
+func replayHTTPCmd(token uint64, target replay.HTTPTarget, method string, params json.RawMessage, routing replay.Routing) tea.Cmd {
+	return func() tea.Msg {
+		res, err := replay.ReplayHTTP(context.Background(), target, method, params, routing, replayTimeout)
+		return replayDoneMsg{token: token, res: res, err: err}
+	}
+}

--- a/internal/tui/replay.go
+++ b/internal/tui/replay.go
@@ -4,34 +4,215 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/kerlenton/mcpsnoop/internal/replay"
+	"github.com/kerlenton/mcpsnoop/internal/store"
 )
 
 // replayDoneMsg carries the outcome of an async replay back into Update.
 type replayDoneMsg struct {
-	res replay.Result
-	err error
+	// token names the run this result belongs to, so a result the user walked
+	// away from cannot be rendered against the run that replaced it.
+	token uint64
+	res   replay.Result
+	err   error
+}
+
+// replayEditDoneMsg is emitted only after the editor has exited, its temporary
+// file has been read and removed, and the saved value has passed JSON-object
+// validation. Until then the model's current replay loop remains untouched.
+type replayEditDoneMsg struct {
+	call     store.CallView
+	captured json.RawMessage
+	err      error
 }
 
 const replayTimeout = 15 * time.Second
 
-func replayCmd(command []string, cwd, method string, params json.RawMessage) tea.Cmd {
+func replayCmd(token uint64, command []string, cwd, method string, params json.RawMessage) tea.Cmd {
 	return func() tea.Msg {
 		res, err := replay.Replay(context.Background(), command, cwd, method, params, replayTimeout)
-		return replayDoneMsg{res: res, err: err}
+		return replayDoneMsg{token: token, res: res, err: err}
 	}
+}
+
+func editReplayCmd(call store.CallView, captured json.RawMessage) (tea.Cmd, error) {
+	cmd, done, err := prepareReplayEditor(call, captured)
+	if err != nil {
+		return nil, err
+	}
+	return tea.ExecProcess(cmd, done), nil
+}
+
+// prepareReplayEditor creates the private buffer and returns the process plus
+// callback separately, which keeps the editor boundary directly testable.
+//
+// The whole value is tried as one executable first, so a path containing a space
+// works on its own. Anything else is split on whitespace, which covers the
+// common command-plus-flags values such as "code --wait" without running a
+// shell. What that cannot do is both at once, since a quoted path carrying flags
+// needs a shell to unquote it, so that case is refused by name rather than left
+// to fail as a mangled argv[0].
+func prepareReplayEditor(call store.CallView, captured json.RawMessage) (*exec.Cmd, tea.ExecCallback, error) {
+	editor := strings.TrimSpace(os.Getenv("VISUAL"))
+	if editor == "" {
+		editor = strings.TrimSpace(os.Getenv("EDITOR"))
+	}
+	if editor == "" {
+		return nil, nil, fmt.Errorf("set $VISUAL or $EDITOR to edit replay params")
+	}
+
+	if _, err := decodeReplayParams(call.Params, true); err != nil {
+		return nil, nil, fmt.Errorf("captured params: %w", err)
+	}
+	pretty, err := indentReplayParams(call.Params)
+	if err != nil {
+		return nil, nil, fmt.Errorf("format captured params: %w", err)
+	}
+
+	// A directory rather than a bare file, removed whole. Editors write companions
+	// beside the file they were given, a vim swap or undo file, an emacs autosave,
+	// a rename-style backup, and those hold the same captured bytes under whatever
+	// name that editor chose. Unlinking the one path mcpsnoop knows about leaves
+	// them behind.
+	dir, err := os.MkdirTemp("", "mcpsnoop-replay-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create editor buffer: %w", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+	path := filepath.Join(dir, "params.json")
+	if err := os.WriteFile(path, append(pretty, '\n'), 0o600); err != nil {
+		return nil, nil, fmt.Errorf("write editor buffer: %w", err)
+	}
+
+	parts := []string{editor}
+	if _, err := exec.LookPath(editor); err != nil {
+		parts = strings.Fields(editor)
+	}
+	if len(parts) == 0 || parts[0] == "" {
+		return nil, nil, errors.New("$VISUAL or $EDITOR is empty")
+	}
+	if _, err := exec.LookPath(parts[0]); err != nil && len(parts) > 1 {
+		return nil, nil, fmt.Errorf("neither %q nor %q is an executable; mcpsnoop splits $VISUAL and $EDITOR on whitespace and runs no shell, so a path containing a space cannot also carry flags",
+			editor, parts[0])
+	}
+	cmd := exec.Command(parts[0], append(parts[1:], path)...)
+	call.Params = append(json.RawMessage(nil), call.Params...)
+	captured = append(json.RawMessage(nil), captured...)
+	seeded := append([]byte(nil), append(pretty, '\n')...)
+	done := func(runErr error) tea.Msg {
+		defer os.RemoveAll(dir)
+		if runErr != nil {
+			return replayEditDoneMsg{err: fmt.Errorf("editor failed: %w", runErr)}
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return replayEditDoneMsg{err: fmt.Errorf("read editor buffer: %w", err)}
+		}
+		// An unchanged buffer is not an edit, and R must not send on one. An editor
+		// that hands the file to an already-running instance and exits, which is
+		// what EDITOR=code without --wait and emacsclient -n do, returns here
+		// before the user has typed anything, and sending then would fire a live
+		// request at the server while they are still looking at the window.
+		if bytes.Equal(raw, seeded) {
+			return replayEditDoneMsg{err: errors.New("the editor saved no change, so nothing was sent; press r to replay the captured params as they are")}
+		}
+		if len(bytes.TrimSpace(raw)) == 0 {
+			return replayEditDoneMsg{err: errors.New("edited params are empty")}
+		}
+		if _, err := decodeReplayParams(raw, false); err != nil {
+			return replayEditDoneMsg{err: err}
+		}
+		call.Params = append(json.RawMessage(nil), bytes.TrimSpace(raw)...)
+		return replayEditDoneMsg{call: call, captured: captured}
+	}
+	keep = true
+	return cmd, done, nil
+}
+
+// indentReplayParams renders the captured params for the editor from the bytes
+// the server actually sent, rather than from a decoded copy of them.
+//
+// encoding/json escapes &, < and > when it marshals, and it sorts the keys of a
+// map, so a decode-and-re-encode showed a URL argument as
+// "https://host?a=1&b=2" and reordered every object the user was about to
+// edit. internal/jsonwire exists for the first half of that, and json.Indent for
+// both: it rewrites nothing but the whitespace between tokens.
+func indentReplayParams(raw json.RawMessage) ([]byte, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return []byte("{}"), nil
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeReplayParams accepts exactly one JSON object. An absent captured params
+// value is represented to the editor as {}, while a user-saved empty file is an
+// explicit error handled before this function is called.
+func decodeReplayParams(raw json.RawMessage, allowEmpty bool) (map[string]any, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		if !allowEmpty {
+			return nil, fmt.Errorf("edited params are empty")
+		}
+		raw = json.RawMessage(`{}`)
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, fmt.Errorf("edited params are not valid JSON: %w", err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("edited params contain more than one JSON value")
+		}
+		return nil, fmt.Errorf("edited params are not valid JSON: %w", err)
+	}
+	obj, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("edited params must be a JSON object")
+	}
+	return obj, nil
+}
+
+func replayParamsEquivalent(a, b json.RawMessage) bool {
+	aObj, aErr := decodeReplayParams(a, true)
+	bObj, bErr := decodeReplayParams(b, true)
+	if aErr != nil || bErr != nil {
+		return false
+	}
+	aCanonical, aErr := json.Marshal(aObj)
+	bCanonical, bErr := json.Marshal(bObj)
+	return aErr == nil && bErr == nil && bytes.Equal(aCanonical, bCanonical)
 }
 
 // replayContent renders the replay outcome for the overlay.
 func (m Model) replayContent(msg replayDoneMsg) string {
 	var b strings.Builder
-	b.WriteString(m.styles.panelTitle.Render("REPLAY · "+msg.res.Method) + "\n\n")
+	title := "REPLAY · " + msg.res.Method
+	if m.replayEdited {
+		title = "REPLAY · EDITED · " + msg.res.Method
+	}
+	b.WriteString(m.styles.panelTitle.Render(title) + "\n\n")
 
 	if msg.err != nil {
 		b.WriteString(m.styles.respErr.Render("failed: "+msg.err.Error()) + "\n")
@@ -42,12 +223,22 @@ func (m Model) replayContent(msg replayDoneMsg) string {
 	switch {
 	case msg.res.Err != nil:
 		b.WriteString(m.styles.respErr.Render(fmt.Sprintf("ERROR %s  (%s)", rpcErrorText(*msg.res.Err), dur)) + "\n\n")
+	case msg.res.ToolErr:
+		b.WriteString(m.styles.respErr.Render(fmt.Sprintf("ERROR tool reported an error  (%s)", dur)) + "\n\n")
 	default:
 		b.WriteString(m.styles.resp.Render(fmt.Sprintf("ok  (%s)", dur)) + "\n\n")
 	}
 
+	if m.replayEdited {
+		b.WriteString(m.styles.dim.Render("captured params") + "\n")
+		b.WriteString(indentJSON(m.replayCaptured) + "\n\n")
+	}
 	if len(msg.res.Params) > 0 {
-		b.WriteString(m.styles.dim.Render("request params") + "\n")
+		label := "request params"
+		if m.replayEdited {
+			label = "params sent"
+		}
+		b.WriteString(m.styles.dim.Render(label) + "\n")
 		b.WriteString(indentJSON(msg.res.Params) + "\n\n")
 	}
 	b.WriteString(m.styles.dim.Render("response") + "\n")

--- a/internal/tui/replay_edit_test.go
+++ b/internal/tui/replay_edit_test.go
@@ -1,0 +1,363 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+// TestMain doubles the current test binary as a portable stub editor. The
+// parent gives it only the temporary JSON path, so no shell or platform-specific
+// script is needed to exercise the real exec.Cmd boundary.
+func TestMain(m *testing.M) {
+	if os.Getenv("MCPSNOOP_EDITOR_HELPER") == "1" {
+		path := os.Args[len(os.Args)-1]
+		var err error
+		switch os.Getenv("MCPSNOOP_EDITOR_BEHAVIOR") {
+		case "unchanged":
+		case "changed":
+			err = os.WriteFile(path, []byte("{\n  \"name\": \"echo\",\n  \"arguments\": {\"text\": \"new\"}\n}\n"), 0o600)
+		case "invalid":
+			err = os.WriteFile(path, []byte("{not json\n"), 0o600)
+		case "non-object":
+			err = os.WriteFile(path, []byte("[1, 2, 3]\n"), 0o600)
+		case "multiple":
+			err = os.WriteFile(path, []byte("{} {}\n"), 0o600)
+		case "empty":
+			err = os.WriteFile(path, nil, 0o600)
+		case "resaved":
+			// vim's :wq on an unmodified buffer, which rewrites the same bytes.
+			seeded, readErr := os.ReadFile(path)
+			if readErr != nil {
+				os.Exit(9)
+			}
+			err = os.WriteFile(path, seeded, 0o600)
+		case "companions":
+			// What vim leaves with "set backup" or "set undofile", and what emacs
+			// leaves as an autosave. Same captured bytes, a name mcpsnoop never chose.
+			dir, base := filepath.Dir(path), filepath.Base(path)
+			seeded, readErr := os.ReadFile(path)
+			if readErr != nil {
+				os.Exit(9)
+			}
+			for _, name := range []string{base + "~", "." + base + ".swp", "#" + base + "#"} {
+				if err = os.WriteFile(filepath.Join(dir, name), seeded, 0o600); err != nil {
+					break
+				}
+			}
+			if err == nil {
+				err = os.WriteFile(path, []byte("{\n  \"name\": \"echo\",\n  \"arguments\": {\"text\": \"new\"}\n}\n"), 0o600)
+			}
+		case "exit":
+			os.Exit(7)
+		default:
+			os.Exit(8)
+		}
+		if err != nil {
+			os.Exit(9)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestReplayEditorOutcomes(t *testing.T) {
+	original := json.RawMessage(`{"name":"echo","arguments":{"text":"old"}}`)
+	call := store.CallView{Method: "tools/call", Params: original}
+
+	for _, tc := range []struct {
+		name     string
+		behavior string
+		wantErr  string
+		wantText string
+	}{
+		{name: "changed", behavior: "changed", wantText: `"new"`},
+		{name: "unchanged", behavior: "unchanged", wantErr: "saved no change"},
+		{name: "invalid", behavior: "invalid", wantErr: "not valid JSON"},
+		{name: "non object", behavior: "non-object", wantErr: "must be a JSON object"},
+		{name: "multiple values", behavior: "multiple", wantErr: "more than one JSON value"},
+		{name: "empty", behavior: "empty", wantErr: "empty"},
+		{name: "nonzero exit", behavior: "exit", wantErr: "editor failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+			t.Setenv("VISUAL", "")
+			t.Setenv("EDITOR", os.Args[0])
+			t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+			t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", tc.behavior)
+
+			cmd, done, err := prepareReplayEditor(call, original)
+			if err != nil {
+				t.Fatalf("prepareReplayEditor: %v", err)
+			}
+			path := cmd.Args[len(cmd.Args)-1]
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("editor buffer: %v", err)
+			}
+			if info.Mode().Perm() != 0o600 {
+				t.Fatalf("editor buffer mode = %o, want 600", info.Mode().Perm())
+			}
+			seeded, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(seeded), "\n  \"arguments\"") {
+				t.Fatalf("editor buffer is not pretty JSON:\n%s", seeded)
+			}
+
+			msg, ok := done(cmd.Run()).(replayEditDoneMsg)
+			if !ok {
+				t.Fatal("editor callback returned the wrong message type")
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("editor buffer was not removed, stat err=%v", err)
+			}
+			if tc.wantErr != "" {
+				if msg.err == nil || !strings.Contains(msg.err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want substring %q", msg.err, tc.wantErr)
+				}
+				return
+			}
+			if msg.err != nil {
+				t.Fatalf("editor callback: %v", msg.err)
+			}
+			if !strings.Contains(string(msg.call.Params), tc.wantText) {
+				t.Fatalf("saved params = %s, want %s", msg.call.Params, tc.wantText)
+			}
+			if string(msg.captured) != string(original) {
+				t.Fatalf("captured params changed: %s", msg.captured)
+			}
+		})
+	}
+}
+
+func TestReplayEditorSelectionAndGuards(t *testing.T) {
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo"}`)}
+
+	t.Run("VISUAL takes precedence", func(t *testing.T) {
+		t.Setenv("TMPDIR", t.TempDir())
+		t.Setenv("VISUAL", os.Args[0])
+		t.Setenv("EDITOR", filepath.Join(t.TempDir(), "must-not-run"))
+		t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "changed")
+		cmd, done, err := prepareReplayEditor(call, call.Params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg := done(cmd.Run()).(replayEditDoneMsg)
+		if msg.err != nil {
+			t.Fatalf("VISUAL was not used: %v", msg.err)
+		}
+	})
+
+	t.Run("EDITOR fallback", func(t *testing.T) {
+		t.Setenv("TMPDIR", t.TempDir())
+		t.Setenv("VISUAL", "")
+		t.Setenv("EDITOR", os.Args[0])
+		t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "changed")
+		cmd, done, err := prepareReplayEditor(call, call.Params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg := done(cmd.Run()).(replayEditDoneMsg); msg.err != nil {
+			t.Fatalf("EDITOR fallback failed: %v", msg.err)
+		}
+	})
+
+	t.Run("missing editor", func(t *testing.T) {
+		t.Setenv("VISUAL", "")
+		t.Setenv("EDITOR", "")
+		if _, _, err := prepareReplayEditor(call, call.Params); err == nil || !strings.Contains(err.Error(), "$VISUAL or $EDITOR") {
+			t.Fatalf("missing editor error = %v", err)
+		}
+	})
+
+	t.Run("captured non-object", func(t *testing.T) {
+		t.Setenv("EDITOR", os.Args[0])
+		bad := call
+		bad.Params = json.RawMessage(`[1]`)
+		if _, _, err := prepareReplayEditor(bad, bad.Params); err == nil || !strings.Contains(err.Error(), "JSON object") {
+			t.Fatalf("non-object captured params error = %v", err)
+		}
+	})
+}
+
+func TestReplayParamsEquivalentIgnoresFormattingAndObjectOrder(t *testing.T) {
+	a := json.RawMessage(`{"b":[2,3],"a":1}`)
+	b := json.RawMessage("{\n  \"a\": 1,\n  \"b\": [2, 3]\n}")
+	if !replayParamsEquivalent(a, b) {
+		t.Fatal("formatting and object key order should not mark a replay as edited")
+	}
+	if replayParamsEquivalent(a, json.RawMessage(`{"a":1,"b":[2,4]}`)) {
+		t.Fatal("a changed nested value should mark a replay as edited")
+	}
+}
+
+// TestEditorBufferKeepsTheBytesTheServerSent. The buffer is what the user edits,
+// so it has to be what the server actually sent. Decoding into a map and
+// re-encoding does neither: encoding/json escapes &, < and > on the way out, so
+// a URL argument arrived as "https://host?a=1&b=2", and a map has no order,
+// so every object came back alphabetised. internal/jsonwire exists in this repo
+// because of the first half of that.
+func TestEditorBufferKeepsTheBytesTheServerSent(t *testing.T) {
+	const captured = `{"zeta":1,"url":"https://h/p?a=1&b=2","alpha":"<b>","n":{"y":2,"x":1}}`
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(captured)}
+
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", os.Args[0])
+	t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+	t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "unchanged")
+
+	cmd, _, err := prepareReplayEditor(call, call.Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seeded, err := os.ReadFile(cmd.Args[len(cmd.Args)-1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(seeded)
+	for _, want := range []string{`"https://h/p?a=1&b=2"`, `"<b>"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buffer escaped what the server sent, %s is missing:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `\u00`) {
+		t.Errorf("buffer carries an escape the capture did not:\n%s", got)
+	}
+	// Key order is the server's, not the alphabet's.
+	if z, a := strings.Index(got, `"zeta"`), strings.Index(got, `"alpha"`); z < 0 || a < 0 || z > a {
+		t.Errorf("buffer reordered the keys:\n%s", got)
+	}
+	if x, y := strings.Index(got, `"y"`), strings.Index(got, `"x"`); x < 0 || y < 0 || x > y {
+		t.Errorf("buffer reordered a nested object:\n%s", got)
+	}
+}
+
+// TestEditorThatSavesNothingSendsNothing. An editor that hands the file to an
+// already-running instance and exits, which is what EDITOR=code without --wait
+// and emacsclient -n do, returns before the user has typed. Treating that as a
+// finished edit fired a live request at the server carrying the untouched
+// captured params, while the user was still looking at the window, and the
+// result panel called it REPLAY rather than EDITED so nothing said so.
+func TestEditorThatSavesNothingSendsNothing(t *testing.T) {
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo"}`)}
+	for _, behavior := range []string{"unchanged", "resaved"} {
+		t.Run(behavior, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+			t.Setenv("VISUAL", "")
+			t.Setenv("EDITOR", os.Args[0])
+			t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+			t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", behavior)
+
+			cmd, done, err := prepareReplayEditor(call, call.Params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			msg := done(cmd.Run()).(replayEditDoneMsg)
+			if msg.err == nil {
+				t.Fatalf("an unedited buffer was sent as an edit: %s", msg.call.Params)
+			}
+			// The message has to name the key that does resend it, or a user who
+			// meant to replay unchanged is left with no way forward.
+			if !strings.Contains(msg.err.Error(), "press r") {
+				t.Fatalf("error does not say what to do instead: %v", msg.err)
+			}
+		})
+	}
+}
+
+// TestEditorBufferDirectoryGoesWholeIncludingCompanions. Editors write beside
+// the file they are given, a vim swap or undo file, an emacs autosave, a
+// rename-style backup, each holding the same captured params and named by the
+// editor rather than by mcpsnoop. Unlinking the one path mcpsnoop knows about
+// left those on disk with the captured request in them.
+func TestEditorBufferDirectoryGoesWholeIncludingCompanions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", os.Args[0])
+	t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+	t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "companions")
+
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo","arguments":{"token":"sk-live-secret"}}`)}
+	cmd, done, err := prepareReplayEditor(call, call.Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Dir(cmd.Args[len(cmd.Args)-1])
+	if msg := done(cmd.Run()).(replayEditDoneMsg); msg.err != nil {
+		t.Fatalf("editor callback: %v", msg.err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		left, _ := os.ReadDir(dir)
+		names := make([]string, 0, len(left))
+		for _, e := range left {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("the buffer directory survived holding %v", names)
+	}
+	// Nothing of it is anywhere else under the temp root either.
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "mcpsnoop-replay") {
+			t.Fatalf("%s was left behind", e.Name())
+		}
+	}
+}
+
+// TestEditorValueThatNeedsAShellIsRefusedByName. The whole value is tried as one
+// executable so a path with a space works, and anything else is split on
+// whitespace so "code --wait" works. A quoted path carrying flags needs a shell
+// to unquote and gets neither, and letting it through produced
+// "fork/exec /Applications/Sublime: no such file or directory", which names a
+// path the user never wrote.
+func TestEditorValueThatNeedsAShellIsRefusedByName(t *testing.T) {
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"a":1}`)}
+
+	// A real executable whose path contains a space, since the whole point is that
+	// this one resolves as a single value and the others cannot.
+	spaced := filepath.Join(t.TempDir(), "My Editor")
+	if err := os.WriteFile(spaced, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, tc := range map[string]struct {
+		editor  string
+		wantErr bool
+	}{
+		"a path with a space, alone":       {spaced, false},
+		"a bare name with flags":           {"vim -n", false},
+		"a path with a space, plus a flag": {spaced + " --wait", true},
+		"a quoted path with a flag":        {`"` + spaced + `" --wait`, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+			t.Setenv("VISUAL", tc.editor)
+			t.Setenv("EDITOR", "")
+			_, _, err := prepareReplayEditor(call, call.Params)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("a value needing a shell was accepted, so exec fails on a mangled path instead")
+				}
+				if !strings.Contains(err.Error(), "runs no shell") {
+					t.Fatalf("the error must say why, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("a value mcpsnoop can run was refused: %v", err)
+			}
+		})
+	}
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -123,8 +123,8 @@ func observeAndNudge(m *toolbaseline.Manager, st *store.Store, sessionID string,
 }
 
 // RunOpen starts the TUI using a preloaded store without starting the live hub.
-func RunOpen(ctx context.Context, st *store.Store) error {
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
+func RunOpen(ctx context.Context, st *store.Store, opts ...Option) error {
+	p := tea.NewProgram(New(st, opts...), tea.WithAltScreen(), tea.WithContext(ctx))
 	go observeAllInBackground(p, st)
 	_, err := p.Run()
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {
@@ -134,8 +134,8 @@ func RunOpen(ctx context.Context, st *store.Store) error {
 }
 
 // RunOpenWithInput starts the TUI using a preloaded store and a custom input reader (e.g., controlling TTY).
-func RunOpenWithInput(ctx context.Context, st *store.Store, in io.Reader) error {
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx), tea.WithInput(in))
+func RunOpenWithInput(ctx context.Context, st *store.Store, in io.Reader, opts ...Option) error {
+	p := tea.NewProgram(New(st, opts...), tea.WithAltScreen(), tea.WithContext(ctx), tea.WithInput(in))
 	go observeAllInBackground(p, st)
 	_, err := p.Run()
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -24,10 +24,20 @@ func Run(ctx context.Context, socketPath, sessionsDir string) error {
 	return RunWithHistoryLimit(ctx, socketPath, sessionsDir, hub.DefaultBackfillLimit)
 }
 
+// liveStore is the store the live TUI runs on. It is bounded, unlike the one
+// check, export, diff and open build, because a hub is left running while a
+// batch command reads a finite log once and has to see all of it.
+//
+// Split out from Run so the choice is a value a test can read rather than a
+// literal inside a call no test can reach.
+func liveStore() *store.Store {
+	return store.NewBounded(store.DefaultLiveBodyLimit, store.DefaultLiveFrameLimit)
+}
+
 // RunWithHistoryLimit starts the live TUI with a bounded history replay.
 // A historyLimit of 0 loads every session log.
 func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
-	st := store.New()
+	st := liveStore()
 	baselines := toolbaseline.New(paths.ToolBaselinesDir())
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
 

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -14,6 +15,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 	"github.com/kerlenton/mcpsnoop/internal/toolbaseline"
+	"github.com/kerlenton/mcpsnoop/internal/youcom"
 )
 
 // Run starts the hub and the live TUI. It blocks until the user quits or ctx is
@@ -27,9 +29,21 @@ func Run(ctx context.Context, socketPath, sessionsDir string) error {
 // RunWithHistoryLimit starts the live TUI with a bounded history replay.
 // A historyLimit of 0 loads every session log.
 func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
+	return RunWithOptions(ctx, socketPath, sessionsDir, historyLimit, "")
+}
+
+// RunWithOptions starts the live TUI with configurable options including You.com search.
+func RunWithOptions(ctx context.Context, socketPath, sessionsDir string, historyLimit int, youcomAPIKey string) error {
 	st := store.New()
 	baselines := toolbaseline.New(paths.ToolBaselinesDir())
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
+	
+	// Create You.com client if API key is provided (from flag or env var)
+	if youcomAPIKey == "" {
+		youcomAPIKey = os.Getenv("YOUCOM_API_KEY")
+	}
+	searchClient := youcom.NewClient(youcomAPIKey)
+	
+	p := tea.NewProgram(NewWithSearchClient(st, searchClient), tea.WithAltScreen(), tea.WithContext(ctx))
 
 	hubCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -14,6 +15,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 	"github.com/kerlenton/mcpsnoop/internal/toolbaseline"
+	"github.com/kerlenton/mcpsnoop/internal/youcom"
 )
 
 // Run starts the hub and the live TUI. It blocks until the user quits or ctx is
@@ -40,12 +42,36 @@ func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, hi
 	return runWithHistoryLimit(ctx, socketPath, sessionsDir, historyLimit)
 }
 
-func runWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
+// RunWithOptions starts the live TUI with the optional You.com web search
+// integration. An empty youcomAPIKey falls back to the YOUCOM_API_KEY
+// environment variable; with neither, search is reported as unconfigured.
+func RunWithOptions(ctx context.Context, socketPath, sessionsDir string, historyLimit int, youcomAPIKey string) error {
+	if youcomAPIKey == "" {
+		youcomAPIKey = os.Getenv("YOUCOM_API_KEY")
+	}
+	var searchOpt Option
+	if client := youcom.NewClient(youcomAPIKey); client != nil {
+		searchOpt = WithSearchClient(searchAdapter{client: client})
+	}
+	return runWithHistoryLimit(ctx, socketPath, sessionsDir, historyLimit, searchOpt)
+}
+
+// searchAdapter fits *youcom.Client to the Model's searchClient interface so
+// the model stays decoupled from the youcom package.
+type searchAdapter struct {
+	client *youcom.Client
+}
+
+func (a searchAdapter) Search(ctx context.Context, query string) (interface{ FormatResults() string }, error) {
+	return a.client.Search(ctx, query)
+}
+
+func runWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int, opts ...Option) error {
 	st := liveStore()
 	baselines := toolbaseline.New(paths.ToolBaselinesDir())
 	hubCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(hubCtx))
+	p := tea.NewProgram(New(st, opts...), tea.WithAltScreen(), tea.WithContext(hubCtx))
 
 	// Baseline observation reads and sometimes writes files, so keep it off the
 	// frame-delivery goroutine. A single worker observes the sessions handed to it

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -37,12 +37,15 @@ func liveStore() *store.Store {
 // RunWithHistoryLimit starts the live TUI with a bounded history replay.
 // A historyLimit of 0 loads every session log.
 func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
+	return runWithHistoryLimit(ctx, socketPath, sessionsDir, historyLimit)
+}
+
+func runWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
 	st := liveStore()
 	baselines := toolbaseline.New(paths.ToolBaselinesDir())
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
-
 	hubCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(hubCtx))
 
 	// Baseline observation reads and sometimes writes files, so keep it off the
 	// frame-delivery goroutine. A single worker observes the sessions handed to it
@@ -61,7 +64,7 @@ func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, hi
 		}
 	}()
 
-	h := hub.NewWithOptions(socketPath, sessionsDir, func(e proxy.Envelope) {
+	handler := func(e proxy.Envelope) {
 		event := st.Ingest(e)
 		if event.Kind == store.EventResponse && event.Call != nil && event.Call.Method == "tools/list" {
 			if _, complete := st.ToolDefinitions(e.SessionID); complete {
@@ -74,14 +77,16 @@ func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, hi
 			}
 		}
 		p.Send(frameMsg{})
-	}, hub.Options{
+	}
+	options := hub.Options{
 		BackfillLimit: historyLimit,
 		OnBackfill: func(report hub.BackfillReport) {
 			if report.Loaded < report.Total {
 				p.Send(historyTruncatedMsg{loaded: report.Loaded, total: report.Total})
 			}
 		},
-	})
+	}
+	h := hub.NewWithOptions(socketPath, sessionsDir, handler, options)
 
 	// A second hub on one MCPSNOOP_HOME cannot take the socket, and Run returns
 	// before it backfills, so swallowing the error left the user staring at an

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -96,3 +96,16 @@ func TestRunReportsAnAlreadyRunningHub(t *testing.T) {
 		t.Fatalf("the error should name the socket, got %v", err)
 	}
 }
+
+// TestLiveStoreIsBounded. The hub feeds this store for as long as mcpsnoop is
+// left open, so it is the one store that has to forget. The batch commands build
+// an unbounded one on purpose, since a bound there would make check under-report
+// on a large capture.
+func TestLiveStoreIsBounded(t *testing.T) {
+	if limit := liveStore().BodyLimit(); limit <= 0 {
+		t.Fatalf("the live TUI store keeps every body, limit = %d", limit)
+	}
+	if got := store.New().BodyLimit(); got != 0 {
+		t.Fatalf("the batch store is bounded at %d, so check would under-report", got)
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -184,7 +184,7 @@ func (m Model) footerHints() string {
 	if m.view == viewStream {
 		hs = []hint{{"enter", "inspect"}}
 		if m.sessionReplayable() {
-			hs = append(hs, hint{"r", "replay"})
+			hs = append(hs, hint{"r", "replay"}, hint{"R", "edit + replay"})
 		}
 		hs = append(hs, hint{"c", "caps"}, hint{"s", "summary"}, hint{"/", "filter"}, hint{"p", "pause"}, hint{"?", "help"})
 	}
@@ -989,6 +989,7 @@ func (m Model) renderHelp() string {
 	}}
 	frameActions := helpGroup{"FRAME ACTIONS", [][2]string{
 		{"r", "replay the selected tool call"},
+		{"R", "edit params and replay the selected call"},
 		{"c", "show negotiated capabilities"},
 		{"s", "show per-tool latency and error summary"},
 		{"p", "pause or resume the stream"},
@@ -1343,14 +1344,14 @@ func (m Model) overlayFooter(w int) string {
 		hs = append(hs, hint{"/", "search"}, hint{"n/N", "match"}, hint{"y", "copy"})
 		// r and x are only offered when they can act on the inspected frame.
 		if m.canReplay() {
-			hs = append(hs, hint{"r", "replay"})
+			hs = append(hs, hint{"r", "replay"}, hint{"R", "edit + replay"})
 		}
 		if _, ok := m.pairIndex(m.inspect); ok {
 			hs = append(hs, hint{"x", "pair"})
 		}
 		hs = append(hs, hint{"esc", "close"})
 	case m.overlay == overlayReplay && m.replayReq.Method != "":
-		hs = append(hs, hint{"r", "replay again"}, hint{"y", "copy"}, hint{"esc", "close"})
+		hs = append(hs, hint{"r", "replay again"}, hint{"R", "edit + replay"}, hint{"y", "copy"}, hint{"esc", "close"})
 	default:
 		hs = append(hs, hint{"y", "copy"}, hint{"esc", "close"})
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1029,6 +1029,7 @@ func (m Model) renderHelp() string {
 		{"R", "edit params and replay the selected call"},
 		{"c", "show negotiated capabilities"},
 		{"s", "show per-tool latency and error summary"},
+		{"l", "show what servers asked the user for"},
 		{"p", "pause or resume the stream"},
 		{"f", "toggle follow"},
 	}}
@@ -2443,4 +2444,79 @@ func formatCacheHint(h store.CacheHint) string {
 	default:
 		return fmt.Sprintf("cache cacheScope=%s", h.Scope)
 	}
+}
+
+// elicitContent renders the elicitation ledger overlay: every question a server
+// put to the user through the client, and what came back.
+//
+// It shows the shape of each question and never its content. What the user typed
+// is in the capture for anyone who needs it, and leaving it out is what makes
+// this panel safe to screenshot whatever the session was redacted with, which
+// matters most in url mode, where the specification puts credentials on purpose.
+func (m Model) elicitContent() string {
+	rows := m.store.Elicitations(m.currentSessionID())
+	if len(rows) == 0 {
+		return m.styles.panelTitle.Render("elicitations") + "\n\n" +
+			m.styles.dim.Render("no server asked the user for anything in this session")
+	}
+
+	var b strings.Builder
+	b.WriteString(m.styles.panelTitle.Render("elicitations") + "  " +
+		m.styles.faint.Render(countLabel(len(rows), len(rows), "question")) + "\n")
+	b.WriteString(m.styles.faint.Render("what each server asked for, and what the user answered. "+
+		"submitted values stay in the capture and are deliberately not shown here") + "\n")
+
+	for _, row := range rows {
+		who := row.Method
+		if row.ToolName != "" {
+			who = row.Method + " " + row.ToolName
+		}
+		b.WriteString("\n" + m.styles.bright.Render(who) +
+			m.styles.faint.Render("  id "+row.CallID+"  ["+row.Mode+"]  "+row.Key) + "\n")
+		if row.Message != "" {
+			b.WriteString(m.styles.neutral.Render("  "+row.Message) + "\n")
+		}
+		switch {
+		case row.URL != "":
+			// The full address, because the specification makes a client show it whole
+			// before consent, and the host called out, because it tells one to
+			// highlight the domain against subdomain spoofing.
+			b.WriteString(m.styles.dim.Render(cellL("  url", 10)) + m.styles.neutral.Render(row.URL) + "\n")
+			if row.Host != "" {
+				b.WriteString(m.styles.dim.Render(cellL("  host", 10)) + m.styles.warn.Render(row.Host) + "\n")
+			}
+		case len(row.Fields) > 0:
+			parts := make([]string, 0, len(row.Fields))
+			for _, f := range row.Fields {
+				typ := f.Type
+				if typ == "" {
+					// Not a type the server declared. A redacted subschema arrives here, and
+					// printing mcpsnoop's own placeholder would present it as one.
+					typ = "unknown"
+				}
+				parts = append(parts, f.Name+" "+m.styles.faint.Render(typ))
+			}
+			b.WriteString(m.styles.dim.Render(cellL("  fields", 10)) + m.styles.neutral.Render(strings.Join(parts, ", ")) + "\n")
+		}
+		b.WriteString(m.styles.dim.Render(cellL("  answer", 10)) + m.elicitAnswer(row) + "\n")
+	}
+	return b.String()
+}
+
+// elicitAnswer renders what the user did. Accept, decline and cancel are the
+// three the specification names, and anything else is a client mcpsnoop does not
+// recognise, which is shown as it arrived rather than dropped.
+func (m Model) elicitAnswer(row store.ElicitationView) string {
+	if row.Pending() {
+		return m.styles.pending.Render("pending") + m.styles.faint.Render("  no retry ever answered this")
+	}
+	style := m.styles.neutral
+	switch row.Action {
+	case "accept":
+		style = m.styles.resp
+	case "decline", "cancel":
+		style = m.styles.warn
+	}
+	return style.Render(row.Action) +
+		m.styles.faint.Render("  after "+formatLatency(row.Elapsed))
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -187,7 +187,7 @@ func (m Model) footerHints() string {
 		if m.sessionReplayable() {
 			hs = append(hs, hint{"r", "replay"}, hint{"R", "edit + replay"})
 		}
-		hs = append(hs, hint{"c", "caps"}, hint{"s", "summary"}, hint{"/", "filter"}, hint{"p", "pause"}, hint{"?", "help"})
+		hs = append(hs, hint{"c", "caps"}, hint{"s", "summary"}, hint{"w", "search"}, hint{"/", "filter"}, hint{"p", "pause"}, hint{"?", "help"})
 	}
 	return m.hintsRow(hs)
 }
@@ -1032,6 +1032,7 @@ func (m Model) renderHelp() string {
 		{"s", "show per-tool latency and error summary"},
 		{"l", "show what servers asked the user for"},
 		{"i", "show interactions with per-hop timing"},
+		{"w", "search the web (You.com integration)"},
 		{"p", "pause or resume the stream"},
 		{"f", "toggle follow"},
 	}}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -216,6 +216,13 @@ func (m Model) footerCounters() string {
 	if missing := m.currentMissingFrames(); missing > 0 {
 		parts = append(parts, m.styles.respErr.Render(fmt.Sprintf("%d missing", missing)))
 	}
+	// Frames the memory budget dropped are a different thing from missing ones.
+	// They were observed and are still in the log, so this is dim rather than red,
+	// but the top of the stream is not the start of the session and saying nothing
+	// would let a reader believe it was.
+	if dropped := m.currentDroppedFrames(); dropped > 0 {
+		parts = append(parts, m.styles.faint.Render(fmt.Sprintf("%d older on disk", dropped)))
+	}
 	c := m.streamSignals
 	for _, sig := range []struct {
 		n     int
@@ -232,6 +239,17 @@ func (m Model) footerCounters() string {
 		}
 	}
 	return strings.Join(parts, sep)
+}
+
+// currentDroppedFrames returns how many of this session's frames the live store
+// released to stay inside its memory budget. They are still in the log.
+func (m Model) currentDroppedFrames() int {
+	for _, s := range m.allSessions {
+		if s.ID == m.streamSessionID {
+			return s.DroppedFromMemory
+		}
+	}
+	return 0
 }
 
 // currentMissingFrames returns the dropped-frame count for the session being
@@ -1104,6 +1122,13 @@ func (m Model) inspectorBody() string {
 	}
 	if len(e.Raw) > 0 {
 		b.WriteString(prettyJSON(e.Raw))
+	}
+	// A frame whose body the live store released still has a row, a verdict and a
+	// place in the timeline, and saying nothing here would read as a server that
+	// sent an empty frame. The log on disk is untouched.
+	if e.BodyReleased {
+		b.WriteString(m.styles.dim.Render(
+			"body released to stay inside the live memory budget; open the session log to read it"))
 	}
 	return b.String()
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -186,7 +186,7 @@ func (m Model) footerHints() string {
 		if m.sessionReplayable() {
 			hs = append(hs, hint{"r", "replay"})
 		}
-		hs = append(hs, hint{"c", "caps"}, hint{"s", "summary"}, hint{"/", "filter"}, hint{"p", "pause"}, hint{"?", "help"})
+		hs = append(hs, hint{"c", "caps"}, hint{"s", "summary"}, hint{"w", "search"}, hint{"/", "filter"}, hint{"p", "pause"}, hint{"?", "help"})
 	}
 	return m.hintsRow(hs)
 }
@@ -991,6 +991,7 @@ func (m Model) renderHelp() string {
 		{"r", "replay the selected tool call"},
 		{"c", "show negotiated capabilities"},
 		{"s", "show per-tool latency and error summary"},
+		{"w", "search the web (You.com integration)"},
 		{"p", "pause or resume the stream"},
 		{"f", "toggle follow"},
 	}}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -1030,6 +1031,7 @@ func (m Model) renderHelp() string {
 		{"c", "show negotiated capabilities"},
 		{"s", "show per-tool latency and error summary"},
 		{"l", "show what servers asked the user for"},
+		{"i", "show interactions with per-hop timing"},
 		{"p", "pause or resume the stream"},
 		{"f", "toggle follow"},
 	}}
@@ -1479,10 +1481,16 @@ const (
 	// and a tool with one problem renders exactly like a tool with five.
 	sumSchemaW = 8
 	sumCallsW  = 7
-	sumErrW    = 6
-	sumLatW    = 10
-	sumDefW    = 9
-	sumResW    = 10
+	sumTripsW  = 6
+	// The fixed columns without TRIPS come to seventy cells, which is exactly what
+	// an eighty-column terminal gives an overlay. TRIPS is the one that drops when
+	// there is no room, the way ACTIVITY and CLIENT drop from the sessions table,
+	// so adding it did not start wrapping every row on a narrow screen.
+	sumWidthWithoutTrips = 70
+	sumErrW              = 6
+	sumLatW              = 10
+	sumDefW              = 9
+	sumResW              = 10
 	// covLabelW fits the longest gutter label plus a space. "definitions" is
 	// eleven cells wide, so eleven would leave no gap at all and run the label
 	// into its value.
@@ -1586,8 +1594,14 @@ func (m Model) summaryContent() string {
 		}
 	})
 	var t strings.Builder
+	overlayW, _ := m.overlayDims()
+	showTrips := overlayW >= sumWidthWithoutTrips+sumTripsW
+	tripsHead := ""
+	if showTrips {
+		tripsHead = cellR("TRIPS", sumTripsW)
+	}
 	t.WriteString(m.styles.dim.Render(cellL("TOOL", sumToolW) +
-		cellR("CALLS", sumCallsW) + cellR("ERR", sumErrW) + cellR("LATENCY", sumLatW) +
+		cellR("CALLS", sumCallsW) + tripsHead + cellR("ERR", sumErrW) + cellR("LATENCY", sumLatW) +
 		cellR("DEF", sumDefW) + cellR("RESULT", sumResW) +
 		"  " + cellL("SCHEMA", sumSchemaW)))
 	for _, tool := range tools {
@@ -1630,8 +1644,20 @@ func (m Model) summaryContent() string {
 			defCell = cellR(base.Render(formatBytes(int64(c.Bytes))), sumDefW)
 		}
 		resCell := cellR(base.Render(formatBytes(tool.ResultBytes)), sumResW)
+		// TRIPS is the most requests any one call of this tool took, so a tool that
+		// elicits is visible without opening a panel. One round trip is what almost
+		// every row says, so it is left blank rather than dotted. A column of dots is
+		// noise, and the point of the column is the row that is not one.
+		trips := ""
+		if showTrips {
+			trips = cellR("", sumTripsW)
+			if tool.MaxRoundTrips > 1 {
+				trips = cellR(m.styles.warn.Render(fmt.Sprintf("%d", tool.MaxRoundTrips)), sumTripsW)
+			}
+		}
 		t.WriteString("\n" + base.Render(cellL(tool.Name, sumToolW)) +
 			cellR(base.Render(fmt.Sprintf("%d", tool.Calls)), sumCallsW) +
+			trips +
 			cellR(errCell, sumErrW) +
 			cellR(lat, sumLatW) +
 			defCell + resCell +
@@ -2519,4 +2545,87 @@ func (m Model) elicitAnswer(row store.ElicitationView) string {
 	}
 	return style.Render(row.Action) +
 		m.styles.faint.Render("  after "+formatLatency(row.Elapsed))
+}
+
+// interactContent renders the interactions overlay: one entry per logical
+// operation, with the per-hop breakdown of a chain.
+//
+// Under multi round-trip requests one tool call is several requests, and the
+// seconds a person spent answering sit inside the total, which is deliberate.
+// This panel is where that total comes apart into the share the server held and
+// the share it was waiting on the client.
+func (m Model) interactContent() string {
+	all := m.store.Interactions(m.currentSessionID())
+	chained := make([]store.InteractionView, 0, len(all))
+	for _, in := range all {
+		if in.RoundTrips > 1 {
+			chained = append(chained, in)
+		}
+	}
+	if len(chained) == 0 {
+		body := "no operation in this session took more than one request"
+		if len(all) > 0 {
+			body += fmt.Sprintf(", so all %s read as they look", countLabel(len(all), len(all), "call"))
+		}
+		return m.styles.panelTitle.Render("interactions") + "\n\n" + m.styles.dim.Render(body)
+	}
+
+	var b strings.Builder
+	b.WriteString(m.styles.panelTitle.Render("interactions") + "  " +
+		m.styles.faint.Render(countLabel(len(chained), len(all), "operation")) + "\n")
+	b.WriteString(m.styles.faint.Render("operations that took more than one request. the total includes the time "+
+		"a person spent answering, so the server's own share is separated out") + "\n")
+
+	for _, in := range chained {
+		who := in.Method
+		if in.ToolName != "" {
+			who = in.Method + " " + in.ToolName
+		}
+		b.WriteString("\n" + m.styles.bright.Render(safeCell(who)) +
+			m.styles.faint.Render(fmt.Sprintf("  id %s  %d round trips", safeCell(in.CallID), in.RoundTrips)) + "\n")
+		b.WriteString(m.styles.dim.Render(cellL("  total", 10)) + m.styles.neutral.Render(formatLatency(in.Duration)) +
+			m.styles.faint.Render("  = ") + m.styles.resp.Render(formatLatency(in.ServerTime)) +
+			m.styles.faint.Render(" server + ") + m.styles.warn.Render(formatLatency(in.ClientTurnaround)) +
+			m.styles.faint.Render(" client") + "\n")
+		for i, hop := range in.Hops {
+			line := fmt.Sprintf("  hop %d", i+1)
+			b.WriteString(m.styles.dim.Render(cellL(line, 10)) +
+				m.styles.faint.Render("id "+safeCell(hop.RequestID)+"  ") +
+				m.styles.resp.Render(formatLatency(hop.ServerTime)))
+			if hop.ClientTurnaround > 0 {
+				b.WriteString(m.styles.faint.Render(" + ") + m.styles.warn.Render(formatLatency(hop.ClientTurnaround)))
+			}
+			if len(hop.Asked) > 0 {
+				b.WriteString(m.styles.faint.Render("  asked " + safeCell(strings.Join(hop.Asked, ", "))))
+			}
+			if hop.Pending {
+				b.WriteString(m.styles.pending.Render("  no answer"))
+			}
+			b.WriteString("\n")
+		}
+		if !in.HopsComplete {
+			// A live store releases old frames, so the breakdown can be a window while
+			// the totals above it stay exact. Saying so keeps the two from reading as
+			// a contradiction.
+			b.WriteString(m.styles.dim.Render(cellL("", 10)) +
+				m.styles.faint.Render(fmt.Sprintf("%d of %d hops still held, the rest were released to stay inside the memory budget",
+					len(in.Hops), in.RoundTrips)) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// safeCell keeps a value the wire supplied from ending the line it is printed on
+// or driving the terminal.
+//
+// A tool name, a method and a JSON-RPC id are all written by whoever wrote the
+// server, and a newline in one closes the row it lands in while an escape
+// sequence moves the cursor out of the panel. paths.CheckLabel refuses a control
+// character for the same reason, and the inventory and stats tables quote rather
+// than drop one so the value stays recoverable.
+func safeCell(s string) string {
+	if strings.ContainsFunc(s, unicode.IsControl) {
+		return strconv.Quote(s)
+	}
+	return s
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -223,6 +223,14 @@ func (m Model) footerCounters() string {
 	if dropped := m.currentDroppedFrames(); dropped > 0 {
 		parts = append(parts, m.styles.faint.Render(fmt.Sprintf("%d older on disk", dropped)))
 	}
+	// Multi round-trip operations the parking cap retired while they were still
+	// open. Warn rather than faint, because unlike the line above this one makes
+	// the numbers beside it wrong: a retry arriving for a retired operation reads
+	// as its own call, so the session shows two calls and two durations where
+	// there was one.
+	if retired := m.currentRetiredExchanges(); retired > 0 {
+		parts = append(parts, m.styles.warn.Render(fmt.Sprintf("%d unlinked", retired)))
+	}
 	c := m.streamSignals
 	for _, sig := range []struct {
 		n     int
@@ -247,6 +255,17 @@ func (m Model) currentDroppedFrames() int {
 	for _, s := range m.allSessions {
 		if s.ID == m.streamSessionID {
 			return s.DroppedFromMemory
+		}
+	}
+	return 0
+}
+
+// currentRetiredExchanges returns how many multi round-trip operations the store
+// dropped at its parking cap while they were still waiting for a retry.
+func (m Model) currentRetiredExchanges() int {
+	for _, s := range m.allSessions {
+		if s.ID == m.streamSessionID {
+			return s.RetiredExchanges
 		}
 	}
 	return 0
@@ -1540,7 +1559,17 @@ func (m Model) summaryContent() string {
 		tools = append(tools, store.ToolStats{Name: name})
 	}
 	slices.SortStableFunc(tools, func(a, b store.ToolStats) int {
-		if ae, be := a.Errors > 0, b.Errors > 0; ae != be {
+		// Protocol errors outrank tool errors rather than sharing one bucket with
+		// them. A tool that answers isError is reporting a domain outcome, so a
+		// search that legitimately finds nothing used to sort above a server that
+		// is actually broken.
+		if ae, be := a.ProtocolErrors > 0, b.ProtocolErrors > 0; ae != be {
+			if ae {
+				return -1
+			}
+			return 1
+		}
+		if ae, be := a.ToolErrors > 0, b.ToolErrors > 0; ae != be {
 			if ae {
 				return -1
 			}
@@ -1565,10 +1594,7 @@ func (m Model) summaryContent() string {
 		if tool.Calls == 0 {
 			base = m.styles.faint // an advertised-but-idle tool recedes until it is called
 		}
-		errCell := m.styles.faint.Render("·")
-		if tool.Errors > 0 {
-			errCell = m.styles.respErr.Render(fmt.Sprintf("%d", tool.Errors))
-		}
+		errCell := m.errCell(tool)
 		// LATENCY is the median (p50), a plain number the reader judges for
 		// themselves. A tool whose calls are all still in flight shows a live cyan
 		// spinner rather than a dash.
@@ -1615,6 +1641,15 @@ func (m Model) summaryContent() string {
 	// The worst single result is the per-call cost's tail, which a total hides:
 	// one 4 MiB answer among a hundred small ones reads as an unremarkable
 	// average until it is named.
+	// The ERR column's two colors only teach themselves once, so the line naming
+	// them appears exactly when there is a yellow number to explain. A session
+	// whose only errors are protocol errors reads the red count without help.
+	if proto, reported := errorSplit(summary.Tools); reported > 0 {
+		sections = append(sections, m.styles.dim.Render(cellL("errors", covLabelW))+
+			m.styles.respErr.Render(fmt.Sprintf("%d", proto))+m.styles.neutral.Render(" from the server, ")+
+			m.styles.warn.Render(fmt.Sprintf("%d", reported))+m.styles.neutral.Render(" reported by the tool itself with isError"))
+	}
+
 	if name, worst := heaviestResult(summary.Tools); worst > 0 {
 		sections = append(sections, m.styles.dim.Render(cellL("heaviest", covLabelW))+
 			m.styles.neutral.Render(fmt.Sprintf("%s returned %s in one result", name, formatBytes(int64(worst)))))
@@ -1629,6 +1664,45 @@ func (m Model) summaryContent() string {
 	}
 
 	return header + "\n\n" + strings.Join(sections, "\n\n")
+}
+
+// errCellPart is one styled piece of the ERR column. The column carries two
+// different findings, so the colour is part of the answer rather than decoration
+// and the pieces are decided separately from the string they render into.
+type errCellPart struct {
+	text  string
+	style lipgloss.Style
+}
+
+// errCellParts decides what the ERR column says about one tool. Red is a
+// protocol error, the server side being broken. Warn is result.isError, the tool
+// reporting that the search found nothing or the input failed validation, which
+// is the tool working. A tool with both shows them joined, red first, so the two
+// counts stay legible without a second column in a table that is already 70
+// cells wide before the panel border.
+func (m Model) errCellParts(tool store.ToolStats) []errCellPart {
+	var parts []errCellPart
+	if tool.ProtocolErrors > 0 {
+		parts = append(parts, errCellPart{fmt.Sprintf("%d", tool.ProtocolErrors), m.styles.respErr})
+	}
+	if tool.ProtocolErrors > 0 && tool.ToolErrors > 0 {
+		parts = append(parts, errCellPart{"+", m.styles.faint})
+	}
+	if tool.ToolErrors > 0 {
+		parts = append(parts, errCellPart{fmt.Sprintf("%d", tool.ToolErrors), m.styles.warn})
+	}
+	if len(parts) == 0 {
+		parts = append(parts, errCellPart{"·", m.styles.faint})
+	}
+	return parts
+}
+
+func (m Model) errCell(tool store.ToolStats) string {
+	var b strings.Builder
+	for _, part := range m.errCellParts(tool) {
+		b.WriteString(part.style.Render(part.text))
+	}
+	return b.String()
 }
 
 // schemaHeadlineOrder ranks findings for the single-label SCHEMA column. A
@@ -1798,6 +1872,16 @@ func (m Model) definitionCostLine(cost store.ToolListCost) string {
 }
 
 // heaviestResult names the tool with the largest single observed result.
+// errorSplit totals the two kinds of failure across a session's tools, so the
+// legend under the table can name them without recounting inside the renderer.
+func errorSplit(tools []store.ToolStats) (protocol, reported int) {
+	for _, t := range tools {
+		protocol += t.ProtocolErrors
+		reported += t.ToolErrors
+	}
+	return protocol, reported
+}
+
 func heaviestResult(tools []store.ToolStats) (string, int) {
 	name, worst := "", 0
 	for _, t := range tools {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -332,3 +332,167 @@ func TestElicitKeyIsBoundAndDocumented(t *testing.T) {
 		t.Fatalf("the help never mentions the panel:\n%s", help)
 	}
 }
+
+// mrtrStore builds the capture from issue #201 in a store.
+func mrtrStore(t *testing.T) *store.Store {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	for i, f := range frames {
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "booking", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+	}
+	return st
+}
+
+// TestInteractPanelSplitsTheTotal covers the panel where a wall clock comes
+// apart into the server's share and the client's.
+func TestInteractPanelSplitsTheTotal(t *testing.T) {
+	m := New(mrtrStore(t))
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.interactContent()
+
+	for _, want := range []string{"book_flight", "3 round trips", "hop 1", "hop 2", "hop 3", "elicitation/create"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("the panel does not show %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "lookup_price") {
+		t.Fatalf("an ordinary one hop call is already a line in the stream:\n%s", out)
+	}
+	// The three figures, rendered the way the rest of the TUI renders a latency.
+	for _, want := range []string{"38.2s", "1.2s", "37s"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("the panel does not show %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestInteractPanelOnASessionWithNoChainSaysSo keeps an empty panel from reading
+// as a broken one.
+func TestInteractPanelOnASessionWithNoChainSaysSo(t *testing.T) {
+	m := New(store.New())
+	m.streamSessionID = "s1"
+	if out := m.interactContent(); !strings.Contains(out, "no operation in this session took more than one request") {
+		t.Fatalf("out = %q", out)
+	}
+}
+
+// TestSummaryShowsRoundTrips covers the column that makes a chatty tool visible
+// without opening a panel, and keeps it quiet for the ordinary case.
+func TestSummaryShowsRoundTrips(t *testing.T) {
+	m := New(mrtrStore(t))
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.summaryContent()
+	if !strings.Contains(out, "TRIPS") {
+		t.Fatalf("the summary has no round trips column:\n%s", out)
+	}
+	// Read by column name, since CALLS also carries small numbers and hunting the
+	// row for one would find the wrong column.
+	if got := summaryCell(t, out, "book_flight", "TRIPS"); got != "3" {
+		t.Fatalf("book_flight TRIPS = %q, want 3\n%s", got, out)
+	}
+	// One round trip is the ordinary case and says nothing.
+	if got := summaryCell(t, out, "lookup_price", "TRIPS"); got != "" {
+		t.Fatalf("lookup_price TRIPS = %q, want blank\n%s", got, out)
+	}
+}
+
+// TestInteractKeyIsBoundAndDocumented keeps the panel reachable and the help
+// honest.
+func TestInteractKeyIsBoundAndDocumented(t *testing.T) {
+	m := New(store.New())
+	if got := m.keys.Interact.Keys(); len(got) != 1 || got[0] != "i" {
+		t.Fatalf("bound to %v, want i", got)
+	}
+	m.width, m.height = 120, 40
+	if help := m.renderHelp(); !strings.Contains(help, "per-hop timing") {
+		t.Fatalf("the help never mentions the panel:\n%s", help)
+	}
+}
+
+// TestInteractPanelCannotBeMadeToForgeRows covers the class of defect the
+// inventory and stats tables were fixed for. A tool name and a method come from
+// whoever wrote the server, so a newline in one would close the row it lands in
+// and an escape sequence would drive the terminal.
+func TestInteractPanelCannotBeMadeToForgeRows(t *testing.T) {
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	const forged = "book\x1b[31mflight\r\n  total     FORGED"
+	// Encoded as JSON, not with %q. Go's quoting spells an escape as \x1b, which
+	// JSON has no such escape for, so the frame would be malformed and the store
+	// would drop it rather than render it.
+	name, err := json.Marshal(forged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, fmt.Sprintf(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":%s}}`, name)},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 5000, fmt.Sprintf(`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":%s,"requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`, name)},
+		{proxy.ServerToClient, 5100, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	}
+	for i, f := range frames {
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+	}
+
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.interactContent()
+	if strings.ContainsRune(out, 0x1b) {
+		t.Fatalf("an escape sequence reached the panel:\n%q", out)
+	}
+	if strings.Contains(out, "\n  total     FORGED") {
+		t.Fatalf("a forged line reached the panel:\n%s", out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("the value was dropped rather than quoted, so it is not recoverable:\n%s", out)
+	}
+}
+
+// TestSummaryTableFitsANarrowTerminal keeps the new column from wrapping every
+// row on an eighty-column screen, which is exactly the width the panel was
+// already sized to fill.
+func TestSummaryTableFitsANarrowTerminal(t *testing.T) {
+	for _, width := range []int{80, 84, 90, 120} {
+		m := New(mrtrStore(t))
+		m.streamSessionID = "s1"
+		m.width, m.height = width, 40
+		panelW, _ := m.overlayDims()
+		out := m.summaryContent()
+		for _, line := range strings.Split(out, "\n") {
+			if got := lipgloss.Width(line); got > panelW {
+				t.Fatalf("at %d columns a row is %d cells wide against a %d-cell panel:\n%s",
+					width, got, panelW, line)
+			}
+		}
+		// The column is there when there is room for it, and gone when there is not.
+		if wantTrips := panelW >= sumWidthWithoutTrips+sumTripsW; strings.Contains(out, "TRIPS") != wantTrips {
+			t.Fatalf("at %d columns TRIPS present = %v, want %v", width, strings.Contains(out, "TRIPS"), wantTrips)
+		}
+	}
+}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1,11 +1,15 @@
 package tui
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 )
 
@@ -127,5 +131,133 @@ func TestSchemaHeadlineOrderRanksEveryKind(t *testing.T) {
 		if got := headlineFinding(findings); got != store.FindingNonObjectRoot {
 			t.Errorf("a schema with %s and a non-object root headlines %s, want the violation", other, got)
 		}
+	}
+}
+
+// TestErrCellSeparatesTheTwoKindsOfFailure locks the ERR column's colours, which
+// are the answer rather than decoration. Red means the server side broke, warn
+// means the tool answered isError, and a tool with both shows the counts joined
+// rather than one number that reads as a single finding.
+func TestErrCellSeparatesTheTwoKindsOfFailure(t *testing.T) {
+	m := New(store.New())
+	red := m.styles.respErr.GetForeground()
+	yellow := m.styles.warn.GetForeground()
+	if red == yellow {
+		t.Fatal("the two error styles share a colour, so the column cannot separate them")
+	}
+
+	for _, tc := range []struct {
+		name   string
+		tool   store.ToolStats
+		text   string
+		colour lipgloss.TerminalColor
+	}{
+		{"clean", store.ToolStats{}, "·", m.styles.faint.GetForeground()},
+		{"server broke", store.ToolStats{Errors: 3, ProtocolErrors: 3}, "3", red},
+		{"tool reported", store.ToolStats{Errors: 3, ToolErrors: 3}, "3", yellow},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := m.errCellParts(tc.tool)
+			if len(parts) != 1 {
+				t.Fatalf("parts = %d, want 1", len(parts))
+			}
+			if parts[0].text != tc.text {
+				t.Fatalf("text = %q, want %q", parts[0].text, tc.text)
+			}
+			if got := parts[0].style.GetForeground(); got != tc.colour {
+				t.Fatalf("colour = %v, want %v", got, tc.colour)
+			}
+		})
+	}
+
+	mixed := m.errCellParts(store.ToolStats{Errors: 5, ProtocolErrors: 2, ToolErrors: 3})
+	if len(mixed) != 3 {
+		t.Fatalf("a tool with both kinds gave %d parts, want 3", len(mixed))
+	}
+	if mixed[0].text != "2" || mixed[0].style.GetForeground() != red {
+		t.Fatalf("the protocol count leads in red, got %q", mixed[0].text)
+	}
+	if mixed[2].text != "3" || mixed[2].style.GetForeground() != yellow {
+		t.Fatalf("the reported count follows in warn, got %q", mixed[2].text)
+	}
+	if cell := m.errCell(store.ToolStats{Errors: 5, ProtocolErrors: 2, ToolErrors: 3}); cell != "2+3" {
+		t.Fatalf("joined cell = %q, want 2+3", cell)
+	} else if lipgloss.Width(cell) > sumErrW {
+		t.Fatalf("the joined cell is %d cells wide, wider than the %d-cell column", lipgloss.Width(cell), sumErrW)
+	}
+}
+
+// TestSummarySortsABrokenServerAboveAToolReportingFailure is the behaviour the
+// split exists for. A search that legitimately finds nothing shared one error
+// count with a server returning -32603, and so sorted above it.
+func TestSummarySortsABrokenServerAboveAToolReportingFailure(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	seq := uint64(0)
+	call := func(tool, response string) {
+		seq++
+		id := fmt.Sprintf("%d", seq)
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ClientToServer, Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":%q}}`, id, tool))})
+		seq++
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ServerToClient, Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,%s}`, id, response))})
+	}
+	for range 3 {
+		call("search", `"result":{"content":[],"isError":true}`)
+	}
+	call("write", `"error":{"code":-32603,"message":"boom"}`)
+
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.summaryContent()
+
+	searchAt := strings.Index(out, "search")
+	writeAt := strings.Index(out, "write")
+	if searchAt < 0 || writeAt < 0 {
+		t.Fatalf("both tools should appear in the summary:\n%s", out)
+	}
+	if writeAt > searchAt {
+		t.Fatalf("the broken server sorts below the tool that answered isError:\n%s", out)
+	}
+	if !strings.Contains(out, "reported by the tool itself with isError") {
+		t.Fatalf("the summary never explains the second colour:\n%s", out)
+	}
+}
+
+// TestFooterNamesRetiredExchanges keeps the parking cap visible where the counts
+// it affects are shown. Unlike frames the memory budget released, a retired
+// operation makes the numbers beside it wrong, so it carries the warn colour.
+func TestFooterNamesRetiredExchanges(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	var seq uint64
+	for i := range 200 {
+		seq++
+		id := fmt.Sprintf("%d", i)
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ClientToServer, Raw: json.RawMessage(fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":"ask"}}`, id))})
+		seq++
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(time.Duration(seq) * time.Millisecond),
+			Direction: proxy.ServerToClient, Raw: json.RawMessage(fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%q,"result":{"resultType":"input_required","requestState":"s-%d","inputRequests":{"k1":{"method":"elicitation/create","params":{}}}}}`, id, i))})
+	}
+
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.view = viewStream
+	if got := m.currentRetiredExchanges(); got == 0 {
+		t.Fatal("the model reports no retired exchanges for a session that hit the cap")
+	}
+	if footer := m.footerCounters(); !strings.Contains(footer, "unlinked") {
+		t.Fatalf("the footer does not name the retired exchanges: %q", footer)
+	}
+
+	clean := New(store.New())
+	clean.view = viewStream
+	if footer := clean.footerCounters(); strings.Contains(footer, "unlinked") {
+		t.Fatalf("a clean session shows the marker anyway: %q", footer)
 	}
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -261,3 +261,74 @@ func TestFooterNamesRetiredExchanges(t *testing.T) {
 		t.Fatalf("a clean session shows the marker anyway: %q", footer)
 	}
 }
+
+// TestElicitOverlayShowsTheLedger covers the panel and the boundary it keeps.
+// The values a user typed stay in the capture; a panel people screenshot must
+// not repeat them.
+func TestElicitOverlayShowsTheLedger(t *testing.T) {
+	const submitted = "hunter2-do-not-repeat-me"
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "s.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq := uint64(0)
+	ingest := func(dir proxy.Direction, off time.Duration, raw string) {
+		seq++
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0.Add(off),
+			Direction: dir, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw)})
+	}
+	seq++
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: seq, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+	ingest(proxy.ClientToServer, time.Second, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"login_legacy"}}`)
+	ingest(proxy.ServerToClient, 2*time.Second, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"creds":{"method":"elicitation/create","params":{"message":"Enter your admin password","requestedSchema":{"type":"object","properties":{"password":{"type":"string"}}}}}}}}`)
+	ingest(proxy.ClientToServer, 5*time.Second, fmt.Sprintf(`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"login_legacy","inputResponses":{"creds":{"action":"decline","content":{"password":%q}}},"requestState":"st"}}`, submitted))
+	ingest(proxy.ClientToServer, 10*time.Second, `{"jsonrpc":"2.0","id":"3","method":"tools/call","params":{"name":"sync"}}`)
+	ingest(proxy.ServerToClient, 11*time.Second, `{"jsonrpc":"2.0","id":"3","result":{"resultType":"input_required","requestState":"st2","inputRequests":{"auth":{"method":"elicitation/create","params":{"mode":"url","url":"https://mcp.example.com/ui/key","message":"api key"}}}}}`)
+
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.elicitContent()
+
+	for _, want := range []string{"login_legacy", "creds", "password", "decline", "Enter your admin password",
+		"https://mcp.example.com/ui/key", "mcp.example.com", "pending"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("the panel does not show %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, submitted) {
+		t.Fatalf("the panel repeats a submitted value:\n%s", out)
+	}
+	if !strings.Contains(out, "submitted values stay in the capture") {
+		t.Fatalf("the panel does not say what it is deliberately not showing:\n%s", out)
+	}
+}
+
+// TestElicitOverlayOnAQuietSessionSaysSo keeps an empty panel from reading as a
+// broken one.
+func TestElicitOverlayOnAQuietSessionSaysSo(t *testing.T) {
+	m := New(store.New())
+	m.streamSessionID = "s1"
+	if out := m.elicitContent(); !strings.Contains(out, "no server asked the user for anything") {
+		t.Fatalf("out = %q", out)
+	}
+}
+
+// TestElicitKeyIsBoundAndDocumented keeps the panel reachable and the help
+// honest, since a panel nobody can find is a panel that does not exist.
+func TestElicitKeyIsBoundAndDocumented(t *testing.T) {
+	m := New(store.New())
+	if !m.keys.Elicit.Enabled() {
+		t.Fatal("the elicitations key is not bound")
+	}
+	if got := m.keys.Elicit.Keys(); len(got) != 1 || got[0] != "l" {
+		t.Fatalf("bound to %v, want l", got)
+	}
+	m.width, m.height = 120, 40
+	if help := m.renderHelp(); !strings.Contains(help, "asked the user for") {
+		t.Fatalf("the help never mentions the panel:\n%s", help)
+	}
+}

--- a/internal/youcom/search.go
+++ b/internal/youcom/search.go
@@ -1,0 +1,104 @@
+package youcom
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client provides web search capabilities via You.com API.
+type Client struct {
+	apiKey string
+	client *http.Client
+}
+
+// NewClient creates a You.com search client. Returns nil if apiKey is empty.
+func NewClient(apiKey string) *Client {
+	if apiKey == "" {
+		return nil
+	}
+	return &Client{
+		apiKey: apiKey,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// SearchResult represents a single search result from You.com.
+type SearchResult struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Snippet string `json:"snippet"`
+}
+
+// SearchResponse represents the response from You.com search API.
+type SearchResponse struct {
+	Results []SearchResult `json:"results"`
+	Query   string         `json:"query"`
+}
+
+// Search performs a web search using You.com API.
+func (c *Client) Search(ctx context.Context, query string) (*SearchResponse, error) {
+	if c == nil {
+		return nil, fmt.Errorf("You.com client not configured")
+	}
+
+	// Use the You.com search API endpoint
+	reqURL := "https://api.you.com/search"
+	params := url.Values{
+		"query": {query},
+		"count": {"5"}, // Limit results for TUI display
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("search API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	result.Query = query
+	return &result, nil
+}
+
+// FormatResults formats search results for TUI display.
+func (sr *SearchResponse) FormatResults() string {
+	if len(sr.Results) == 0 {
+		return fmt.Sprintf("No web search results for: %s", sr.Query)
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Web Search: %s\n\n", sr.Query)
+
+	for i, result := range sr.Results {
+		fmt.Fprintf(&buf, "%d. %s\n", i+1, result.Title)
+		fmt.Fprintf(&buf, "   %s\n", result.URL)
+		if result.Snippet != "" {
+			fmt.Fprintf(&buf, "   %s\n", result.Snippet)
+		}
+		fmt.Fprint(&buf, "\n")
+	}
+
+	return buf.String()
+}

--- a/internal/youcom/search_test.go
+++ b/internal/youcom/search_test.go
@@ -1,0 +1,70 @@
+package youcom
+
+import (
+	"context"
+	"testing"
+)
+
+func TestClientCreation(t *testing.T) {
+	// Test creating client without API key
+	client := NewClient("")
+	if client != nil {
+		t.Error("Expected nil client when no API key provided")
+	}
+
+	// Test creating client with API key
+	client = NewClient("test-key")
+	if client == nil {
+		t.Error("Expected non-nil client when API key provided")
+	}
+}
+
+func TestSearchFormatting(t *testing.T) {
+	resp := &SearchResponse{
+		Query: "test query",
+		Results: []SearchResult{
+			{Title: "Test Result 1", URL: "https://example.com/1", Snippet: "Test snippet 1"},
+			{Title: "Test Result 2", URL: "https://example.com/2", Snippet: "Test snippet 2"},
+		},
+	}
+
+	formatted := resp.FormatResults()
+	
+	if !contains(formatted, "test query") {
+		t.Error("Formatted results should contain the query")
+	}
+	
+	if !contains(formatted, "Test Result 1") {
+		t.Error("Formatted results should contain result titles")
+	}
+	
+	if !contains(formatted, "https://example.com/1") {
+		t.Error("Formatted results should contain URLs")
+	}
+}
+
+func TestSearchEmptyResults(t *testing.T) {
+	resp := &SearchResponse{
+		Query:   "empty query",
+		Results: []SearchResult{},
+	}
+
+	formatted := resp.FormatResults()
+	
+	if !contains(formatted, "No web search results") {
+		t.Error("Should indicate no results found")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || (len(s) > len(substr) && 
+		(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || 
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())))
+}

--- a/internal/youcom/search_test.go
+++ b/internal/youcom/search_test.go
@@ -1,0 +1,69 @@
+package youcom
+
+import (
+	"testing"
+)
+
+func TestClientCreation(t *testing.T) {
+	// Test creating client without API key
+	client := NewClient("")
+	if client != nil {
+		t.Error("Expected nil client when no API key provided")
+	}
+
+	// Test creating client with API key
+	client = NewClient("test-key")
+	if client == nil {
+		t.Error("Expected non-nil client when API key provided")
+	}
+}
+
+func TestSearchFormatting(t *testing.T) {
+	resp := &SearchResponse{
+		Query: "test query",
+		Results: []SearchResult{
+			{Title: "Test Result 1", URL: "https://example.com/1", Snippet: "Test snippet 1"},
+			{Title: "Test Result 2", URL: "https://example.com/2", Snippet: "Test snippet 2"},
+		},
+	}
+
+	formatted := resp.FormatResults()
+
+	if !contains(formatted, "test query") {
+		t.Error("Formatted results should contain the query")
+	}
+
+	if !contains(formatted, "Test Result 1") {
+		t.Error("Formatted results should contain result titles")
+	}
+
+	if !contains(formatted, "https://example.com/1") {
+		t.Error("Formatted results should contain URLs")
+	}
+}
+
+func TestSearchEmptyResults(t *testing.T) {
+	resp := &SearchResponse{
+		Query:   "empty query",
+		Results: []SearchResult{},
+	}
+
+	formatted := resp.FormatResults()
+
+	if !contains(formatted, "No web search results") {
+		t.Error("Should indicate no results found")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || (len(s) > len(substr) &&
+		(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
+			func() bool {
+				for i := 0; i <= len(s)-len(substr); i++ {
+					if s[i:i+len(substr)] == substr {
+						return true
+					}
+				}
+				return false
+			}())))
+}

--- a/npm/mcpsnoop/LICENSE
+++ b/npm/mcpsnoop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kerlenton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/mcpsnoop/README.md
+++ b/npm/mcpsnoop/README.md
@@ -1,0 +1,46 @@
+# mcpsnoop
+
+**Wireshark for MCP.** A transparent proxy that shows every real tool call
+between your AI client and your MCP servers, live in your terminal.
+
+No Go toolchain needed. Put it in front of the server you are writing and watch
+the wire.
+
+```bash
+npx mcpsnoop -- node build/index.js
+```
+
+Everything the client and the server say to each other goes through, unchanged,
+and shows up in the UI. Open it in another terminal.
+
+```bash
+npx mcpsnoop
+```
+
+For a streamable-HTTP server, run it as a reverse proxy instead.
+
+```bash
+npx mcpsnoop http --target http://localhost:3000/mcp --listen :7000
+```
+
+## What this package is
+
+The binary is written in Go. This package ships none of it. The six platform
+packages under the `@mcpsnoop` scope each carry one build, and npm installs the
+single one that matches your machine. So there is no download step at install
+time, nothing to unblock in a proxy, and it works under `--ignore-scripts`.
+
+Supported are macOS, Linux and Windows on x64 and arm64. On anything else,
+install from source.
+
+```bash
+go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@latest
+```
+
+## Documentation
+
+The full README, including what the UI shows, the recording format, and
+`mcpsnoop check` for CI, is at
+[github.com/kerlenton/mcpsnoop](https://github.com/kerlenton/mcpsnoop).
+
+MIT licensed.

--- a/npm/mcpsnoop/bin/mcpsnoop.js
+++ b/npm/mcpsnoop/bin/mcpsnoop.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+'use strict'
+
+// The launcher for the npm distribution of mcpsnoop.
+//
+// mcpsnoop is a Go binary. This package ships none of it: the six platform
+// packages below each carry one build, and npm installs the single one matching
+// the machine through their os and cpu fields. So the download is the ordinary
+// registry one, which works behind a proxy, from a cache, and under
+// --ignore-scripts, where a postinstall that fetched from GitHub would not.
+//
+// What this file does is find that binary and get out of the way. mcpsnoop is a
+// shim that sits in the pipe between an MCP client and its server, so the three
+// things below are not incidental.
+
+const { spawn } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+
+// platformPackage names the package holding this machine's build. The Go side
+// spells the same pair differently, so the mapping is written out rather than
+// derived, and an unknown platform is named rather than guessed at.
+const platformPackage = {
+  'darwin-arm64': '@mcpsnoop/darwin-arm64',
+  'darwin-x64': '@mcpsnoop/darwin-x64',
+  'linux-arm64': '@mcpsnoop/linux-arm64',
+  'linux-x64': '@mcpsnoop/linux-x64',
+  'win32-arm64': '@mcpsnoop/win32-arm64',
+  'win32-x64': '@mcpsnoop/win32-x64',
+}
+
+function resolveBinary() {
+  const key = `${process.platform}-${process.arch}`
+  const pkg = platformPackage[key]
+  if (!pkg) {
+    fail(
+      `mcpsnoop has no prebuilt binary for ${key}.`,
+      '',
+      'The npm package ships builds for ' + Object.keys(platformPackage).sort().join(', ') + '.',
+      'Install from source instead with: go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@latest'
+    )
+  }
+  const file = process.platform === 'win32' ? 'mcpsnoop.exe' : 'mcpsnoop'
+  try {
+    return require.resolve(`${pkg}/bin/${file}`)
+  } catch {
+    // npm skipped or dropped the optional dependency. It does that on purpose
+    // for a platform that does not match, which is handled above, and by
+    // accident when a lockfile was written on another platform or the install
+    // ran with --no-optional. Both are fixed the same way and neither is worth
+    // a stack trace.
+    fail(
+      `mcpsnoop is installed but ${pkg} is not, so there is no binary to run.`,
+      '',
+      'npm leaves out an optional dependency when the install ran with',
+      '--no-optional, and sometimes when a lockfile written on another platform',
+      'is installed as it stands. Clearing what remembers the wrong answer fixes',
+      'it.',
+      '',
+      '  in a project   rm -rf node_modules package-lock.json && npm install',
+      '  through npx    npm cache clean --force',
+      '',
+      'Or install from source with: go install github.com/kerlenton/mcpsnoop/cmd/mcpsnoop@latest'
+    )
+  }
+}
+
+// fail writes to stderr and stops.
+//
+// Synchronously, and not through console.error. On macOS and Windows a pipe is
+// written asynchronously, and process.exit does not wait for that, so a message
+// followed by an exit can simply vanish. An MCP client captures its server's
+// stderr into a log, which is a pipe, and the whole point of these messages is
+// that someone reads them there.
+function fail(...lines) {
+  try {
+    fs.writeSync(2, lines.join('\n') + '\n')
+  } catch {
+    // Nothing useful is left to do about a stderr that will not take bytes.
+  }
+  process.exit(1)
+}
+
+// start runs the binary, putting back an execute bit that the install lost.
+//
+// npm carries the mode through, and the packaging step and its tests keep the
+// bit on. Other clients have not always, and a binary unpacked without it cannot
+// be started at all. Telling someone to chmod a file inside node_modules is a
+// poor answer when the fix is one call.
+//
+// The check has to come first. spawn reports EACCES through the error event
+// rather than by throwing, so by the time it is known the moment to fix it and
+// try again has passed.
+function start(binary) {
+  try {
+    fs.accessSync(binary, fs.constants.X_OK)
+  } catch {
+    try {
+      fs.chmodSync(binary, 0o755)
+    } catch {
+      // Let spawn report it. Its error names the file and the reason, and a
+      // read-only install is not something this can talk its way out of.
+    }
+  }
+  return spawn(binary, process.argv.slice(2), spawnOptions)
+}
+
+const spawnOptions = {
+  // The real file descriptors, not pipes. mcpsnoop stands between a client and a
+  // server on stdin and stdout, and its TUI needs the terminal, so anything that
+  // copies bytes through this process would add buffering to a pipe whose whole
+  // purpose is to be transparent.
+  stdio: 'inherit',
+  windowsHide: true,
+}
+
+const child = start(resolveBinary())
+
+// A client stops its server by signalling it. Without this the signal reaches
+// the wrapper and not the shim, and mcpsnoop's own shutdown never runs.
+//
+// Installing a handler also takes away Node's own default, which is to die. That
+// is what makes the wrapper wait for the shim rather than abandoning it, and it
+// is why the close handler below has to put the default back before raising the
+// signal on itself.
+const forwarded = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']
+for (const signal of forwarded) {
+  process.on(signal, () => {
+    if (child.exitCode === null && child.signalCode === null) child.kill(signal)
+  })
+}
+
+child.on('error', (err) => {
+  // spawn reports most failures here rather than by throwing, EACCES included
+  // when the binary is found but cannot be executed.
+  if (err.code === 'EACCES') {
+    fail(
+      `mcpsnoop cannot run ${err.path || 'its binary'}, which arrived without its execute bit.`,
+      '',
+      'Reinstalling usually restores it:',
+      '',
+      '  npm install mcpsnoop --force'
+    )
+  }
+  fail(`mcpsnoop could not start: ${err.message}`)
+})
+
+child.on('close', (code, signal) => {
+  if (signal) {
+    // Die the way the child died, so a caller reading the wait status sees the
+    // signal rather than an invented exit code.
+    //
+    // The handlers have to come off first. While one is installed the signal is
+    // delivered to it instead of killing the process, so raising it here would
+    // only call that handler again, and the wrapper would sit in its event loop
+    // for ever holding a client that is waiting for it to exit.
+    for (const s of forwarded) process.removeAllListeners(s)
+    process.kill(process.pid, signal)
+    // Only reached if the signal turned out not to be fatal after all.
+    process.exit(128 + (os.constants.signals[signal] || 0))
+    return
+  }
+  // mcpsnoop reports the wrapped server's exit code as its own, and a wrapper
+  // that flattened it would throw away the one number a caller came for.
+  process.exit(code === null ? 1 : code)
+})

--- a/npm/mcpsnoop/package.json
+++ b/npm/mcpsnoop/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "mcpsnoop",
+  "version": "0.0.0",
+  "description": "Wireshark for MCP. A transparent proxy that shows every real tool call between your AI client and your MCP servers, live in your terminal.",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "debugger",
+    "proxy",
+    "jsonrpc",
+    "tui"
+  ],
+  "homepage": "https://github.com/kerlenton/mcpsnoop#readme",
+  "bugs": "https://github.com/kerlenton/mcpsnoop/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kerlenton/mcpsnoop.git",
+    "directory": "npm/mcpsnoop"
+  },
+  "license": "MIT",
+  "author": "kerlenton",
+  "type": "commonjs",
+  "bin": {
+    "mcpsnoop": "bin/mcpsnoop.js"
+  },
+  "files": [
+    "bin/mcpsnoop.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@mcpsnoop/darwin-arm64": "0.0.0",
+    "@mcpsnoop/darwin-x64": "0.0.0",
+    "@mcpsnoop/linux-arm64": "0.0.0",
+    "@mcpsnoop/linux-x64": "0.0.0",
+    "@mcpsnoop/win32-arm64": "0.0.0",
+    "@mcpsnoop/win32-x64": "0.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds optional You.com web search integration to mcpsnoop, enhancing the MCP debugging workflow by allowing developers to search for error explanations, protocol specifications, and tool documentation directly from the TUI.

## What Changed

**Core Integration**:
- Added `internal/youcom/search.go` - You.com API client with search functionality
- Modified TUI to support web search via keyboard shortcut `w` and commands `:search` / `:web`  
- Added search overlay display consistent with other mcpsnoop panels
- Graceful error handling when API key is missing or requests fail

**Configuration Options**:
- Environment variable: `YOUCOM_API_KEY`
- Command flag: `--youcom-api-key`
- Config file: `youcom-api-key = "key"` in `.mcpsnoop.toml`

**User Interface**:
- Press `w` to open search prompt
- Commands `:search <query>` and `:web <query>` 
- Results display in scrollable overlay
- Added to help text and hint bar
- Async search with 10s timeout (doesn't block TUI)

## Why This is Useful

When debugging MCP sessions, developers often need to:
- Research error codes and messages they encounter
- Look up MCP protocol specifications
- Find tool documentation or examples  
- Understand server capabilities and behaviors

This integration eliminates context switching - you can search directly from the debugging session without leaving mcpsnoop.

## Implementation Notes

- **Completely Optional**: mcpsnoop works normally without any API key
- **Clean Architecture**: Search client is dependency-injected, easily testable
- **Consistent UX**: Follows existing mcpsnoop overlay patterns (capabilities, summary, etc.)
- **Privacy-Conscious**: Only search queries sent to You.com, no session data
- **Error Recovery**: Clear messaging when search unavailable or fails

## Validation

- All existing functionality preserved (when no API key provided)
- Search works with valid API key (manual testing with You.com API)
- Configuration loading works (env var, flag, config file precedence)
- Help text updated appropriately
- Code follows existing mcpsnoop patterns and conventions

Resolves: Optional web search capability for enhanced MCP debugging workflow

Tracking: https://github.com/youdotcom-oss/integration-tracking/issues/178