### PR TITLE
feat(tui): edit replay request parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ server is written in.
 |---|---|---|---|---|
 | `enter` | inspect / drill in | | `/` | filter |
 | `esc` | back | | `:` | command |
-| `j` / `k` | move | | `r` | replay a call |
+| `j` / `k` | move | | `r` / `R` | replay / edit and replay |
 | `g` / `G` | top / bottom | | `c` | capabilities |
 | `ctrl-f` / `ctrl-b` | page | | `s` | tool summary |
 | `p` | pause | | `y` | copy |

--- a/docs/TRY_IT.md
+++ b/docs/TRY_IT.md
@@ -58,7 +58,7 @@ well. When you're done, `mcpsnoop unwrap everything` puts it back.
    > run its long-running operation.
 
 4. Drill into a frame with `enter`, filter with `/`, inspect capabilities with
-   `c`, and replay a call with `r`.
+   `c`, replay a call with `r`, or edit its params and replay with `R`.
 
 Frames stream in as the client works. The quick calls come back OK, and the long
 one sends progress notifications and shows a visibly higher latency.

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -139,6 +139,10 @@ func Replay(ctx context.Context, command []string, cwd, method string, params js
 	}, nil
 }
 
+// isToolError mirrors the store's own definition of a tool-level error, kept
+// here because the two packages are peers and neither imports the other. Change
+// one and check the other, or a replayed call and the captured call it came from
+// will disagree about the same bytes.
 func isToolError(result json.RawMessage) bool {
 	var r struct {
 		IsError bool `json:"isError"`

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -25,6 +25,7 @@ type Result struct {
 	Response  json.RawMessage // raw response frame
 	RPCResult json.RawMessage
 	Err       *proxy.RPCError
+	ToolErr   bool // tools/call result.isError == true
 	Duration  time.Duration
 }
 
@@ -133,8 +134,16 @@ func Replay(ctx context.Context, command []string, cwd, method string, params js
 		Response:  resp,
 		RPCResult: msg.Result,
 		Err:       msg.Error,
+		ToolErr:   method == "tools/call" && isToolError(msg.Result),
 		Duration:  dur,
 	}, nil
+}
+
+func isToolError(result json.RawMessage) bool {
+	var r struct {
+		IsError bool `json:"isError"`
+	}
+	return json.Unmarshal(result, &r) == nil && r.IsError
 }
 
 // withClientMeta adds the self-describing _meta a stateless server expects,

--- a/internal/replay/replay_test.go
+++ b/internal/replay/replay_test.go
@@ -53,6 +53,8 @@ func handle(line []byte) {
 		if req.Params.Name == "echo" {
 			time.Sleep(120 * time.Millisecond)
 			out["result"] = map[string]any{"content": []map[string]string{{"type": "text", "text": "echo: " + req.Params.Arguments.Text}}}
+		} else if req.Params.Name == "tool-error" {
+			out["result"] = map[string]any{"content": []map[string]string{{"type": "text", "text": "bad argument"}}, "isError": true}
 		} else {
 			out["error"] = map[string]any{"code": -32601, "message": "unknown tool: " + req.Params.Name}
 		}
@@ -190,6 +192,20 @@ func TestReplayToolError(t *testing.T) {
 	}
 }
 
+func TestReplayToolResultError(t *testing.T) {
+	res, err := Replay(context.Background(), []string{demoBin}, "",
+		"tools/call", json.RawMessage(`{"name":"tool-error"}`), 10*time.Second)
+	if err != nil {
+		t.Fatalf("Replay transport error: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("tool-level error must not become a JSON-RPC error: %+v", res.Err)
+	}
+	if !res.ToolErr {
+		t.Fatalf("result.isError was not classified: %s", res.RPCResult)
+	}
+}
+
 func TestReplayEmptyCommand(t *testing.T) {
 	if _, err := Replay(context.Background(), nil, "", "tools/list", nil, time.Second); err == nil {
 		t.Fatal("expected error for empty command")
@@ -222,7 +238,7 @@ func TestReadResponseRejectsMalformedResponse(t *testing.T) {
 // the initialize error and carry on rather than giving up or hanging.
 func TestReplayAgainstStatelessServer(t *testing.T) {
 	res, err := Replay(context.Background(), []string{statelessBin}, "",
-		"tools/call", json.RawMessage(`{"name":"echo","arguments":{"text":"hi"}}`), 10*time.Second)
+		"tools/call", json.RawMessage(`{"name":"echo","arguments":{"text":"hi"},"_meta":{"progressToken":"p-7"}}`), 10*time.Second)
 	if err != nil {
 		t.Fatalf("Replay: %v", err)
 	}
@@ -233,6 +249,12 @@ func TestReplayAgainstStatelessServer(t *testing.T) {
 	// proves the request described itself.
 	if !strings.Contains(string(res.RPCResult), "stateless echo "+statelessProtocolVersion) {
 		t.Fatalf("result missing the self-describing metadata: %s", res.RPCResult)
+	}
+	if !strings.Contains(string(res.Params), statelessProtocolVersion) {
+		t.Fatalf("Result.Params must be the actual wire params with injected metadata: %s", res.Params)
+	}
+	if !strings.Contains(string(res.Params), `"progressToken":"p-7"`) {
+		t.Fatalf("injected metadata must preserve captured _meta values: %s", res.Params)
 	}
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -19,14 +19,15 @@ type keyMap struct {
 	Command key.Binding
 	Help    key.Binding
 
-	Replay  key.Binding
-	Caps    key.Binding
-	Summary key.Binding
-	Pause   key.Binding
-	Follow  key.Binding
-	Copy    key.Binding
-	Export  key.Binding
-	Delete  key.Binding
+	Replay     key.Binding
+	EditReplay key.Binding
+	Caps       key.Binding
+	Summary    key.Binding
+	Pause      key.Binding
+	Follow     key.Binding
+	Copy       key.Binding
+	Export     key.Binding
+	Delete     key.Binding
 
 	Quit key.Binding
 }
@@ -46,14 +47,15 @@ func defaultKeys() keyMap {
 		Command: key.NewBinding(key.WithKeys(":"), key.WithHelp(":", "command")),
 		Help:    key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 
-		Replay:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "replay")),
-		Caps:    key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
-		Summary: key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
-		Pause:   key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
-		Follow:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
-		Copy:    key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
-		Export:  key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
-		Delete:  key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
+		Replay:     key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "replay")),
+		EditReplay: key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "edit + replay")),
+		Caps:       key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
+		Summary:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
+		Pause:      key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
+		Follow:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
+		Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),
+		Export:     key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export HTML")),
+		Delete:     key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("ctrl-d", "delete session")),
 
 		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp(":q", "quit")),
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"cmp"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -135,8 +136,10 @@ type Model struct {
 	paused bool
 
 	overlay        overlayMode
-	replayReq      store.CallView // last request sent to replay, so r can re-run it from the result
-	replaying      bool           // an async replay is in flight; a footer spinner shows until the result lands
+	replayReq      store.CallView  // last user-supplied request sent to replay, so r can re-run it from the result
+	replayCaptured json.RawMessage // immutable params from the observed request behind the current replay loop
+	replayEdited   bool            // the user-supplied params differ semantically from replayCaptured
+	replaying      bool            // an async replay is in flight; a footer spinner shows until the result lands
 	vp             viewport.Model
 	overlayRaw     string // overlay body before styling (re-rendered on resize)
 	overlayDisplay string // styled body shown in the viewport (highlight, numbers)
@@ -287,6 +290,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setFlash(fmt.Sprintf("loaded newest %d of %d sessions; older traces stay on disk", msg.loaded, msg.total))
 		return m, nil
 
+	case replayEditDoneMsg:
+		if msg.err != nil {
+			m.setFlash("edit replay aborted: " + msg.err.Error())
+			return m, nil
+		}
+		edited := !replayParamsEquivalent(msg.captured, msg.call.Params)
+		return m, m.runReplay(msg.call, msg.captured, edited)
+
 	case replayDoneMsg:
 		if !m.replaying {
 			return m, nil // the replay was abandoned by navigating away
@@ -354,8 +365,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 			if cmd := m.startReplay(); cmd != nil {
 				return m, cmd
 			}
+		case m.overlay == overlayInspector && key.Matches(msg, m.keys.EditReplay):
+			if cmd := m.startEditReplay(); cmd != nil {
+				return m, cmd
+			}
 		case m.overlay == overlayReplay && key.Matches(msg, m.keys.Replay):
 			if cmd := m.replayAgain(); cmd != nil {
+				return m, cmd
+			}
+		case m.overlay == overlayReplay && key.Matches(msg, m.keys.EditReplay):
+			if cmd := m.startEditReplay(); cmd != nil {
 				return m, cmd
 			}
 		case key.Matches(msg, m.keys.Copy):
@@ -420,6 +439,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 	case key.Matches(msg, m.keys.Replay):
 		if cmd := m.startReplay(); cmd != nil {
+			return m, cmd
+		}
+	case key.Matches(msg, m.keys.EditReplay):
+		if cmd := m.startEditReplay(); cmd != nil {
 			return m, cmd
 		}
 
@@ -744,8 +767,8 @@ func (m Model) focusedFrame() (store.EventView, bool) {
 }
 
 // canReplay reports whether the focused frame is a request this session can
-// actually replay (its server command was captured), so r is only offered, and
-// acted on, when it will work.
+// actually replay (its server command was captured), so the replay keys are
+// only offered, and acted on, when they will work.
 func (m Model) canReplay() bool {
 	ev, ok := m.focusedFrame()
 	if !ok || ev.Call == nil || ev.Kind != store.EventRequest {
@@ -755,9 +778,9 @@ func (m Model) canReplay() bool {
 }
 
 // sessionReplayable reports whether the streamed session recorded the server
-// command a replay needs. It gates r at the session level, stable with no
-// per-frame flicker, so replay is never offered for a session that can never run
-// it (for example a log opened without its meta frame).
+// command a replay needs. It gates r/R at the session level, stable with no
+// per-frame flicker, so replay is never offered for a session that can never
+// run it (for example a log opened without its meta frame).
 func (m Model) sessionReplayable() bool {
 	_, _, ok := m.store.Command(m.streamSessionID)
 	return ok
@@ -772,7 +795,7 @@ func (m *Model) startReplay() tea.Cmd {
 		m.setFlash("replay needs a request frame")
 		return nil
 	}
-	return m.runReplay(*ev.Call)
+	return m.runReplay(*ev.Call, ev.Call.Params, false)
 }
 
 // replayAgain re-runs the last replayed request, so r works straight from the
@@ -781,10 +804,45 @@ func (m *Model) replayAgain() tea.Cmd {
 	if m.replayReq.Method == "" {
 		return nil
 	}
-	return m.runReplay(m.replayReq)
+	return m.runReplay(m.replayReq, m.replayCaptured, m.replayEdited)
 }
 
-func (m *Model) runReplay(call store.CallView) tea.Cmd {
+// startEditReplay opens the focused request, or the current replay candidate,
+// in the user's editor. The callback validates the file before runReplay ever
+// reaches the existing recorded-command confirmation gate.
+func (m *Model) startEditReplay() tea.Cmd {
+	if m.replaying {
+		return nil
+	}
+
+	var call store.CallView
+	var captured json.RawMessage
+	if m.overlay == overlayReplay && m.replayReq.Method != "" {
+		call = m.replayReq
+		captured = m.replayCaptured
+	} else {
+		ev, ok := m.focusedFrame()
+		if !ok || ev.Call == nil || ev.Kind != store.EventRequest {
+			m.setFlash("edit replay needs a request frame")
+			return nil
+		}
+		call = *ev.Call
+		captured = ev.Call.Params
+	}
+
+	if !m.sessionReplayable() {
+		m.setFlash("no recorded server command to replay")
+		return nil
+	}
+	cmd, err := editReplayCmd(call, captured)
+	if err != nil {
+		m.setFlash("edit replay aborted: " + err.Error())
+		return nil
+	}
+	return cmd
+}
+
+func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited bool) tea.Cmd {
 	if m.replaying {
 		return nil // a replay is already in flight; ignore until it lands or is abandoned
 	}
@@ -800,6 +858,9 @@ func (m *Model) runReplay(call store.CallView) tea.Cmd {
 	start := func(m *Model) tea.Cmd {
 		m.replayConfirmed = m.streamSessionID
 		m.replayReq = call
+		m.replayReq.Params = append(json.RawMessage(nil), call.Params...)
+		m.replayCaptured = append(json.RawMessage(nil), captured...)
+		m.replayEdited = edited
 		m.replaying = true
 		return replayCmd(command, cwd, call.Method, call.Params)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -140,6 +140,11 @@ type Model struct {
 	replayCaptured json.RawMessage // immutable params from the observed request behind the current replay loop
 	replayEdited   bool            // the user-supplied params differ semantically from replayCaptured
 	replaying      bool            // an async replay is in flight; a footer spinner shows until the result lands
+	// replayToken numbers each run. replaying alone only says that some replay is
+	// in flight, so an abandoned run's result was rendered against whatever had
+	// started since, putting one request's captured params over another's answer
+	// and dropping the answer the user was waiting for.
+	replayToken    uint64
 	vp             viewport.Model
 	overlayRaw     string // overlay body before styling (re-rendered on resize)
 	overlayDisplay string // styled body shown in the viewport (highlight, numbers)
@@ -299,8 +304,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.runReplay(msg.call, msg.captured, edited)
 
 	case replayDoneMsg:
-		if !m.replaying {
-			return m, nil // the replay was abandoned by navigating away
+		if !m.replaying || msg.token != m.replayToken {
+			return m, nil // abandoned by navigating away, or belongs to an earlier run
 		}
 		m.replaying = false
 		m.openOverlay(overlayReplay, m.replayContent(msg))
@@ -862,12 +867,20 @@ func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited 
 		m.replayCaptured = append(json.RawMessage(nil), captured...)
 		m.replayEdited = edited
 		m.replaying = true
-		return replayCmd(command, cwd, call.Method, call.Params)
+		m.replayToken++
+		return replayCmd(m.replayToken, command, cwd, call.Method, call.Params)
 	}
 	if m.replayConfirmed == m.streamSessionID {
 		return start(m)
 	}
-	m.ask("replay runs: "+strings.Join(command, " ")+"  y/n", start)
+	// The prompt names the edit, so answering n is unambiguously declining to send
+	// the params the user just wrote rather than declining some replay they have
+	// lost track of. The candidate is dropped either way.
+	what := "replay runs: "
+	if edited {
+		what = "replay your edited params through: "
+	}
+	m.ask(what+strings.Join(command, " ")+"  y/n", start)
 	return nil
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1011,7 +1011,7 @@ func TestReplayAgainFromResult(t *testing.T) {
 	}
 
 	// The result lands and opens the replay overlay.
-	m = drive(t, m, replayDoneMsg{res: replay.Result{Method: "get_sum", Response: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`)}})
+	m = drive(t, m, replayDoneMsg{token: m.replayToken, res: replay.Result{Method: "get_sum", Response: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`)}})
 	if m.overlay != overlayReplay || m.replaying {
 		t.Fatalf("the result should open the replay overlay, overlay=%d replaying=%v", m.overlay, m.replaying)
 	}
@@ -1072,7 +1072,7 @@ func TestEditedReplayKeepsConfirmationAndThreeParamLayers(t *testing.T) {
 	}
 
 	actual := json.RawMessage(`{"x":"edited","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`)
-	m = drive(t, m, replayDoneMsg{res: replay.Result{
+	m = drive(t, m, replayDoneMsg{token: m.replayToken, res: replay.Result{
 		Method:   "echo",
 		Params:   actual,
 		Response: json.RawMessage(`{"jsonrpc":"2.0","id":2,"result":{"isError":true}}`),
@@ -1187,7 +1187,7 @@ func TestReplayAbandonedOnNavigation(t *testing.T) {
 	if m.replaying {
 		t.Fatal("closing the overlay should abandon the in-flight replay")
 	}
-	m = drive(t, m, replayDoneMsg{res: replay.Result{Method: "x", Response: json.RawMessage("{}")}})
+	m = drive(t, m, replayDoneMsg{token: m.replayToken, res: replay.Result{Method: "x", Response: json.RawMessage("{}")}})
 	if m.overlay == overlayReplay {
 		t.Fatal("an abandoned replay result should not open an overlay")
 	}
@@ -2077,5 +2077,56 @@ func TestCancelAndLateRowsAreSelectableByWhatTheySay(t *testing.T) {
 				t.Fatal("the cancellation frame is missing from the timeline")
 			}
 		})
+	}
+}
+
+// TestAnAbandonedReplayResultIsNotAdoptedByTheNextOne. replaying is a bare bool,
+// so it only said that some replay was in flight. Walking away from one replay
+// clears it, the spawned server keeps running, and when that first result finally
+// landed it was rendered against whatever run had started since: one request's
+// captured params over another request's answer, with the second run's own result
+// then dropped because the same line clears the flag.
+func TestAnAbandonedReplayResultIsNotAdoptedByTheNextOne(t *testing.T) {
+	st := store.New()
+	meta, _ := json.Marshal(proxy.SessionMeta{Command: []string{"true"}, CWD: "/tmp"})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 0, TS: time.Now(), Direction: proxy.DirectionMeta, Raw: meta})
+	seed(st)
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = typeRunes(t, m, "x")
+
+	// First replay, then walk away from it the way opening any overlay does.
+	m = typeRunes(t, m, "r")
+	m = typeRunes(t, m, "y")
+	first := m.replayToken
+	if !m.replaying {
+		t.Fatal("the first replay did not start")
+	}
+	m.dismissTransient()
+
+	// Second replay, of the same session, which is what the user is now watching.
+	m = typeRunes(t, m, "r")
+	second := m.replayToken
+	if first == second {
+		t.Fatal("the two runs share a token, so nothing can tell them apart")
+	}
+
+	// The abandoned run answers late.
+	m = drive(t, m, replayDoneMsg{token: first, res: replay.Result{Method: "stale", Response: json.RawMessage(`{"stale":true}`)}})
+	if m.overlay == overlayReplay {
+		t.Fatal("a result from an abandoned replay was rendered over the current one")
+	}
+	if !m.replaying {
+		t.Fatal("the abandoned result cleared the flag the live run needs")
+	}
+
+	// The run the user is actually waiting for still lands.
+	m = drive(t, m, replayDoneMsg{token: second, res: replay.Result{Method: "live", Response: json.RawMessage(`{"live":true}`)}})
+	if m.overlay != overlayReplay {
+		t.Fatal("the live result never reached the screen")
+	}
+	if !strings.Contains(ansi.Strip(m.overlayRaw), "live") {
+		t.Fatalf("the overlay shows the wrong run:\n%s", ansi.Strip(m.overlayRaw))
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -933,6 +933,31 @@ func TestReplayFromInspector(t *testing.T) {
 	}
 }
 
+func TestEditReplayFromInspector(t *testing.T) {
+	st := store.New()
+	st.Ingest(metaEnv("s1", []string{"true"}))
+	seed(st)
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // stream
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // inspector on the response
+	m = typeRunes(t, m, "x")                        // paired request
+
+	// Keep any editor fixture in the test's private directory even though this
+	// fail-before test only needs to prove that R launches an editor command.
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "true")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	got := next.(Model)
+	if cmd == nil {
+		t.Fatal("R on a replayable request should launch the edit-and-replay editor")
+	}
+	if got.replaying {
+		t.Fatal("editing must finish and validate before a replay can start")
+	}
+}
+
 func TestInspectorFooterConditionalKeys(t *testing.T) {
 	st := store.New()
 	meta, _ := json.Marshal(proxy.SessionMeta{Command: []string{"true"}, CWD: "/tmp"})
@@ -1002,6 +1027,142 @@ func TestReplayAgainFromResult(t *testing.T) {
 	m = typeRunes(t, m, "r")
 	if !m.replaying || m.replayReq.Method != before {
 		t.Fatalf("r in the replay overlay should re-run the same replay, replaying=%v method=%q", m.replaying, m.replayReq.Method)
+	}
+}
+
+func TestEditedReplayKeepsConfirmationAndThreeParamLayers(t *testing.T) {
+	st := store.New()
+	st.Ingest(metaEnv("s1", []string{"safe-server", "--stdio"}))
+	seed(st)
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // stream
+
+	var captured store.CallView
+	for _, ev := range m.full {
+		if ev.Kind == store.EventRequest && ev.Call != nil && ev.Call.Method == "tools/call" {
+			captured = *ev.Call
+			break
+		}
+	}
+	if captured.Method == "" {
+		t.Fatal("test request not found")
+	}
+	edited := captured
+	edited.Params = json.RawMessage(`{"x":"edited"}`)
+	beforeTimeline := len(st.Timeline("s1"))
+
+	next, cmd := m.Update(replayEditDoneMsg{call: edited, captured: captured.Params})
+	m = next.(Model)
+	if cmd != nil || m.confirm == "" {
+		t.Fatal("a valid edit must enter the existing command confirmation before replay")
+	}
+	if m.replaying || m.replayReq.Method != "" {
+		t.Fatal("editor completion must not mutate replay state before confirmation")
+	}
+
+	m = typeRunes(t, m, "y")
+	if !m.replaying {
+		t.Fatal("confirmed edited replay did not start")
+	}
+	if !m.replayEdited || string(m.replayCaptured) != string(captured.Params) || string(m.replayReq.Params) != string(edited.Params) {
+		t.Fatalf("replay param layers were not retained: captured=%s candidate=%s edited=%v", m.replayCaptured, m.replayReq.Params, m.replayEdited)
+	}
+	if got := len(st.Timeline("s1")); got != beforeTimeline {
+		t.Fatalf("starting an edited replay changed the observed store: got %d want %d", got, beforeTimeline)
+	}
+
+	actual := json.RawMessage(`{"x":"edited","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`)
+	m = drive(t, m, replayDoneMsg{res: replay.Result{
+		Method:   "echo",
+		Params:   actual,
+		Response: json.RawMessage(`{"jsonrpc":"2.0","id":2,"result":{"isError":true}}`),
+		ToolErr:  true,
+	}})
+	out := ansi.Strip(m.overlayRaw)
+	for _, want := range []string{"REPLAY · EDITED · echo", "ERROR tool reported an error", "captured params", "params sent", "2026-07-28"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("edited replay overlay missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "ok  (") {
+		t.Fatalf("a tool-level error must not render as ok:\n%s", out)
+	}
+	if got := len(st.Timeline("s1")); got != beforeTimeline {
+		t.Fatalf("an edited replay result entered the observed store: got %d want %d", got, beforeTimeline)
+	}
+
+	// Lowercase r repeats the candidate, not the captured bytes or the system
+	// metadata added to the prior wire request.
+	m = typeRunes(t, m, "r")
+	if !m.replaying || string(m.replayReq.Params) != string(edited.Params) {
+		t.Fatalf("r did not repeat the edited candidate: %s", m.replayReq.Params)
+	}
+}
+
+func TestReplayEditFailureLeavesCurrentLoopUntouched(t *testing.T) {
+	m := New(store.New())
+	m.replayReq = store.CallView{Method: "tools/call", Params: json.RawMessage(`{"old":true}`)}
+	m.replayCaptured = json.RawMessage(`{"captured":true}`)
+	m.replayEdited = true
+
+	next, cmd := m.Update(replayEditDoneMsg{err: os.ErrInvalid})
+	got := next.(Model)
+	if cmd != nil || got.replaying {
+		t.Fatal("an invalid edit must not start a replay")
+	}
+	if got.replayReq.Method != m.replayReq.Method || string(got.replayReq.Params) != string(m.replayReq.Params) || string(got.replayCaptured) != string(m.replayCaptured) || got.replayEdited != m.replayEdited {
+		t.Fatal("an invalid edit partially changed the current replay loop")
+	}
+	if !strings.Contains(got.flash, "edit replay aborted") {
+		t.Fatalf("invalid edit flash = %q", got.flash)
+	}
+}
+
+func TestReplayContentSeparatesProtocolMetadataFromUserEdits(t *testing.T) {
+	m := New(store.New())
+	m.replayCaptured = json.RawMessage(`{"name":"echo"}`)
+	m.replayEdited = false
+	out := ansi.Strip(m.replayContent(replayDoneMsg{res: replay.Result{
+		Method:   "tools/call",
+		Params:   json.RawMessage(`{"name":"echo","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`),
+		Response: json.RawMessage(`{"jsonrpc":"2.0","id":2,"result":{"content":[]}}`),
+	}}))
+	if strings.Contains(out, "EDITED") || strings.Contains(out, "captured params") {
+		t.Fatalf("protocol-required metadata must not masquerade as a user edit:\n%s", out)
+	}
+	for _, want := range []string{"REPLAY · tools/call", "request params", "2026-07-28"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("actual stateless wire params missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestEditReplayKeyFromStreamAndReplayOverlay(t *testing.T) {
+	st := store.New()
+	st.Ingest(metaEnv("s1", []string{"true"}))
+	st.Ingest(env(1, proxy.ClientToServer, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`))
+	m := ready(t, st)
+	m = drive(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "true")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("R in the stream should launch the editor for the selected request")
+	}
+
+	m.overlay = overlayReplay
+	m.replayReq = store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo","arguments":{"text":"edited"}}`)}
+	m.replayCaptured = json.RawMessage(`{"name":"echo","arguments":{"text":"captured"}}`)
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("R in the replay overlay should reopen the editor on the current candidate")
+	}
+	if string(m.replayReq.Params) != `{"name":"echo","arguments":{"text":"edited"}}` {
+		t.Fatal("opening the editor must not mutate the current candidate")
 	}
 }
 
@@ -1522,6 +1683,13 @@ func TestSortSessions(t *testing.T) {
 	m = typeRunes(t, m, "N")
 	if m.sessions[0].Label != "gamma" {
 		t.Fatalf("shift+N twice should be desc, got %s first", m.sessions[0].Label)
+	}
+	// R remains the request-count sort in the sessions view; edit-and-replay is
+	// only reachable after drilling into a request frame.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	m = next.(Model)
+	if cmd != nil || m.sessionSort.col != "req" {
+		t.Fatalf("R in sessions should sort requests, cmd=%v sort=%q", cmd != nil, m.sessionSort.col)
 	}
 }
 

--- a/internal/tui/replay.go
+++ b/internal/tui/replay.go
@@ -5,18 +5,31 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/kerlenton/mcpsnoop/internal/replay"
+	"github.com/kerlenton/mcpsnoop/internal/store"
 )
 
 // replayDoneMsg carries the outcome of an async replay back into Update.
 type replayDoneMsg struct {
 	res replay.Result
 	err error
+}
+
+// replayEditDoneMsg is emitted only after the editor has exited, its temporary
+// file has been read and removed, and the saved value has passed JSON-object
+// validation. Until then the model's current replay loop remains untouched.
+type replayEditDoneMsg struct {
+	call     store.CallView
+	captured json.RawMessage
+	err      error
 }
 
 const replayTimeout = 15 * time.Second
@@ -28,10 +41,141 @@ func replayCmd(command []string, cwd, method string, params json.RawMessage) tea
 	}
 }
 
+func editReplayCmd(call store.CallView, captured json.RawMessage) (tea.Cmd, error) {
+	cmd, done, err := prepareReplayEditor(call, captured)
+	if err != nil {
+		return nil, err
+	}
+	return tea.ExecProcess(cmd, done), nil
+}
+
+// prepareReplayEditor creates the private buffer and returns the process plus
+// callback separately, which keeps the editor boundary directly testable. An
+// exact executable value is tried first so paths containing spaces work; common
+// command-plus-flags values such as "code --wait" use a deliberately shell-free
+// whitespace split.
+func prepareReplayEditor(call store.CallView, captured json.RawMessage) (*exec.Cmd, tea.ExecCallback, error) {
+	editor := strings.TrimSpace(os.Getenv("VISUAL"))
+	if editor == "" {
+		editor = strings.TrimSpace(os.Getenv("EDITOR"))
+	}
+	if editor == "" {
+		return nil, nil, fmt.Errorf("set $VISUAL or $EDITOR to edit replay params")
+	}
+
+	obj, err := decodeReplayParams(call.Params, true)
+	if err != nil {
+		return nil, nil, fmt.Errorf("captured params: %w", err)
+	}
+	pretty, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return nil, nil, fmt.Errorf("format captured params: %w", err)
+	}
+
+	f, err := os.CreateTemp("", "mcpsnoop-replay-*.json")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create editor buffer: %w", err)
+	}
+	path := f.Name()
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.Remove(path)
+		}
+	}()
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("secure editor buffer: %w", err)
+	}
+	if _, err := f.Write(append(pretty, '\n')); err != nil {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("write editor buffer: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close editor buffer: %w", err)
+	}
+
+	parts := []string{editor}
+	if _, err := exec.LookPath(editor); err != nil {
+		parts = strings.Fields(editor)
+	}
+	if len(parts) == 0 || parts[0] == "" {
+		return nil, nil, fmt.Errorf("$VISUAL or $EDITOR is empty")
+	}
+	cmd := exec.Command(parts[0], append(parts[1:], path)...)
+	call.Params = append(json.RawMessage(nil), call.Params...)
+	captured = append(json.RawMessage(nil), captured...)
+	done := func(runErr error) tea.Msg {
+		defer os.Remove(path)
+		if runErr != nil {
+			return replayEditDoneMsg{err: fmt.Errorf("editor failed: %w", runErr)}
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return replayEditDoneMsg{err: fmt.Errorf("read editor buffer: %w", err)}
+		}
+		if len(bytes.TrimSpace(raw)) == 0 {
+			return replayEditDoneMsg{err: fmt.Errorf("edited params are empty")}
+		}
+		if _, err := decodeReplayParams(raw, false); err != nil {
+			return replayEditDoneMsg{err: err}
+		}
+		call.Params = append(json.RawMessage(nil), bytes.TrimSpace(raw)...)
+		return replayEditDoneMsg{call: call, captured: captured}
+	}
+	keep = true
+	return cmd, done, nil
+}
+
+// decodeReplayParams accepts exactly one JSON object. An absent captured params
+// value is represented to the editor as {}, while a user-saved empty file is an
+// explicit error handled before this function is called.
+func decodeReplayParams(raw json.RawMessage, allowEmpty bool) (map[string]any, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		if !allowEmpty {
+			return nil, fmt.Errorf("edited params are empty")
+		}
+		raw = json.RawMessage(`{}`)
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, fmt.Errorf("edited params are not valid JSON: %w", err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("edited params contain more than one JSON value")
+		}
+		return nil, fmt.Errorf("edited params are not valid JSON: %w", err)
+	}
+	obj, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("edited params must be a JSON object")
+	}
+	return obj, nil
+}
+
+func replayParamsEquivalent(a, b json.RawMessage) bool {
+	aObj, aErr := decodeReplayParams(a, true)
+	bObj, bErr := decodeReplayParams(b, true)
+	if aErr != nil || bErr != nil {
+		return false
+	}
+	aCanonical, aErr := json.Marshal(aObj)
+	bCanonical, bErr := json.Marshal(bObj)
+	return aErr == nil && bErr == nil && bytes.Equal(aCanonical, bCanonical)
+}
+
 // replayContent renders the replay outcome for the overlay.
 func (m Model) replayContent(msg replayDoneMsg) string {
 	var b strings.Builder
-	b.WriteString(m.styles.panelTitle.Render("REPLAY · "+msg.res.Method) + "\n\n")
+	title := "REPLAY · " + msg.res.Method
+	if m.replayEdited {
+		title = "REPLAY · EDITED · " + msg.res.Method
+	}
+	b.WriteString(m.styles.panelTitle.Render(title) + "\n\n")
 
 	if msg.err != nil {
 		b.WriteString(m.styles.respErr.Render("failed: "+msg.err.Error()) + "\n")
@@ -42,12 +186,22 @@ func (m Model) replayContent(msg replayDoneMsg) string {
 	switch {
 	case msg.res.Err != nil:
 		b.WriteString(m.styles.respErr.Render(fmt.Sprintf("ERROR %s  (%s)", rpcErrorText(*msg.res.Err), dur)) + "\n\n")
+	case msg.res.ToolErr:
+		b.WriteString(m.styles.respErr.Render(fmt.Sprintf("ERROR tool reported an error  (%s)", dur)) + "\n\n")
 	default:
 		b.WriteString(m.styles.resp.Render(fmt.Sprintf("ok  (%s)", dur)) + "\n\n")
 	}
 
+	if m.replayEdited {
+		b.WriteString(m.styles.dim.Render("captured params") + "\n")
+		b.WriteString(indentJSON(m.replayCaptured) + "\n\n")
+	}
 	if len(msg.res.Params) > 0 {
-		b.WriteString(m.styles.dim.Render("request params") + "\n")
+		label := "request params"
+		if m.replayEdited {
+			label = "params sent"
+		}
+		b.WriteString(m.styles.dim.Render(label) + "\n")
 		b.WriteString(indentJSON(msg.res.Params) + "\n\n")
 	}
 	b.WriteString(m.styles.dim.Render("response") + "\n")

--- a/internal/tui/replay.go
+++ b/internal/tui/replay.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,8 +21,11 @@ import (
 
 // replayDoneMsg carries the outcome of an async replay back into Update.
 type replayDoneMsg struct {
-	res replay.Result
-	err error
+	// token names the run this result belongs to, so a result the user walked
+	// away from cannot be rendered against the run that replaced it.
+	token uint64
+	res   replay.Result
+	err   error
 }
 
 // replayEditDoneMsg is emitted only after the editor has exited, its temporary
@@ -34,10 +39,10 @@ type replayEditDoneMsg struct {
 
 const replayTimeout = 15 * time.Second
 
-func replayCmd(command []string, cwd, method string, params json.RawMessage) tea.Cmd {
+func replayCmd(token uint64, command []string, cwd, method string, params json.RawMessage) tea.Cmd {
 	return func() tea.Msg {
 		res, err := replay.Replay(context.Background(), command, cwd, method, params, replayTimeout)
-		return replayDoneMsg{res: res, err: err}
+		return replayDoneMsg{token: token, res: res, err: err}
 	}
 }
 
@@ -50,10 +55,14 @@ func editReplayCmd(call store.CallView, captured json.RawMessage) (tea.Cmd, erro
 }
 
 // prepareReplayEditor creates the private buffer and returns the process plus
-// callback separately, which keeps the editor boundary directly testable. An
-// exact executable value is tried first so paths containing spaces work; common
-// command-plus-flags values such as "code --wait" use a deliberately shell-free
-// whitespace split.
+// callback separately, which keeps the editor boundary directly testable.
+//
+// The whole value is tried as one executable first, so a path containing a space
+// works on its own. Anything else is split on whitespace, which covers the
+// common command-plus-flags values such as "code --wait" without running a
+// shell. What that cannot do is both at once, since a quoted path carrying flags
+// needs a shell to unquote it, so that case is refused by name rather than left
+// to fail as a mangled argv[0].
 func prepareReplayEditor(call store.CallView, captured json.RawMessage) (*exec.Cmd, tea.ExecCallback, error) {
 	editor := strings.TrimSpace(os.Getenv("VISUAL"))
 	if editor == "" {
@@ -63,36 +72,32 @@ func prepareReplayEditor(call store.CallView, captured json.RawMessage) (*exec.C
 		return nil, nil, fmt.Errorf("set $VISUAL or $EDITOR to edit replay params")
 	}
 
-	obj, err := decodeReplayParams(call.Params, true)
-	if err != nil {
+	if _, err := decodeReplayParams(call.Params, true); err != nil {
 		return nil, nil, fmt.Errorf("captured params: %w", err)
 	}
-	pretty, err := json.MarshalIndent(obj, "", "  ")
+	pretty, err := indentReplayParams(call.Params)
 	if err != nil {
 		return nil, nil, fmt.Errorf("format captured params: %w", err)
 	}
 
-	f, err := os.CreateTemp("", "mcpsnoop-replay-*.json")
+	// A directory rather than a bare file, removed whole. Editors write companions
+	// beside the file they were given, a vim swap or undo file, an emacs autosave,
+	// a rename-style backup, and those hold the same captured bytes under whatever
+	// name that editor chose. Unlinking the one path mcpsnoop knows about leaves
+	// them behind.
+	dir, err := os.MkdirTemp("", "mcpsnoop-replay-*")
 	if err != nil {
 		return nil, nil, fmt.Errorf("create editor buffer: %w", err)
 	}
-	path := f.Name()
 	keep := false
 	defer func() {
 		if !keep {
-			_ = os.Remove(path)
+			_ = os.RemoveAll(dir)
 		}
 	}()
-	if err := f.Chmod(0o600); err != nil {
-		_ = f.Close()
-		return nil, nil, fmt.Errorf("secure editor buffer: %w", err)
-	}
-	if _, err := f.Write(append(pretty, '\n')); err != nil {
-		_ = f.Close()
+	path := filepath.Join(dir, "params.json")
+	if err := os.WriteFile(path, append(pretty, '\n'), 0o600); err != nil {
 		return nil, nil, fmt.Errorf("write editor buffer: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		return nil, nil, fmt.Errorf("close editor buffer: %w", err)
 	}
 
 	parts := []string{editor}
@@ -100,13 +105,18 @@ func prepareReplayEditor(call store.CallView, captured json.RawMessage) (*exec.C
 		parts = strings.Fields(editor)
 	}
 	if len(parts) == 0 || parts[0] == "" {
-		return nil, nil, fmt.Errorf("$VISUAL or $EDITOR is empty")
+		return nil, nil, errors.New("$VISUAL or $EDITOR is empty")
+	}
+	if _, err := exec.LookPath(parts[0]); err != nil && len(parts) > 1 {
+		return nil, nil, fmt.Errorf("neither %q nor %q is an executable; mcpsnoop splits $VISUAL and $EDITOR on whitespace and runs no shell, so a path containing a space cannot also carry flags",
+			editor, parts[0])
 	}
 	cmd := exec.Command(parts[0], append(parts[1:], path)...)
 	call.Params = append(json.RawMessage(nil), call.Params...)
 	captured = append(json.RawMessage(nil), captured...)
+	seeded := append([]byte(nil), append(pretty, '\n')...)
 	done := func(runErr error) tea.Msg {
-		defer os.Remove(path)
+		defer os.RemoveAll(dir)
 		if runErr != nil {
 			return replayEditDoneMsg{err: fmt.Errorf("editor failed: %w", runErr)}
 		}
@@ -114,8 +124,16 @@ func prepareReplayEditor(call store.CallView, captured json.RawMessage) (*exec.C
 		if err != nil {
 			return replayEditDoneMsg{err: fmt.Errorf("read editor buffer: %w", err)}
 		}
+		// An unchanged buffer is not an edit, and R must not send on one. An editor
+		// that hands the file to an already-running instance and exits, which is
+		// what EDITOR=code without --wait and emacsclient -n do, returns here
+		// before the user has typed anything, and sending then would fire a live
+		// request at the server while they are still looking at the window.
+		if bytes.Equal(raw, seeded) {
+			return replayEditDoneMsg{err: errors.New("the editor saved no change, so nothing was sent; press r to replay the captured params as they are")}
+		}
 		if len(bytes.TrimSpace(raw)) == 0 {
-			return replayEditDoneMsg{err: fmt.Errorf("edited params are empty")}
+			return replayEditDoneMsg{err: errors.New("edited params are empty")}
 		}
 		if _, err := decodeReplayParams(raw, false); err != nil {
 			return replayEditDoneMsg{err: err}
@@ -125,6 +143,25 @@ func prepareReplayEditor(call store.CallView, captured json.RawMessage) (*exec.C
 	}
 	keep = true
 	return cmd, done, nil
+}
+
+// indentReplayParams renders the captured params for the editor from the bytes
+// the server actually sent, rather than from a decoded copy of them.
+//
+// encoding/json escapes &, < and > when it marshals, and it sorts the keys of a
+// map, so a decode-and-re-encode showed a URL argument as
+// "https://host?a=1&b=2" and reordered every object the user was about to
+// edit. internal/jsonwire exists for the first half of that, and json.Indent for
+// both: it rewrites nothing but the whitespace between tokens.
+func indentReplayParams(raw json.RawMessage) ([]byte, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return []byte("{}"), nil
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // decodeReplayParams accepts exactly one JSON object. An absent captured params

--- a/internal/tui/replay_edit_test.go
+++ b/internal/tui/replay_edit_test.go
@@ -29,6 +29,29 @@ func TestMain(m *testing.M) {
 			err = os.WriteFile(path, []byte("{} {}\n"), 0o600)
 		case "empty":
 			err = os.WriteFile(path, nil, 0o600)
+		case "resaved":
+			// vim's :wq on an unmodified buffer, which rewrites the same bytes.
+			seeded, readErr := os.ReadFile(path)
+			if readErr != nil {
+				os.Exit(9)
+			}
+			err = os.WriteFile(path, seeded, 0o600)
+		case "companions":
+			// What vim leaves with "set backup" or "set undofile", and what emacs
+			// leaves as an autosave. Same captured bytes, a name mcpsnoop never chose.
+			dir, base := filepath.Dir(path), filepath.Base(path)
+			seeded, readErr := os.ReadFile(path)
+			if readErr != nil {
+				os.Exit(9)
+			}
+			for _, name := range []string{base + "~", "." + base + ".swp", "#" + base + "#"} {
+				if err = os.WriteFile(filepath.Join(dir, name), seeded, 0o600); err != nil {
+					break
+				}
+			}
+			if err == nil {
+				err = os.WriteFile(path, []byte("{\n  \"name\": \"echo\",\n  \"arguments\": {\"text\": \"new\"}\n}\n"), 0o600)
+			}
 		case "exit":
 			os.Exit(7)
 		default:
@@ -53,7 +76,7 @@ func TestReplayEditorOutcomes(t *testing.T) {
 		wantText string
 	}{
 		{name: "changed", behavior: "changed", wantText: `"new"`},
-		{name: "unchanged", behavior: "unchanged", wantText: `"old"`},
+		{name: "unchanged", behavior: "unchanged", wantErr: "saved no change"},
 		{name: "invalid", behavior: "invalid", wantErr: "not valid JSON"},
 		{name: "non object", behavior: "non-object", wantErr: "must be a JSON object"},
 		{name: "multiple values", behavior: "multiple", wantErr: "more than one JSON value"},
@@ -121,7 +144,7 @@ func TestReplayEditorSelectionAndGuards(t *testing.T) {
 		t.Setenv("VISUAL", os.Args[0])
 		t.Setenv("EDITOR", filepath.Join(t.TempDir(), "must-not-run"))
 		t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
-		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "unchanged")
+		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "changed")
 		cmd, done, err := prepareReplayEditor(call, call.Params)
 		if err != nil {
 			t.Fatal(err)
@@ -137,7 +160,7 @@ func TestReplayEditorSelectionAndGuards(t *testing.T) {
 		t.Setenv("VISUAL", "")
 		t.Setenv("EDITOR", os.Args[0])
 		t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
-		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "unchanged")
+		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "changed")
 		cmd, done, err := prepareReplayEditor(call, call.Params)
 		if err != nil {
 			t.Fatal(err)
@@ -173,5 +196,168 @@ func TestReplayParamsEquivalentIgnoresFormattingAndObjectOrder(t *testing.T) {
 	}
 	if replayParamsEquivalent(a, json.RawMessage(`{"a":1,"b":[2,4]}`)) {
 		t.Fatal("a changed nested value should mark a replay as edited")
+	}
+}
+
+// TestEditorBufferKeepsTheBytesTheServerSent. The buffer is what the user edits,
+// so it has to be what the server actually sent. Decoding into a map and
+// re-encoding does neither: encoding/json escapes &, < and > on the way out, so
+// a URL argument arrived as "https://host?a=1&b=2", and a map has no order,
+// so every object came back alphabetised. internal/jsonwire exists in this repo
+// because of the first half of that.
+func TestEditorBufferKeepsTheBytesTheServerSent(t *testing.T) {
+	const captured = `{"zeta":1,"url":"https://h/p?a=1&b=2","alpha":"<b>","n":{"y":2,"x":1}}`
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(captured)}
+
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", os.Args[0])
+	t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+	t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "unchanged")
+
+	cmd, _, err := prepareReplayEditor(call, call.Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seeded, err := os.ReadFile(cmd.Args[len(cmd.Args)-1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(seeded)
+	for _, want := range []string{`"https://h/p?a=1&b=2"`, `"<b>"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buffer escaped what the server sent, %s is missing:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `\u00`) {
+		t.Errorf("buffer carries an escape the capture did not:\n%s", got)
+	}
+	// Key order is the server's, not the alphabet's.
+	if z, a := strings.Index(got, `"zeta"`), strings.Index(got, `"alpha"`); z < 0 || a < 0 || z > a {
+		t.Errorf("buffer reordered the keys:\n%s", got)
+	}
+	if x, y := strings.Index(got, `"y"`), strings.Index(got, `"x"`); x < 0 || y < 0 || x > y {
+		t.Errorf("buffer reordered a nested object:\n%s", got)
+	}
+}
+
+// TestEditorThatSavesNothingSendsNothing. An editor that hands the file to an
+// already-running instance and exits, which is what EDITOR=code without --wait
+// and emacsclient -n do, returns before the user has typed. Treating that as a
+// finished edit fired a live request at the server carrying the untouched
+// captured params, while the user was still looking at the window, and the
+// result panel called it REPLAY rather than EDITED so nothing said so.
+func TestEditorThatSavesNothingSendsNothing(t *testing.T) {
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo"}`)}
+	for _, behavior := range []string{"unchanged", "resaved"} {
+		t.Run(behavior, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+			t.Setenv("VISUAL", "")
+			t.Setenv("EDITOR", os.Args[0])
+			t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+			t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", behavior)
+
+			cmd, done, err := prepareReplayEditor(call, call.Params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			msg := done(cmd.Run()).(replayEditDoneMsg)
+			if msg.err == nil {
+				t.Fatalf("an unedited buffer was sent as an edit: %s", msg.call.Params)
+			}
+			// The message has to name the key that does resend it, or a user who
+			// meant to replay unchanged is left with no way forward.
+			if !strings.Contains(msg.err.Error(), "press r") {
+				t.Fatalf("error does not say what to do instead: %v", msg.err)
+			}
+		})
+	}
+}
+
+// TestEditorBufferDirectoryGoesWholeIncludingCompanions. Editors write beside
+// the file they are given, a vim swap or undo file, an emacs autosave, a
+// rename-style backup, each holding the same captured params and named by the
+// editor rather than by mcpsnoop. Unlinking the one path mcpsnoop knows about
+// left those on disk with the captured request in them.
+func TestEditorBufferDirectoryGoesWholeIncludingCompanions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", os.Args[0])
+	t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+	t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "companions")
+
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo","arguments":{"token":"sk-live-secret"}}`)}
+	cmd, done, err := prepareReplayEditor(call, call.Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Dir(cmd.Args[len(cmd.Args)-1])
+	if msg := done(cmd.Run()).(replayEditDoneMsg); msg.err != nil {
+		t.Fatalf("editor callback: %v", msg.err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		left, _ := os.ReadDir(dir)
+		names := make([]string, 0, len(left))
+		for _, e := range left {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("the buffer directory survived holding %v", names)
+	}
+	// Nothing of it is anywhere else under the temp root either.
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "mcpsnoop-replay") {
+			t.Fatalf("%s was left behind", e.Name())
+		}
+	}
+}
+
+// TestEditorValueThatNeedsAShellIsRefusedByName. The whole value is tried as one
+// executable so a path with a space works, and anything else is split on
+// whitespace so "code --wait" works. A quoted path carrying flags needs a shell
+// to unquote and gets neither, and letting it through produced
+// "fork/exec /Applications/Sublime: no such file or directory", which names a
+// path the user never wrote.
+func TestEditorValueThatNeedsAShellIsRefusedByName(t *testing.T) {
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"a":1}`)}
+
+	// A real executable whose path contains a space, since the whole point is that
+	// this one resolves as a single value and the others cannot.
+	spaced := filepath.Join(t.TempDir(), "My Editor")
+	if err := os.WriteFile(spaced, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, tc := range map[string]struct {
+		editor  string
+		wantErr bool
+	}{
+		"a path with a space, alone":       {spaced, false},
+		"a bare name with flags":           {"vim -n", false},
+		"a path with a space, plus a flag": {spaced + " --wait", true},
+		"a quoted path with a flag":        {`"` + spaced + `" --wait`, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+			t.Setenv("VISUAL", tc.editor)
+			t.Setenv("EDITOR", "")
+			_, _, err := prepareReplayEditor(call, call.Params)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("a value needing a shell was accepted, so exec fails on a mangled path instead")
+				}
+				if !strings.Contains(err.Error(), "runs no shell") {
+					t.Fatalf("the error must say why, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("a value mcpsnoop can run was refused: %v", err)
+			}
+		})
 	}
 }

--- a/internal/tui/replay_edit_test.go
+++ b/internal/tui/replay_edit_test.go
@@ -1,0 +1,177 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+// TestMain doubles the current test binary as a portable stub editor. The
+// parent gives it only the temporary JSON path, so no shell or platform-specific
+// script is needed to exercise the real exec.Cmd boundary.
+func TestMain(m *testing.M) {
+	if os.Getenv("MCPSNOOP_EDITOR_HELPER") == "1" {
+		path := os.Args[len(os.Args)-1]
+		var err error
+		switch os.Getenv("MCPSNOOP_EDITOR_BEHAVIOR") {
+		case "unchanged":
+		case "changed":
+			err = os.WriteFile(path, []byte("{\n  \"name\": \"echo\",\n  \"arguments\": {\"text\": \"new\"}\n}\n"), 0o600)
+		case "invalid":
+			err = os.WriteFile(path, []byte("{not json\n"), 0o600)
+		case "non-object":
+			err = os.WriteFile(path, []byte("[1, 2, 3]\n"), 0o600)
+		case "multiple":
+			err = os.WriteFile(path, []byte("{} {}\n"), 0o600)
+		case "empty":
+			err = os.WriteFile(path, nil, 0o600)
+		case "exit":
+			os.Exit(7)
+		default:
+			os.Exit(8)
+		}
+		if err != nil {
+			os.Exit(9)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestReplayEditorOutcomes(t *testing.T) {
+	original := json.RawMessage(`{"name":"echo","arguments":{"text":"old"}}`)
+	call := store.CallView{Method: "tools/call", Params: original}
+
+	for _, tc := range []struct {
+		name     string
+		behavior string
+		wantErr  string
+		wantText string
+	}{
+		{name: "changed", behavior: "changed", wantText: `"new"`},
+		{name: "unchanged", behavior: "unchanged", wantText: `"old"`},
+		{name: "invalid", behavior: "invalid", wantErr: "not valid JSON"},
+		{name: "non object", behavior: "non-object", wantErr: "must be a JSON object"},
+		{name: "multiple values", behavior: "multiple", wantErr: "more than one JSON value"},
+		{name: "empty", behavior: "empty", wantErr: "empty"},
+		{name: "nonzero exit", behavior: "exit", wantErr: "editor failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+			t.Setenv("VISUAL", "")
+			t.Setenv("EDITOR", os.Args[0])
+			t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+			t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", tc.behavior)
+
+			cmd, done, err := prepareReplayEditor(call, original)
+			if err != nil {
+				t.Fatalf("prepareReplayEditor: %v", err)
+			}
+			path := cmd.Args[len(cmd.Args)-1]
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("editor buffer: %v", err)
+			}
+			if info.Mode().Perm() != 0o600 {
+				t.Fatalf("editor buffer mode = %o, want 600", info.Mode().Perm())
+			}
+			seeded, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(seeded), "\n  \"arguments\"") {
+				t.Fatalf("editor buffer is not pretty JSON:\n%s", seeded)
+			}
+
+			msg, ok := done(cmd.Run()).(replayEditDoneMsg)
+			if !ok {
+				t.Fatal("editor callback returned the wrong message type")
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("editor buffer was not removed, stat err=%v", err)
+			}
+			if tc.wantErr != "" {
+				if msg.err == nil || !strings.Contains(msg.err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want substring %q", msg.err, tc.wantErr)
+				}
+				return
+			}
+			if msg.err != nil {
+				t.Fatalf("editor callback: %v", msg.err)
+			}
+			if !strings.Contains(string(msg.call.Params), tc.wantText) {
+				t.Fatalf("saved params = %s, want %s", msg.call.Params, tc.wantText)
+			}
+			if string(msg.captured) != string(original) {
+				t.Fatalf("captured params changed: %s", msg.captured)
+			}
+		})
+	}
+}
+
+func TestReplayEditorSelectionAndGuards(t *testing.T) {
+	call := store.CallView{Method: "tools/call", Params: json.RawMessage(`{"name":"echo"}`)}
+
+	t.Run("VISUAL takes precedence", func(t *testing.T) {
+		t.Setenv("TMPDIR", t.TempDir())
+		t.Setenv("VISUAL", os.Args[0])
+		t.Setenv("EDITOR", filepath.Join(t.TempDir(), "must-not-run"))
+		t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "unchanged")
+		cmd, done, err := prepareReplayEditor(call, call.Params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg := done(cmd.Run()).(replayEditDoneMsg)
+		if msg.err != nil {
+			t.Fatalf("VISUAL was not used: %v", msg.err)
+		}
+	})
+
+	t.Run("EDITOR fallback", func(t *testing.T) {
+		t.Setenv("TMPDIR", t.TempDir())
+		t.Setenv("VISUAL", "")
+		t.Setenv("EDITOR", os.Args[0])
+		t.Setenv("MCPSNOOP_EDITOR_HELPER", "1")
+		t.Setenv("MCPSNOOP_EDITOR_BEHAVIOR", "unchanged")
+		cmd, done, err := prepareReplayEditor(call, call.Params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg := done(cmd.Run()).(replayEditDoneMsg); msg.err != nil {
+			t.Fatalf("EDITOR fallback failed: %v", msg.err)
+		}
+	})
+
+	t.Run("missing editor", func(t *testing.T) {
+		t.Setenv("VISUAL", "")
+		t.Setenv("EDITOR", "")
+		if _, _, err := prepareReplayEditor(call, call.Params); err == nil || !strings.Contains(err.Error(), "$VISUAL or $EDITOR") {
+			t.Fatalf("missing editor error = %v", err)
+		}
+	})
+
+	t.Run("captured non-object", func(t *testing.T) {
+		t.Setenv("EDITOR", os.Args[0])
+		bad := call
+		bad.Params = json.RawMessage(`[1]`)
+		if _, _, err := prepareReplayEditor(bad, bad.Params); err == nil || !strings.Contains(err.Error(), "JSON object") {
+			t.Fatalf("non-object captured params error = %v", err)
+		}
+	})
+}
+
+func TestReplayParamsEquivalentIgnoresFormattingAndObjectOrder(t *testing.T) {
+	a := json.RawMessage(`{"b":[2,3],"a":1}`)
+	b := json.RawMessage("{\n  \"a\": 1,\n  \"b\": [2, 3]\n}")
+	if !replayParamsEquivalent(a, b) {
+		t.Fatal("formatting and object key order should not mark a replay as edited")
+	}
+	if replayParamsEquivalent(a, json.RawMessage(`{"a":1,"b":[2,4]}`)) {
+		t.Fatal("a changed nested value should mark a replay as edited")
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -184,7 +184,7 @@ func (m Model) footerHints() string {
 	if m.view == viewStream {
 		hs = []hint{{"enter", "inspect"}}
 		if m.sessionReplayable() {
-			hs = append(hs, hint{"r", "replay"})
+			hs = append(hs, hint{"r", "replay"}, hint{"R", "edit + replay"})
 		}
 		hs = append(hs, hint{"c", "caps"}, hint{"s", "summary"}, hint{"/", "filter"}, hint{"p", "pause"}, hint{"?", "help"})
 	}
@@ -989,6 +989,7 @@ func (m Model) renderHelp() string {
 	}}
 	frameActions := helpGroup{"FRAME ACTIONS", [][2]string{
 		{"r", "replay the selected tool call"},
+		{"R", "edit params and replay the selected call"},
 		{"c", "show negotiated capabilities"},
 		{"s", "show per-tool latency and error summary"},
 		{"p", "pause or resume the stream"},
@@ -1343,14 +1344,14 @@ func (m Model) overlayFooter(w int) string {
 		hs = append(hs, hint{"/", "search"}, hint{"n/N", "match"}, hint{"y", "copy"})
 		// r and x are only offered when they can act on the inspected frame.
 		if m.canReplay() {
-			hs = append(hs, hint{"r", "replay"})
+			hs = append(hs, hint{"r", "replay"}, hint{"R", "edit + replay"})
 		}
 		if _, ok := m.pairIndex(m.inspect); ok {
 			hs = append(hs, hint{"x", "pair"})
 		}
 		hs = append(hs, hint{"esc", "close"})
 	case m.overlay == overlayReplay && m.replayReq.Method != "":
-		hs = append(hs, hint{"r", "replay again"}, hint{"y", "copy"}, hint{"esc", "close"})
+		hs = append(hs, hint{"r", "replay again"}, hint{"R", "edit + replay"}, hint{"y", "copy"}, hint{"esc", "close"})
 	default:
 		hs = append(hs, hint{"y", "copy"}, hint{"esc", "close"})
 	}


### PR DESCRIPTION
## What and why

Fixes #207.

`r` could replay a captured request, but fixing a bad argument required leaving mcpsnoop and reconstructing the call elsewhere. This adds `R` (shift+r) beside every replay entry point so users can edit the complete `params` object in `$VISUAL` or `$EDITOR`, validate it, and send it through the existing isolated replay path.

The implementation keeps three values distinct:

- the immutable captured params
- the user-edited replay candidate
- the actual wire params returned by `replay.Replay`, including stateless protocol `_meta`

Edited results show both captured and sent params, `r` repeats the current candidate, and `R` reopens it. Invalid, empty, non-object, or editor-failed buffers abort without changing replay state. The existing recorded-command confirmation still gates every spawn, temporary buffers are mode 0600 and removed on every callback path, and replay traffic remains outside the observed store and logs.

This also makes replay results classify MCP `result.isError: true` as an error instead of displaying `ok`.

## Checklist

- [x] `make check` passes (gofmt, vet, staticcheck, race tests)
- [x] Added or updated tests for the change, including editor failure cases and fail-before/pass-after behavior
- [x] Updated the README / docs for the new key
- [x] Windows cross-build passes
