### PR TITLE
feat(proxy): capture the transport headers the spec makes mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,38 @@ definition stay observational. Key- and value-based redaction applies to capture
 parameter-header values before they reach a sink, and a value mcpsnoop scrubbed
 itself is never reported as a disagreement.
 
+### Check the transport headers the spec makes mandatory
+
+The routing headers above were the only ones a frame carried, so the rest of the
+Streamable HTTP transport's mandatory headers reached nothing that could check
+them. `Content-Type` was the sharpest case: the response side already read it to
+tell an SSE stream from a JSON body, then threw it away.
+
+An HTTP frame now carries the headers the transport states rules about, and two
+of those rules are checkable.
+
+| Rule | Reported as |
+|---|---|
+| the client **MUST** send an `Accept` listing both `application/json` and `text/event-stream` | `warn` on the request |
+| a server answering a JSON-RPC request **MUST** return `Content-Type: application/json` or `text/event-stream` | `warn` on the response |
+
+Both sentences read the same in 2025-11-25 and 2026-07-28, so unlike the drift
+and extension checks these need no revision gate. `Origin` is recorded too, since
+servers **MUST** validate it and **MUST** answer `403` when it is invalid, but
+mcpsnoop cannot know your allowed origins so it shows the value rather than
+judging it.
+
+Wildcards count. A client sending `*/*` has offered both types and is never
+reported, and a `charset` parameter on a `Content-Type` is ignored. A log
+captured before mcpsnoop recorded these headers stays silent rather than
+reporting every frame in it for a header nobody wrote down, and stdio never has
+them at all.
+
+`Authorization` is deliberately not captured. Turning a challenge into token
+facts is its own problem and putting a bearer token on disk is not the answer to
+it. `Mcp-Session-Id` and `Last-Event-ID` are not captured either: 2026-07-28
+removed both and tells a server to ignore them, so there is no rule left to check.
+
 ### Detect tool definition drift
 
 The first complete `tools/list` observed for a server label becomes its trusted

--- a/internal/proxy/frame.go
+++ b/internal/proxy/frame.go
@@ -104,6 +104,35 @@ type Envelope struct {
 	// response header worth keeping verbatim: a 401 without it is a dead end,
 	// and with it names the scheme and the resource metadata to go to next.
 	AuthChallenge string `json:"auth_challenge,omitempty"`
+	// TransportHeaders carries the Streamable HTTP headers the transport
+	// specification makes normative, which are the ones a conformance check can
+	// be written against. Nil on stdio, and nil on a log captured before mcpsnoop
+	// recorded them, which is what keeps reading an old log from reporting every
+	// frame in it for a header nobody ever wrote down.
+	TransportHeaders *TransportHeaders `json:"transport_headers,omitempty"`
+}
+
+// TransportHeaders are the spec-mandated Streamable HTTP headers of one frame.
+// A closed list drawn from normative clauses, not a general header dump: someone
+// who wants every header wants mitmproxy, and this exists so `check` can gate on
+// rules the transport actually states.
+//
+// Authorization is deliberately absent. Decoding a challenge into token facts is
+// its own problem and putting a bearer token on disk is not the answer to it.
+// Mcp-Session-Id and Last-Event-ID are absent too: 2026-07-28 removed both, and
+// tells a server to ignore them, so there is no rule left to check.
+type TransportHeaders struct {
+	// Accept is the client's Accept header. The client MUST list both
+	// application/json and text/event-stream on a POST.
+	Accept string `json:"accept,omitempty"`
+	// ContentType is the frame's own Content-Type, the request's on a client
+	// frame and the response's on a server one. A server answering a JSON-RPC
+	// request MUST return one of the same two types.
+	ContentType string `json:"content_type,omitempty"`
+	// Origin is the request's Origin. Servers MUST validate it and MUST answer
+	// 403 when it is invalid, which mcpsnoop cannot judge without knowing the
+	// allowed set, so this is recorded for the reader rather than checked.
+	Origin string `json:"origin,omitempty"`
 }
 
 // RPCError is the JSON-RPC error object.

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -88,6 +88,10 @@ type route struct {
 	truncated bool   // the observed copy was cut at the frame-size cap
 	status    int    // HTTP status of the response carrying this frame
 	challenge string // WWW-Authenticate on that response
+	// headers are the spec-mandated transport headers of this frame. A pointer so
+	// a frame mcpsnoop captured with none is distinguishable from a log written
+	// before it recorded them at all.
+	headers *TransportHeaders
 }
 
 // wwwAuthenticateHeader carries the challenge on a 401. It is kept verbatim
@@ -117,6 +121,7 @@ func newHTTPEmitter(cfg HTTPConfig, sink Sink) func(Direction, []byte, route) {
 			Truncated:          r.truncated,
 			Status:             r.status,
 			AuthChallenge:      r.challenge,
+			TransportHeaders:   r.headers,
 		}
 		if raw != nil {
 			env.Raw = append([]byte(nil), raw...)
@@ -276,7 +281,13 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 		ModifyResponse: func(resp *http.Response) error {
 			// The status and the challenge ride every frame observed on this
 			// response, so the transport layer is visible even when the body is not.
-			rt := route{status: resp.StatusCode, challenge: resp.Header.Get(wwwAuthenticateHeader)}
+			rt := route{
+				status:    resp.StatusCode,
+				challenge: resp.Header.Get(wwwAuthenticateHeader),
+				// Read a few lines below to pick the SSE branch, and until now
+				// discarded afterwards, so nothing could check the rule it decides.
+				headers: &TransportHeaders{ContentType: resp.Header.Get("Content-Type")},
+			}
 			if resp.Request != nil {
 				rt.conn = resp.Request.RemoteAddr
 			}
@@ -337,8 +348,13 @@ func httpProxyHandler(target *url.URL, emit func(Direction, []byte, route)) http
 				method:          r.Header.Get(mcpMethodHeader),
 				name:            r.Header.Get(mcpNameHeader),
 				protocolVersion: r.Header.Get(mcpProtocolVersionHeader),
-				params:          mcpParamHeaders(r.Header),
-				conn:            r.RemoteAddr,
+				headers: &TransportHeaders{
+					Accept:      r.Header.Get("Accept"),
+					ContentType: r.Header.Get("Content-Type"),
+					Origin:      r.Header.Get("Origin"),
+				},
+				params: mcpParamHeaders(r.Header),
+				conn:   r.RemoteAddr,
 			}
 			// Same streaming tap for the request body, so a large upload is forwarded
 			// without being held in memory whole.

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -768,3 +768,78 @@ func TestProxyForwardsTheRequestUnchanged(t *testing.T) {
 		t.Fatalf("no frame carried a connection identity: %v", conns)
 	}
 }
+
+// TestProxyCapturesTheSpecMandatedHeaders. check already gates on routing
+// headers, but the rest of the transport's mandatory headers reached no frame,
+// so no signal could be written against them. Content-Type was the sharpest
+// case: the response side already read it to pick the SSE branch and then threw
+// it away.
+func TestProxyCapturesTheSpecMandatedHeaders(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer target.Close()
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []Envelope
+	front := httptest.NewServer(httpProxyHandler(u, func(dir Direction, body []byte, rt route) {
+		got = append(got, Envelope{Direction: dir, TransportHeaders: rt.headers})
+	}))
+	defer front.Close()
+
+	req, err := http.NewRequest(http.MethodPost, front.URL+"/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:1234")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	var request, response *TransportHeaders
+	for _, e := range got {
+		if e.Direction == ClientToServer {
+			request = e.TransportHeaders
+		} else {
+			response = e.TransportHeaders
+		}
+	}
+	if request == nil {
+		t.Fatal("the client frame carried no transport headers")
+	}
+	for field, want := range map[string]string{
+		"Accept":      "application/json, text/event-stream",
+		"ContentType": "application/json",
+		"Origin":      "http://localhost:1234",
+	} {
+		var got string
+		switch field {
+		case "Accept":
+			got = request.Accept
+		case "ContentType":
+			got = request.ContentType
+		case "Origin":
+			got = request.Origin
+		}
+		if got != want {
+			t.Errorf("%s = %q, want %q", field, got, want)
+		}
+	}
+	if response == nil || response.ContentType != "application/json" {
+		t.Fatalf("the response frame did not carry its Content-Type: %+v", response)
+	}
+	// A pointer, not a value, so a log written before this existed stays
+	// distinguishable from a request that genuinely carried none.
+	if got := (&Envelope{}).TransportHeaders; got != nil {
+		t.Fatalf("an envelope with nothing captured is not nil: %+v", got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -521,6 +521,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 		sess.caps.applyResponseMeta(msg.Result)
 		c, matched := sess.completeCall(ev.id, e.Direction, e.ConnID, e.TS, msg, e.Redacted)
 		ev.call = c
+		if note := responseContentTypeWarning(e.Direction, e.TransportHeaders); note != "" {
+			ev.warning = appendWarning(ev.warning, note)
+		}
 		// A task handle is the server reaching for the extension. It is judged
 		// against what the client declared, since the client is the side that has
 		// to understand the handle it is being given.
@@ -638,6 +641,9 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			if note := sess.unnegotiatedTasksWarning(e.Direction, requestProtocolVersion(msg.Params, ev.mcpProtocolVersion)); note != "" {
 				ev.warning = appendWarning(ev.warning, strconv.Quote(msg.Method)+" "+note)
 			}
+		}
+		if note := acceptWarning(e.Direction, e.TransportHeaders); note != "" {
+			ev.warning = appendWarning(ev.warning, note)
 		}
 		var reused bool
 		if root, stateIssue := sess.matchRetry(msg); root != nil {

--- a/internal/store/transportheaders.go
+++ b/internal/store/transportheaders.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"mime"
+	"strings"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// The two content types the Streamable HTTP transport is written in terms of.
+const (
+	contentTypeJSON = "application/json"
+	contentTypeSSE  = "text/event-stream"
+)
+
+// acceptWarning reports a client POST whose Accept header does not offer both
+// types the transport requires.
+//
+// "The client MUST include an `Accept` header listing both `application/json`
+// and `text/event-stream` as supported content types." The same sentence is in
+// 2025-11-25, so unlike the extension rules this one needs no revision gate: a
+// client has owed both types for as long as the transport has existed.
+//
+// A server is free to answer with either, so offering only one is not a
+// preference, it is a client that will reject half the legal answers. The usual
+// symptom is a stream that never opens and no error anywhere.
+func acceptWarning(dir proxy.Direction, headers *proxy.TransportHeaders) string {
+	if dir != proxy.ClientToServer || headers == nil {
+		// nil means the log predates mcpsnoop recording these, not that the client
+		// sent nothing. Reading an old capture must not report every frame in it.
+		return ""
+	}
+	if headers.Accept == "" {
+		return "the request sent no Accept header, and the transport requires one listing " +
+			contentTypeJSON + " and " + contentTypeSSE
+	}
+	var missing []string
+	for _, want := range []string{contentTypeJSON, contentTypeSSE} {
+		if !acceptOffers(headers.Accept, want) {
+			missing = append(missing, want)
+		}
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	return "the request's Accept header does not offer " + strings.Join(missing, " or ") +
+		", which the transport requires a client to list"
+}
+
+// acceptOffers reports whether an Accept header admits a media type, honouring
+// the wildcards HTTP defines. A client sending */* has offered everything, and
+// reporting it would be mcpsnoop inventing a stricter rule than the one written.
+func acceptOffers(accept, want string) bool {
+	wantType, _, _ := strings.Cut(want, "/")
+	for _, part := range strings.Split(accept, ",") {
+		media, _, err := mime.ParseMediaType(strings.TrimSpace(part))
+		if err != nil {
+			// q-values and unknown parameters are handled by ParseMediaType; anything
+			// it cannot read is compared whole rather than dropped, since discarding
+			// it would be the same as the client not having sent it.
+			media = strings.ToLower(strings.TrimSpace(strings.Split(part, ";")[0]))
+		}
+		if media == "*/*" || media == want || media == wantType+"/*" {
+			return true
+		}
+	}
+	return false
+}
+
+// responseContentTypeWarning reports a server answering a JSON-RPC request with
+// a body that is neither of the two types the transport allows.
+//
+// "If the body is a JSON-RPC request, the server MUST return either
+// `Content-Type: application/json` (a single JSON object) or
+// `Content-Type: text/event-stream` (an SSE response stream)." Also unchanged
+// since 2025-11-25.
+//
+// Only answers to a request are judged, which is why this is called from the
+// response branch alone. A 202 acknowledging a notification carries no JSON-RPC
+// body and never reaches it, and neither does a bare transport failure.
+func responseContentTypeWarning(dir proxy.Direction, headers *proxy.TransportHeaders) string {
+	if dir != proxy.ServerToClient || headers == nil {
+		return ""
+	}
+	if headers.ContentType == "" {
+		return "the response to a request carried no Content-Type, and the transport requires " +
+			contentTypeJSON + " or " + contentTypeSSE
+	}
+	media, _, err := mime.ParseMediaType(headers.ContentType)
+	if err != nil {
+		media = strings.ToLower(strings.TrimSpace(strings.Split(headers.ContentType, ";")[0]))
+	}
+	if media == contentTypeJSON || media == contentTypeSSE {
+		return ""
+	}
+	return "the response to a request is " + media + ", and the transport allows only " +
+		contentTypeJSON + " or " + contentTypeSSE
+}

--- a/internal/store/transportheaders_test.go
+++ b/internal/store/transportheaders_test.go
@@ -64,15 +64,17 @@ func TestResponseContentTypeIsCheckedAgainstTheTwoAllowedTypes(t *testing.T) {
 		headers *proxy.TransportHeaders
 		want    string
 	}{
-		"json":                {&proxy.TransportHeaders{ContentType: "application/json"}, ""},
-		"json with a charset": {&proxy.TransportHeaders{ContentType: "application/json; charset=utf-8"}, ""},
-		"an event stream":     {&proxy.TransportHeaders{ContentType: "text/event-stream"}, ""},
-		"plain text":          {&proxy.TransportHeaders{ContentType: "text/plain"}, "is text/plain"},
-		// Not "anything under application", which the transport does not say.
-		"another application type":                 {&proxy.TransportHeaders{ContentType: "application/xml"}, "is application/xml"},
-		"html, the shape a proxy error page takes": {&proxy.TransportHeaders{ContentType: "text/html"}, "is text/html"},
-		"none at all":                    {&proxy.TransportHeaders{}, "carried no Content-Type"},
-		"a log from before this existed": {nil, ""},
+		"json":            {&proxy.TransportHeaders{ContentType: "application/json"}, ""},
+		"json + charset":  {&proxy.TransportHeaders{ContentType: "application/json; charset=utf-8"}, ""},
+		"an event stream": {&proxy.TransportHeaders{ContentType: "text/event-stream"}, ""},
+		"plain text":      {&proxy.TransportHeaders{ContentType: "text/plain"}, "is text/plain"},
+		// application/xml, not "anything under application", which the transport
+		// does not say. text/html is the shape a proxy error page takes.
+		"another app type": {&proxy.TransportHeaders{ContentType: "application/xml"}, "is application/xml"},
+		"html":             {&proxy.TransportHeaders{ContentType: "text/html"}, "is text/html"},
+		"none at all":      {&proxy.TransportHeaders{}, "carried no Content-Type"},
+		// nil is a log written before mcpsnoop recorded these headers.
+		"an older log": {nil, ""},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got := responseContentTypeWarning(proxy.ServerToClient, tc.headers)

--- a/internal/store/transportheaders_test.go
+++ b/internal/store/transportheaders_test.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// TestAcceptHeaderIsCheckedAgainstWhatTheTransportRequires. The transport says
+// the client MUST list both application/json and text/event-stream, in
+// 2025-11-25 and 2026-07-28 alike, so this needs no revision gate. A client that
+// offers only one will reject half the legal answers, and the symptom is a
+// stream that never opens with no error anywhere.
+func TestAcceptHeaderIsCheckedAgainstWhatTheTransportRequires(t *testing.T) {
+	for name, tc := range map[string]struct {
+		headers *proxy.TransportHeaders
+		want    string
+	}{
+		"both types":         {&proxy.TransportHeaders{Accept: "application/json, text/event-stream"}, ""},
+		"both, reordered":    {&proxy.TransportHeaders{Accept: "text/event-stream, application/json"}, ""},
+		"both with q-values": {&proxy.TransportHeaders{Accept: "text/event-stream;q=0.9, application/json;q=1.0"}, ""},
+		// A client offering everything has offered both, and reporting it would be
+		// mcpsnoop inventing a stricter rule than the one written down.
+		"the */* wildcard": {&proxy.TransportHeaders{Accept: "*/*"}, ""},
+		"type wildcards":   {&proxy.TransportHeaders{Accept: "application/*, text/*"}, ""},
+		"only json":        {&proxy.TransportHeaders{Accept: "application/json"}, "text/event-stream"},
+		"only the stream":  {&proxy.TransportHeaders{Accept: "text/event-stream"}, "application/json"},
+		"neither":          {&proxy.TransportHeaders{Accept: "text/plain"}, "application/json or text/event-stream"},
+		"no Accept at all": {&proxy.TransportHeaders{ContentType: "application/json"}, "sent no Accept header"},
+		// nil is a log written before mcpsnoop recorded these headers. Reading one
+		// back must not report every frame in it for a header nobody wrote down.
+		"a log from before this existed": {nil, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := acceptWarning(proxy.ClientToServer, tc.headers)
+			if tc.want == "" {
+				if got != "" {
+					t.Fatalf("warned about a conforming request: %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("warning = %q, want it to name %q", got, tc.want)
+			}
+		})
+	}
+
+	// The rule is the client's, so a server frame carrying the same header is not
+	// under it.
+	if got := acceptWarning(proxy.ServerToClient, &proxy.TransportHeaders{Accept: "text/plain"}); got != "" {
+		t.Fatalf("a server frame was judged by the client's rule: %q", got)
+	}
+}
+
+// TestResponseContentTypeIsCheckedAgainstTheTwoAllowedTypes. Answering a
+// JSON-RPC request with anything but application/json or text/event-stream is a
+// MUST violation, and the value was already read to pick the SSE branch and then
+// thrown away, so nothing could check the rule it decides.
+func TestResponseContentTypeIsCheckedAgainstTheTwoAllowedTypes(t *testing.T) {
+	for name, tc := range map[string]struct {
+		headers *proxy.TransportHeaders
+		want    string
+	}{
+		"json":                {&proxy.TransportHeaders{ContentType: "application/json"}, ""},
+		"json with a charset": {&proxy.TransportHeaders{ContentType: "application/json; charset=utf-8"}, ""},
+		"an event stream":     {&proxy.TransportHeaders{ContentType: "text/event-stream"}, ""},
+		"plain text":          {&proxy.TransportHeaders{ContentType: "text/plain"}, "is text/plain"},
+		// Not "anything under application", which the transport does not say.
+		"another application type":                 {&proxy.TransportHeaders{ContentType: "application/xml"}, "is application/xml"},
+		"html, the shape a proxy error page takes": {&proxy.TransportHeaders{ContentType: "text/html"}, "is text/html"},
+		"none at all":                    {&proxy.TransportHeaders{}, "carried no Content-Type"},
+		"a log from before this existed": {nil, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := responseContentTypeWarning(proxy.ServerToClient, tc.headers)
+			if tc.want == "" {
+				if got != "" {
+					t.Fatalf("warned about a conforming response: %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("warning = %q, want it to name %q", got, tc.want)
+			}
+		})
+	}
+
+	// The rule is the server's.
+	if got := responseContentTypeWarning(proxy.ClientToServer, &proxy.TransportHeaders{ContentType: "text/plain"}); got != "" {
+		t.Fatalf("a client frame was judged by the server's rule: %q", got)
+	}
+}
+
+// TestTransportHeaderChecksNeverFireOnStdio. stdio has no HTTP headers at all,
+// and these warnings fail a default check run, so a stdio capture reporting one
+// would turn every such CI job red for a rule that does not apply to it.
+func TestTransportHeaderChecksNeverFireOnStdio(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/list", `{}`))
+	for _, ev := range s.Timeline("s1") {
+		if ev.Warning != "" {
+			t.Fatalf("a stdio frame was warned about: %q", ev.Warning)
+		}
+	}
+	// The response half too.
+	got := s.Ingest(resp(2, t0, proxy.ServerToClient, "1", `"result":{"tools":[]}`))
+	if got.Warning != "" {
+		t.Fatalf("a stdio response was warned about: %q", got.Warning)
+	}
+}
+
+// TestTransportHeaderChecksReachTheStream drives the ingest path rather than the
+// two functions, since a check nothing calls is a check that does not exist.
+func TestTransportHeaderChecksReachTheStream(t *testing.T) {
+	s := New()
+	t0 := time.Now()
+	request := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+		Raw:              json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"ping"}`),
+		TransportHeaders: &proxy.TransportHeaders{Accept: "application/json", ContentType: "application/json"},
+	})
+	if !strings.Contains(request.Warning, "text/event-stream") {
+		t.Fatalf("the Accept rule never reached the stream: %q", request.Warning)
+	}
+	response := s.Ingest(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0, Status: 200,
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP,
+		Raw:              json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`),
+		TransportHeaders: &proxy.TransportHeaders{ContentType: "text/html"},
+	})
+	if !strings.Contains(response.Warning, "text/html") {
+		t.Fatalf("the Content-Type rule never reached the stream: %q", response.Warning)
+	}
+	if h := s.Sessions()[0]; h.Errors != 0 {
+		t.Fatalf("a header rule was counted as an error, not a warning: %+v", h)
+	}
+}


### PR DESCRIPTION
Closes #220 