### PR TITLE
feat(store): split a multi round-trip operation into server time and human time

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Explicit command-line flags override values from the config file.
 | `mcpsnoop` | open the live TUI |
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, har, or otlp |
-| `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, or late results |
+| `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, late results, or a latency budget |
 | `mcpsnoop baseline` | inspect, accept, or reset trusted tool definitions |
 | `mcpsnoop diff` | compare tools and calls across two captured sessions |
 | `mcpsnoop open` | open a saved session in the TUI |
@@ -723,6 +723,65 @@ mcpsnoop still changes nothing about the traffic it forwards.
 
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
+
+### Tell the server's latency from the user's
+
+Under multi round-trip requests one tool call is several requests, and the
+seconds a person spent answering an elicitation sit inside the span. That is
+deliberate, since that interval is usually the one you most want to see, but it
+means one number cannot answer both questions.
+
+On a `book_flight` chain where the server worked 1.2 seconds while the user took
+37, `check --max-duration 5s` blames the tool for 38.2 seconds. It still does,
+because changing what that flag means would loosen every pipeline that already
+sets it. Two siblings name what they measure instead.
+
+```bash
+mcpsnoop check --max-server-duration 1s session.jsonl   # the server's share alone
+mcpsnoop check --max-round-trips 2 session.jsonl        # how chatty a tool is
+```
+
+```
+assertion failed: 1 tool call exceeded the 1s server budget (worst: tool "book_flight" held for 1.2s)
+assertion failed: 1 tool call exceeded the 2 round trip budget (worst: tool "book_flight" took 3)
+```
+
+Both are off by default, so a default `check` run is unaffected, and both are
+read off frame timestamps and a link mcpsnoop already inferred, so neither
+guesses at intent.
+
+Press `i` in the TUI for the breakdown, or read `interactions` in the json,
+text and html exports. Each entry is one logical operation with its round trip
+count, its total, the share the server held it for and the share it was waiting
+on the client, plus a per-hop line naming what each answer asked for. The
+per-tool summary gains a `TRIPS` column so a chatty tool is visible without
+opening anything.
+
+`export --format har` puts the server's share in `wait` and the rest in
+`blocked`, which is what that field is for, so a viewer stops drawing a 38-second
+server wait that never happened.
+
+The counts and the two shares are accumulated as frames arrive rather than
+derived when you ask, because the live store releases old frames to stay inside
+its budget and a derived answer would quietly be a window instead of a chain.
+The per-hop breakdown is read from the frames still held, and says so when it is
+only part of one. `ServerTime + ClientTurnaround` equals the total by
+construction rather than by arithmetic anyone has to trust.
+
+`--max-round-trips` judges a chain that is still running, because every request
+it has already made is countable and a server asking again and again produces
+exactly the operation nobody ever finishes. `--max-server-duration` waits for an
+ending, which is the rule `--max-duration` already applies, since an operation
+still open has no latency to judge.
+
+An operation mcpsnoop could not link stays its own single-hop entry. `matchRetry`
+refuses an ambiguous link on purpose, and this view does not fill that gap in.
+
+An operation that took one request carries no hop breakdown, because a single
+hop restates the totals above it word for word. A chain reports one hop per
+request, and says so when the store no longer holds every frame or when work
+settled off the request and answer pair a hop is made of, which a task handle
+does.
 
 ### See what a server asked your user for
 

--- a/cmd/mcpsnoop/check.go
+++ b/cmd/mcpsnoop/check.go
@@ -159,7 +159,9 @@ func newCheckCmd() *cobra.Command {
 	cmd.Flags().StringVar(&failOn, "fail-on", "error,invalid,warn", "comma-separated signals to fail on, any of error, invalid, warn, mismatch, pending, late-result, drift, deprecated, incomplete, schema")
 	cmd.Flags().StringVar(&formatFlag, "format", string(checkFormatText), "output format, one of text, junit, or sarif")
 	cmd.Flags().StringVar(&baselineDir, "baseline", "", "tool-baseline directory to compare against (default: the mcpsnoop state dir); point CI at a persisted or checked-in directory")
-	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this duration (e.g. 500ms), disabled when zero")
+	cmd.Flags().DurationVar(&assertions.maxDuration, "max-duration", 0, "fail if any completed tool call exceeds this wall-clock duration, including time a user spent answering an elicitation (e.g. 500ms), disabled when zero")
+	cmd.Flags().DurationVar(&assertions.maxServerDuration, "max-server-duration", 0, "fail if the server's own share of any completed tool call exceeds this duration, excluding time the client took to answer, disabled when zero")
+	cmd.Flags().IntVar(&assertions.maxRoundTrips, "max-round-trips", 0, "fail if any tool call took more than this many requests, which multi round-trip requests make possible, disabled when zero")
 	cmd.Flags().StringArrayVar(&assertions.expectTools, "expect-tool", nil, "fail if this tool was never called, repeatable")
 	cmd.Flags().StringArrayVar(&assertions.forbidTools, "forbid-tool", nil, "fail if this tool was called, repeatable")
 	return cmd
@@ -168,9 +170,18 @@ func newCheckCmd() *cobra.Command {
 // checkAssertions holds the first-class check assertions, evaluated per session
 // on top of the signal counts.
 type checkAssertions struct {
-	maxDuration time.Duration
-	expectTools []string
-	forbidTools []string
+	// maxDuration is wall clock for the whole interaction and deliberately stays
+	// that way. Under multi round-trip requests one tool call is several requests
+	// and the seconds a person spent answering are inside the span, which is the
+	// point: that interval is the one you most want to see. Redefining this flag
+	// to measure only the server would quietly loosen every pipeline that already
+	// sets it, so the two figures underneath get flags of their own that say what
+	// they measure.
+	maxDuration       time.Duration
+	maxServerDuration time.Duration
+	maxRoundTrips     int
+	expectTools       []string
+	forbidTools       []string
 }
 
 // eval returns one message per assertion the session violates, empty when all
@@ -178,7 +189,8 @@ type checkAssertions struct {
 // The latency budget only judges calls that got a response, since a call that
 // never did has no real latency and is the pending signal's job.
 func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
-	if a.maxDuration <= 0 && len(a.expectTools) == 0 && len(a.forbidTools) == 0 {
+	if a.maxDuration <= 0 && a.maxServerDuration <= 0 && a.maxRoundTrips <= 0 &&
+		len(a.expectTools) == 0 && len(a.forbidTools) == 0 {
 		return nil
 	}
 	calls := st.Calls(sessionID)
@@ -209,13 +221,12 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 			}
 		}
 		if exceeded > 0 {
-			callWord := "calls"
-			if exceeded == 1 {
-				callWord = "call"
-			}
 			failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %s budget (worst: tool %q took %s)",
-				exceeded, callWord, a.maxDuration, worstTool, worstDuration.Round(time.Millisecond)))
+				exceeded, callWord(exceeded), a.maxDuration, worstTool, worstDuration.Round(time.Millisecond)))
 		}
+	}
+	if a.maxServerDuration > 0 || a.maxRoundTrips > 0 {
+		failures = append(failures, a.evalInteractions(st, sessionID)...)
 	}
 	for _, name := range a.expectTools {
 		if !called[name] {
@@ -228,6 +239,66 @@ func (a checkAssertions) eval(st *store.Store, sessionID string) []string {
 		}
 	}
 	return failures
+}
+
+// evalInteractions judges the two figures underneath a wall-clock duration, the
+// share the server held the operation for and how many requests it took.
+//
+// Both are read off frame timestamps and a link mcpsnoop already inferred, so
+// neither guesses at intent, which is what a check has to be able to say. A tool
+// call that never completed is skipped for the same reason --max-duration skips
+// it: an operation still open has no latency to judge, and the pending signal is
+// what reports it.
+func (a checkAssertions) evalInteractions(st *store.Store, sessionID string) []string {
+	var failures []string
+	slowest, slowestTool, slowCount := time.Duration(0), "", 0
+	mostTrips, tripsTool, tripsCount := 0, "", 0
+	for _, in := range st.Interactions(sessionID) {
+		if in.ToolName == "" {
+			continue
+		}
+		// A round trip count needs no ending. Every request of the chain has already
+		// happened, so a runaway one is countable while it is still running, and
+		// that is the case the budget exists for: a server asking again and again is
+		// exactly the operation nobody ever finishes. Skipping it made the assertion
+		// silent on its own headline case.
+		if a.maxRoundTrips > 0 && in.RoundTrips > a.maxRoundTrips {
+			tripsCount++
+			if in.RoundTrips > mostTrips {
+				mostTrips, tripsTool = in.RoundTrips, in.ToolName
+			}
+		}
+		// A latency does need one, which is the rule --max-duration already applies.
+		// An operation still open has no round trip to judge, a superseded one was
+		// never answered, and a cancelled one without a late result delivered
+		// nothing. The pending signal is what reports those.
+		if !in.Measurable() {
+			continue
+		}
+		if a.maxServerDuration > 0 && in.ServerTime > a.maxServerDuration {
+			slowCount++
+			if in.ServerTime > slowest {
+				slowest, slowestTool = in.ServerTime, in.ToolName
+			}
+		}
+	}
+	if slowCount > 0 {
+		failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %s server budget (worst: tool %q held for %s)",
+			slowCount, callWord(slowCount), a.maxServerDuration, slowestTool, slowest.Round(time.Millisecond)))
+	}
+	if tripsCount > 0 {
+		failures = append(failures, fmt.Sprintf("%d tool %s exceeded the %d round trip budget (worst: tool %q took %d)",
+			tripsCount, callWord(tripsCount), a.maxRoundTrips, tripsTool, mostTrips))
+	}
+	return failures
+}
+
+// callWord picks the noun for a count, so a failure line reads as a sentence.
+func callWord(n int) string {
+	if n == 1 {
+		return "call"
+	}
+	return "calls"
 }
 
 func parseCheckSignals(value string) (map[checkSignal]bool, error) {

--- a/cmd/mcpsnoop/check_test.go
+++ b/cmd/mcpsnoop/check_test.go
@@ -801,3 +801,167 @@ func TestCheckRejectsAnUnknownSignalAndAcceptsEveryKnownOne(t *testing.T) {
 		t.Fatal("an unknown signal must be rejected rather than silently ignored")
 	}
 }
+
+// mrtrCheckLog is the capture from issue #201, encoded for check -. The server
+// works 1.2s in total while the user takes 37s, so the wall clock is 38.2s.
+func mrtrCheckLog(t *testing.T) string {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	envs := make([]proxy.Envelope, 0, len(frames))
+	for i, f := range frames {
+		envs = append(envs, proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Raw: json.RawMessage(f.raw)})
+	}
+	return encodeCheckLog(t, envs...)
+}
+
+// TestCheckServerDurationBlamesTheServerAlone is the reason the flag exists.
+// --max-duration blames a tool for 38.2s of which it is responsible for 1.2s,
+// because the seconds a person spent answering are inside the span. That figure
+// stays what it is, and this one names what it measures.
+func TestCheckServerDurationBlamesTheServerAlone(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := mrtrCheckLog(t)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-server-duration", "1s", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for a server over the budget", code)
+	}
+	if !strings.Contains(stdout, `1 tool call exceeded the 1s server budget (worst: tool "book_flight" held for 1.2s)`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if strings.Contains(stdout, "38.2s") {
+		t.Fatalf("the server budget reported the wall clock:\n%s", stdout)
+	}
+
+	code, stdout, _ = executeCheck(t, []string{"--max-server-duration", "2s", "-"}, log)
+	if code != 0 || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("a server within budget should pass, code %d stdout %q", code, stdout)
+	}
+}
+
+// TestCheckRoundTripsAssertion covers the second sibling, which multi round-trip
+// requests make possible: the specification puts no bound on how many times a
+// server may ask again.
+func TestCheckRoundTripsAssertion(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := mrtrCheckLog(t)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-round-trips", "2", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for a chain over the budget", code)
+	}
+	if !strings.Contains(stdout, `1 tool call exceeded the 2 round trip budget (worst: tool "book_flight" took 3)`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+
+	code, stdout, _ = executeCheck(t, []string{"--max-round-trips", "3", "-"}, log)
+	if code != 0 || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("a chain within budget should pass, code %d stdout %q", code, stdout)
+	}
+}
+
+// TestCheckWallClockIsUnchangedByTheSiblings is the promise the whole flag
+// surface rests on. Nobody's pipeline changes behaviour on upgrade, so
+// --max-duration still means the whole interaction including the human.
+func TestCheckWallClockIsUnchangedByTheSiblings(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	log := mrtrCheckLog(t)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-duration", "5s", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stdout, `1 tool call exceeded the 5s budget (worst: tool "book_flight" took 38.2s)`) {
+		t.Fatalf("--max-duration no longer means wall clock: %q", stdout)
+	}
+
+	// And the new ones are opt in, so a default run over the same capture passes.
+	code, stdout, _ = executeCheck(t, []string{"-"}, log)
+	if code != 0 || !strings.Contains(stdout, "check passed") {
+		t.Fatalf("a default run should be unaffected, code %d stdout %q", code, stdout)
+	}
+}
+
+// TestCheckSiblingsSkipAnOperationWithNoLatency keeps the two new assertions to
+// the same rule --max-duration already applies. An operation still open has no
+// latency to judge, and reporting one would blame a server for a chain the
+// client walked away from.
+func TestCheckSiblingsSkipAnOperationWithNoLatency(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	// A chain the client abandoned after two answers, over an hour of wall clock.
+	log := encodeCheckLog(t,
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0, Direction: proxy.ClientToServer,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book"}}`)},
+		proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Hour), Direction: proxy.ServerToClient,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st","inputRequests":{"q":{"method":"elicitation/create"}}}}`)},
+	)
+	for _, args := range [][]string{
+		{"--max-server-duration", "1ms", "-"},
+		{"--max-round-trips", "1", "-"},
+	} {
+		code, stdout, _ := executeCheck(t, args, log)
+		if code != 0 {
+			t.Fatalf("%v exited %d on an operation that never completed: %s", args, code, stdout)
+		}
+	}
+}
+
+// TestCheckRoundTripsCountsAnUnfinishedChain is the case the assertion exists
+// for. A server asking again and again produces exactly the operation nobody
+// finishes, so gating the count on completion made the budget silent on its own
+// headline case. A latency still needs an ending; a count of requests already
+// made does not.
+func TestCheckRoundTripsCountsAnUnfinishedChain(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"a":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 5000, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"a":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 5400, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"b":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 9000, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"b":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 9400, `{"jsonrpc":"2.0","id":3,"result":{"resultType":"input_required","requestState":"st-3","inputRequests":{"c":{"method":"elicitation/create"}}}}`},
+	}
+	envs := make([]proxy.Envelope, 0, len(frames))
+	for i, f := range frames {
+		envs = append(envs, proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir, Raw: json.RawMessage(f.raw)})
+	}
+	log := encodeCheckLog(t, envs...)
+
+	code, stdout, _ := executeCheck(t, []string{"--max-round-trips", "2", "-"}, log)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; the chain took three requests and nobody finished it\n%s", code, stdout)
+	}
+	if !strings.Contains(stdout, `exceeded the 2 round trip budget (worst: tool "book_flight" took 3)`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+
+	// A latency, by contrast, still needs an ending, so the server budget stays
+	// quiet on the same capture.
+	code, stdout, _ = executeCheck(t, []string{"--max-server-duration", "1ms", "-"}, log)
+	if code != 0 {
+		t.Fatalf("the server budget judged an operation that never completed, code %d: %s", code, stdout)
+	}
+}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -47,6 +47,50 @@ type SessionExport struct {
 	// answered. Absent from a session that saw none, so an ordinary export is
 	// unchanged.
 	Elicitations []ElicitationExport `json:"elicitations,omitempty"`
+	// Interactions is one entry per logical operation, with the per-hop breakdown
+	// of a multi round-trip chain. A call with no retry is a one hop interaction,
+	// so this describes every operation uniformly.
+	Interactions []InteractionExport `json:"interactions,omitempty"`
+}
+
+// InteractionExport is one logical operation, however many requests it took.
+type InteractionExport struct {
+	CallIndex *int   `json:"call_index,omitempty"`
+	CallID    string `json:"call_id"`
+	Method    string `json:"method"`
+	ToolName  string `json:"tool_name,omitempty"`
+	State     string `json:"state"`
+	// RoundTrips is how many requests the operation took. ServerTimeMS is how long
+	// the server held it across all of them and ClientTurnaroundMS is the rest,
+	// mostly a person deciding. The two sum to DurationMS by construction.
+	RoundTrips         int       `json:"round_trips"`
+	ServerTimeMS       float64   `json:"server_time_ms"`
+	ClientTurnaroundMS float64   `json:"client_turnaround_ms"`
+	DurationMS         float64   `json:"duration_ms"`
+	StartedAt          time.Time `json:"started_at"`
+	// Hops is the per-hop breakdown. HopsComplete is false when the store no
+	// longer holds every frame, which a live one does to stay inside its budget,
+	// so a partial breakdown is never read as the whole operation.
+	Hops         []HopExport `json:"hops,omitempty"`
+	HopsComplete bool        `json:"hops_complete"`
+}
+
+// HopExport is one request and its answer inside an interaction.
+type HopExport struct {
+	RequestID  string     `json:"request_id"`
+	RequestAt  time.Time  `json:"request_at"`
+	ResponseAt *time.Time `json:"response_at,omitempty"`
+	// ServerTimeMS is this hop alone and ClientTurnaroundMS the wait before it,
+	// zero on the first since nothing preceded it.
+	ServerTimeMS       float64 `json:"server_time_ms"`
+	ClientTurnaroundMS float64 `json:"client_turnaround_ms"`
+	// Asked names what this hop's answer asked the client for, sorted, and is
+	// absent on a hop that finished the operation. AskedUnknown separates that from
+	// a hop whose answer is no longer readable, which a live store produces by
+	// releasing frame bodies.
+	Asked        []string `json:"asked,omitempty"`
+	AskedUnknown bool     `json:"asked_unknown,omitempty"`
+	Pending      bool     `json:"pending,omitempty"`
 }
 
 // ElicitationExport is one question a server put to the user through the client.
@@ -202,6 +246,13 @@ type CallExport struct {
 	CancelReason string          `json:"cancel_reason,omitempty"`
 	LateResult   bool            `json:"late_result,omitempty"`
 	DurationMS   *float64        `json:"duration_ms,omitempty"`
+	// RoundTrips is how many requests this operation took, and ServerTimeMS the
+	// share of DurationMS the server held it for. Under multi round-trip requests
+	// one call is several requests and the time a person spent answering sits
+	// inside the duration, so a record carrying only the total implies the server
+	// was busy for all of it. Absent on an operation with no measured hops.
+	RoundTrips   int             `json:"round_trips,omitempty"`
+	ServerTimeMS *float64        `json:"server_time_ms,omitempty"`
 	Params       json.RawMessage `json:"params,omitempty"`
 	Result       json.RawMessage `json:"result,omitempty"`
 	Error        *proxy.RPCError `json:"error,omitempty"`
@@ -539,6 +590,50 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 		outEvents = append(outEvents, exportEvent(ev, callIndex))
 	}
 
+	interactions := st.Interactions(sessionID)
+	// Indexed by the call each one belongs to, so a per-call record can say how
+	// many requests it took and how much of its duration was the server.
+	byCall := make(map[uint64]store.InteractionView, len(interactions))
+	outInteractions := make([]InteractionExport, 0, len(interactions))
+	for _, in := range interactions {
+		byCall[in.CallSeq] = in
+		row := InteractionExport{
+			CallID: in.CallID, Method: in.Method, ToolName: in.ToolName,
+			State:        in.State.String(),
+			RoundTrips:   in.RoundTrips,
+			ServerTimeMS: durationMS(in.ServerTime), ClientTurnaroundMS: durationMS(in.ClientTurnaround),
+			DurationMS: durationMS(in.Duration), StartedAt: in.Start,
+			HopsComplete: in.HopsComplete,
+		}
+		if idx, ok := callIndex[strconv.FormatUint(in.CallSeq, 10)]; ok {
+			row.CallIndex = &idx
+		}
+		for _, h := range in.Hops {
+			hop := HopExport{
+				RequestID: h.RequestID, RequestAt: h.RequestAt,
+				ServerTimeMS: durationMS(h.ServerTime), ClientTurnaroundMS: durationMS(h.ClientTurnaround),
+				Asked: h.Asked, AskedUnknown: h.AskedUnknown, Pending: h.Pending,
+			}
+			if !h.ResponseAt.IsZero() {
+				at := h.ResponseAt
+				hop.ResponseAt = &at
+			}
+			row.Hops = append(row.Hops, hop)
+		}
+		outInteractions = append(outInteractions, row)
+	}
+	for i := range outCalls {
+		in, ok := byCall[calls[i].RequestSeq]
+		if !ok {
+			continue
+		}
+		outCalls[i].RoundTrips = in.RoundTrips
+		if in.ServerTime > 0 || in.RoundTrips > 1 {
+			ms := durationMS(in.ServerTime)
+			outCalls[i].ServerTimeMS = &ms
+		}
+	}
+
 	elicitations := st.Elicitations(sessionID)
 	outElicitations := make([]ElicitationExport, 0, len(elicitations))
 	for _, e := range elicitations {
@@ -583,6 +678,7 @@ func Build(st *store.Store, sessionID string) (SessionExport, error) {
 		Calls:        outCalls,
 		Events:       outEvents,
 		Elicitations: outElicitations,
+		Interactions: outInteractions,
 	}
 	if summary, ok := st.ToolSummary(sessionID); ok {
 		out.Summary = exportToolSummary(summary)
@@ -1111,6 +1207,63 @@ func writeText(w io.Writer, data SessionExport) error {
 	if err != nil {
 		return err
 	}
+	if len(data.Interactions) > 0 {
+		chained := 0
+		for _, in := range data.Interactions {
+			if in.RoundTrips > 1 {
+				chained++
+			}
+		}
+		if chained > 0 {
+			if _, err := fmt.Fprintln(w, "interactions:"); err != nil {
+				return err
+			}
+			for _, in := range data.Interactions {
+				if in.RoundTrips <= 1 {
+					continue // an ordinary call is already a line above
+				}
+				who := in.Method
+				if in.ToolName != "" {
+					who = in.Method + " " + in.ToolName
+				}
+				if _, err := fmt.Fprintf(w, "  %s: %d round trips, %s total, %s server, %s client\n",
+					oneLine(who), in.RoundTrips,
+					msDuration(in.DurationMS), msDuration(in.ServerTimeMS), msDuration(in.ClientTurnaroundMS)); err != nil {
+					return err
+				}
+				for i, hop := range in.Hops {
+					asked := ""
+					if len(hop.Asked) > 0 {
+						asked = "  asked " + oneLine(strings.Join(hop.Asked, ", "))
+					}
+					state := ""
+					if hop.Pending {
+						state = "  (no answer)"
+					}
+					if _, err := fmt.Fprintf(w, "    hop %d id=%s  %s server", i+1, oneLine(hop.RequestID), msDuration(hop.ServerTimeMS)); err != nil {
+						return err
+					}
+					if hop.ClientTurnaroundMS > 0 {
+						if _, err := fmt.Fprintf(w, ", %s waiting on the client", msDuration(hop.ClientTurnaroundMS)); err != nil {
+							return err
+						}
+					}
+					if _, err := fmt.Fprintf(w, "%s%s\n", asked, state); err != nil {
+						return err
+					}
+				}
+				if !in.HopsComplete {
+					if _, err := fmt.Fprintf(w, "    (%d of %d hops still held, the rest were released to stay inside the memory budget)\n",
+						len(in.Hops), in.RoundTrips); err != nil {
+						return err
+					}
+				}
+			}
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+	}
 	if len(data.Elicitations) > 0 {
 		if _, err := fmt.Fprintln(w, "elicitations:"); err != nil {
 			return err
@@ -1356,4 +1509,10 @@ func oneLine(s string) string {
 		return strconv.Quote(s)
 	}
 	return s
+}
+
+// msDuration renders a millisecond figure the way the rest of the text export
+// renders a duration, so a reader is not comparing two spellings.
+func msDuration(ms float64) string {
+	return time.Duration(ms * float64(time.Millisecond)).Round(time.Millisecond).String()
 }

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1814,3 +1814,291 @@ func TestElicitationCallIndexIsAbsentRatherThanNegative(t *testing.T) {
 		t.Fatalf("an unresolved index is present rather than absent:\n%s", buf.String())
 	}
 }
+
+// writeMRTRCapture writes the capture from issue #201: a three hop book_flight
+// chain where the server works 1.2s and the user takes 37s, plus one ordinary
+// call for contrast.
+func writeMRTRCapture(t *testing.T, path string) {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	var buf bytes.Buffer
+	for i, f := range frames {
+		b, err := json.Marshal(proxy.Envelope{SessionID: "demo", ServerLabel: "booking", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestExportCarriesTheInteractions covers the json shape and the two fields the
+// per-call record gains, so a consumer stops reading the whole duration as
+// server work.
+func TestExportCarriesTheInteractions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mrtr.jsonl")
+	writeMRTRCapture(t, path)
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data.Interactions) != 2 {
+		t.Fatalf("interactions = %d, want one per operation: %+v", len(data.Interactions), data.Interactions)
+	}
+	var book InteractionExport
+	for _, in := range data.Interactions {
+		if in.ToolName == "book_flight" {
+			book = in
+		}
+	}
+	if book.RoundTrips != 3 || book.ServerTimeMS != 1200 || book.ClientTurnaroundMS != 37000 || book.DurationMS != 38200 {
+		t.Fatalf("book_flight = %+v", book)
+	}
+	if book.ServerTimeMS+book.ClientTurnaroundMS != book.DurationMS {
+		t.Fatalf("the two shares do not add up: %+v", book)
+	}
+	if len(book.Hops) != 3 || !book.HopsComplete {
+		t.Fatalf("hops = %d complete=%v", len(book.Hops), book.HopsComplete)
+	}
+	if book.Hops[1].ClientTurnaroundMS != 12000 || book.Hops[1].ServerTimeMS != 300 {
+		t.Fatalf("hop 2 = %+v", book.Hops[1])
+	}
+	if book.CallIndex == nil || data.Calls[*book.CallIndex].ID != book.CallID {
+		t.Fatalf("call_index %v does not point at call %q", book.CallIndex, book.CallID)
+	}
+
+	for _, c := range data.Calls {
+		if c.ToolName != "book_flight" {
+			continue
+		}
+		if c.RoundTrips != 3 || c.ServerTimeMS == nil || *c.ServerTimeMS != 1200 {
+			t.Fatalf("the call record does not carry its share: %+v", c)
+		}
+		if c.DurationMS == nil || *c.DurationMS != 38200 {
+			t.Fatalf("the wall clock changed: %+v", c.DurationMS)
+		}
+	}
+
+	for _, format := range []Format{FormatJSON, FormatText, FormatHTML} {
+		var buf bytes.Buffer
+		if err := Write(&buf, data, Options{Format: format}); err != nil {
+			t.Fatalf("%s: %v", format, err)
+		}
+		if !strings.Contains(buf.String(), "book_flight") {
+			t.Fatalf("%s does not name the chained operation", format)
+		}
+	}
+	var text bytes.Buffer
+	if err := Write(&text, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text.String(), "3 round trips, 38.2s total, 1.2s server, 37s client") {
+		t.Fatalf("the text export does not split the total:\n%s", text.String())
+	}
+}
+
+// TestHARSplitsWaitFromBlocked stops a viewer drawing a server that was busy for
+// the whole interaction. HAR keeps wait for the server and blocked for time the
+// entry spent waiting on something else, which here is a person answering.
+func TestHARSplitsWaitFromBlocked(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mrtr.jsonl")
+	writeMRTRCapture(t, path)
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := WriteHAR(&buf, data); err != nil {
+		t.Fatal(err)
+	}
+	var har struct {
+		Log struct {
+			Entries []struct {
+				Time    float64 `json:"time"`
+				Request struct {
+					URL string `json:"url"`
+				} `json:"request"`
+				Timings struct {
+					Blocked float64 `json:"blocked"`
+					Send    float64 `json:"send"`
+					Wait    float64 `json:"wait"`
+					Receive float64 `json:"receive"`
+				} `json:"timings"`
+			} `json:"entries"`
+		} `json:"log"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &har); err != nil {
+		t.Fatalf("the HAR does not parse: %v", err)
+	}
+	if len(har.Log.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(har.Log.Entries))
+	}
+	for _, e := range har.Log.Entries {
+		sum := e.Timings.Send + e.Timings.Wait + e.Timings.Receive
+		if e.Timings.Blocked > 0 {
+			sum += e.Timings.Blocked
+		}
+		if sum != e.Time {
+			t.Fatalf("%s: timings sum to %v against a time of %v", e.Request.URL, sum, e.Time)
+		}
+		if !strings.Contains(e.Request.URL, "book_flight") {
+			continue
+		}
+		if e.Timings.Wait != 1200 {
+			t.Fatalf("wait = %v, want the 1.2s the server held it", e.Timings.Wait)
+		}
+		if e.Timings.Blocked != 37000 {
+			t.Fatalf("blocked = %v, want the 37s the client took", e.Timings.Blocked)
+		}
+	}
+}
+
+// TestAnOrdinaryExportGainsNoInteractionsSection keeps a capture with no chain
+// unchanged, since every operation there is already one line.
+func TestAnOrdinaryExportGainsNoInteractionsSection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plain.jsonl")
+	writeEnv(t, path, proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 1, TS: time.Now(),
+		Direction: proxy.ClientToServer, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"t"}}`)})
+	writeEnv(t, path, proxy.Envelope{SessionID: "s1", ServerLabel: "demo", Seq: 2, TS: time.Now().Add(time.Millisecond),
+		Direction: proxy.ServerToClient, Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`)})
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatText}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "interactions:") {
+		t.Fatalf("a capture with no chain gained a section:\n%s", buf.String())
+	}
+	if len(data.Interactions) != 1 || data.Interactions[0].RoundTrips != 1 {
+		t.Fatalf("an ordinary call is still a one hop interaction: %+v", data.Interactions)
+	}
+}
+
+// TestHARNeverEmitsAnIllegalBlocked covers the entries HAR 1.2 constrains most.
+// An operation with no exportable duration used to report a negative blocked,
+// which is not the -1 sentinel and is the one negative the format forbids
+// elsewhere.
+func TestHARNeverEmitsAnIllegalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	full := filepath.Join(dir, "full.jsonl")
+	writeMRTRCapture(t, full)
+	// The same capture cut while the user is still answering, which MRTR makes an
+	// ordinary outcome rather than damage.
+	body, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.SplitN(string(body), "\n", 5)
+	abandoned := filepath.Join(dir, "abandoned.jsonl")
+	if err := os.WriteFile(abandoned, []byte(strings.Join(lines[:4], "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{full, abandoned} {
+		st, id, err := LoadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := Build(st, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		if err := WriteHAR(&buf, data); err != nil {
+			t.Fatal(err)
+		}
+		var har struct {
+			Log struct {
+				Entries []struct {
+					Time    float64 `json:"time"`
+					Timings struct {
+						Blocked float64 `json:"blocked"`
+						Send    float64 `json:"send"`
+						Wait    float64 `json:"wait"`
+						Receive float64 `json:"receive"`
+					} `json:"timings"`
+				} `json:"entries"`
+			} `json:"log"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &har); err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range har.Log.Entries {
+			tm := e.Timings
+			if tm.Blocked < 0 && tm.Blocked != -1 {
+				t.Fatalf("%s: blocked = %v, and the only negative HAR allows is -1", filepath.Base(path), tm.Blocked)
+			}
+			for name, v := range map[string]float64{"send": tm.Send, "wait": tm.Wait, "receive": tm.Receive} {
+				if v < 0 {
+					t.Fatalf("%s: %s = %v, which HAR never allows to be negative", filepath.Base(path), name, v)
+				}
+			}
+			if tm.Wait > e.Time {
+				t.Fatalf("%s: wait %v is larger than the entry time %v", filepath.Base(path), tm.Wait, e.Time)
+			}
+		}
+	}
+}
+
+// TestHopsCarryWhetherAnAnswerWasReadable keeps an unreadable hop apart from one
+// that asked for nothing, which is what a released frame body produces.
+func TestHopsCarryWhetherAnAnswerWasReadable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mrtr.jsonl")
+	writeMRTRCapture(t, path)
+	st, id, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := Build(st, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, data, Options{Format: FormatJSON}); err != nil {
+		t.Fatal(err)
+	}
+	// A batch read holds every body, so nothing is unknown and the key stays out.
+	if strings.Contains(buf.String(), "asked_unknown") {
+		t.Fatalf("a complete capture reports an unreadable hop:\n%s", buf.String()[:600])
+	}
+	for _, in := range data.Interactions {
+		for _, h := range in.Hops {
+			if h.AskedUnknown {
+				t.Fatalf("hop %s is marked unreadable in a batch read", h.RequestID)
+			}
+		}
+	}
+}

--- a/internal/exporter/har.go
+++ b/internal/exporter/har.go
@@ -77,6 +77,13 @@ type harResponse struct {
 type harCache struct{}
 
 type harTimings struct {
+	// Blocked is time the entry spent waiting on something other than the server.
+	// Under multi round-trip requests that is the client gathering an answer from
+	// a person, which is what the field is for, and putting it in wait drew a
+	// server that had been busy for the whole interaction. A one hop call reports
+	// zero, since nothing blocked it, and -1, which HAR 1.2 reserves for a timing
+	// that does not apply, is used only when there is no split to report at all.
+	Blocked float64 `json:"blocked"`
 	Send    float64 `json:"send"`
 	Wait    float64 `json:"wait"`
 	Receive float64 `json:"receive"`
@@ -128,11 +135,28 @@ func WriteHAR(w io.Writer, data SessionExport) error {
 	for _, call := range data.Calls {
 		status, statusText := harStatus(call.Status)
 
-		// Only the total round trip is known, so it all lands in wait, and time is
-		// the sum of the three. An unanswered call has no round trip, so it stays 0.
+		// time is the whole interaction, split between the server and whatever the
+		// client was doing between hops. An unanswered call has no round trip, so it
+		// stays 0.
 		var durationMS float64
 		if call.DurationMS != nil {
 			durationMS = *call.DurationMS
+		}
+		// wait is the server's share and blocked is the rest. Without the split a
+		// viewer drew a thirty-eight second server wait for an operation the server
+		// spent one second on, with the other thirty-seven belonging to a person
+		// answering an elicitation. An operation with no measured share reports -1,
+		// which is how HAR 1.2 spells a timing that does not apply.
+		// The split needs a duration large enough to contain the server's share. An
+		// operation with no exportable duration, which is every pending, superseded
+		// and cancelled one, has zero here, so subtracting a server share that is
+		// real produced a negative blocked. HAR 1.2 allows exactly one negative,
+		// the -1 that means the timing does not apply, so that is what such an entry
+		// reports.
+		wait, blocked := durationMS, float64(-1)
+		if call.ServerTimeMS != nil && *call.ServerTimeMS <= durationMS {
+			wait = *call.ServerTimeMS
+			blocked = durationMS - wait
 		}
 
 		request := harRequest{
@@ -166,7 +190,7 @@ func WriteHAR(w io.Writer, data SessionExport) error {
 				BodySize:    len(body),
 			},
 			Cache:   harCache{},
-			Timings: harTimings{Send: 0, Wait: durationMS, Receive: 0},
+			Timings: harTimings{Blocked: blocked, Send: 0, Wait: wait, Receive: 0},
 		})
 	}
 

--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -94,6 +94,35 @@ document.getElementById("summary").innerHTML = [
   ["Late results", data.session.late_results],
   ["Protocol", data.capabilities?.protocol_version || ""]
 ].map(([k,v]) => "<div class=\"pill\">" + esc(k) + "<br><b>" + esc(v) + "</b></div>").join("");
+const chained = (data.interactions || []).filter(i => i.round_trips > 1);
+if (chained.length) {
+  const block = document.createElement("div");
+  block.innerHTML = "<div class=\"section-title\">Interactions</div>" +
+    "<div class=\"dim\">Operations that took more than one request. Under multi round-trip requests " +
+    "the time a person spent answering sits inside the total, so the server's own share is separated out.</div>";
+  const list = document.createElement("div");
+  list.className = "grid";
+  const ms = (v) => v >= 1000 ? (v / 1000).toFixed(1) + "s" : Math.round(v) + "ms";
+  for (const i of chained) {
+    const who = esc(i.tool_name ? i.method + " " + i.tool_name : i.method);
+    const hops = (i.hops || []).map((h, n) =>
+      "hop " + (n + 1) + " <span class=\"dim\">id " + esc(h.request_id) + "</span> " + ms(h.server_time_ms) + " server" +
+      (h.client_turnaround_ms > 0 ? ", " + ms(h.client_turnaround_ms) + " waiting on the client" : "") +
+      ((h.asked || []).length ? " <span class=\"dim\">asked " + esc(h.asked.join(", ")) + "</span>" : "") +
+      (h.pending ? " <span class=\"dim\">(no answer)</span>" : "")).join("<br>");
+    const card = document.createElement("div");
+    card.className = "pill";
+    card.innerHTML = who + " <span class=\"dim\">" + i.round_trips + " round trips</span><br>" +
+      "<b>" + ms(i.duration_ms) + "</b> total, " + ms(i.server_time_ms) + " server, " +
+      ms(i.client_turnaround_ms) + " client" +
+      (hops ? "<br>" + hops : "") +
+      (i.hops_complete === false ? "<br><span class=\"dim\">" + (i.hops || []).length + " of " +
+        i.round_trips + " hops still held</span>" : "");
+    list.appendChild(card);
+  }
+  block.appendChild(list);
+  document.getElementById("summary").after(block);
+}
 if ((data.elicitations || []).length) {
   const block = document.createElement("div");
   block.innerHTML = "<div class=\"section-title\">Elicitations</div>" +

--- a/internal/store/interaction.go
+++ b/internal/store/interaction.go
@@ -1,0 +1,241 @@
+package store
+
+import (
+	"bytes"
+	"slices"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// InteractionView is one logical operation, however many requests it took on the
+// wire.
+//
+// Under multi round-trip requests a tool call can be several requests, each with
+// its own JSON-RPC id, because the specification says the id "MUST be different
+// between the initial request and the retry, as they are independent requests".
+// A call with no retry is a one hop interaction, so this describes every
+// operation uniformly rather than only the chained ones.
+type InteractionView struct {
+	// CallID is the id of the request that opened the operation, and CallSeq the
+	// sequence of that frame, which is what the exporter indexes calls by.
+	CallSeq  uint64
+	CallID   string
+	Method   string
+	ToolName string
+	// RoundTrips is how many requests the operation took. One means no retry.
+	RoundTrips int
+	// ServerTime is how long the server held the operation across every hop, and
+	// ClientTurnaround the rest, which is the time between an answer arriving and
+	// the client coming back, mostly a person deciding. They sum to Duration by
+	// construction rather than by arithmetic anyone has to trust.
+	ServerTime       time.Duration
+	ClientTurnaround time.Duration
+	Duration         time.Duration
+	Start            time.Time
+	State            CallState
+	Errored          bool
+	// LateResult marks a cancelled operation whose answer arrived anyway, which is
+	// what makes its timing real rather than a stub.
+	LateResult bool
+	// Hops is the per-hop breakdown, newest last, and is built only for an
+	// operation that took more than one request. A single hop's breakdown is the
+	// totals above it word for word, so producing one would restate them and, on a
+	// session of twenty thousand ordinary calls, allocate twenty thousand slices to
+	// do it, under the read lock a live panel holds.
+	//
+	// It is derived from the frames still held, so a live store that has released
+	// old ones reports fewer hops than RoundTrips counts. HopsComplete says which
+	// case this is, because a partial breakdown that looked whole would understate
+	// an operation rather than declining to describe it.
+	Hops         []HopView
+	HopsComplete bool
+	// swapped records that this operation's request came from the server, so the
+	// walk knows to swap each hop the way the totals already are.
+	swapped bool
+}
+
+// Done reports whether the operation is no longer open, the same question
+// CallView.Done answers about a single request.
+func (i InteractionView) Done() bool { return i.State != Pending && i.State != Streaming }
+
+// Measurable reports whether this operation has a latency worth judging, which
+// is the rule --max-duration already applies to a call. An operation still open
+// has none, a superseded one was never answered, and a cancelled one without a
+// late result delivered nothing.
+func (i InteractionView) Measurable() bool {
+	return i.Done() && i.State != Superseded && (i.State != Cancelled || i.LateResult)
+}
+
+// HopView is one request and its answer inside an interaction.
+type HopView struct {
+	// RequestID is the JSON-RPC id of this hop, which differs from the others by
+	// specification.
+	RequestID  string
+	RequestAt  time.Time
+	ResponseAt time.Time
+	// ServerTime is this hop alone, and ClientTurnaround is the wait before it,
+	// zero on the first hop since nothing preceded it.
+	ServerTime       time.Duration
+	ClientTurnaround time.Duration
+	// Asked names the server-to-client requests this hop's answer carried, sorted,
+	// and is empty on a hop that finished the operation. AskedUnknown separates
+	// that from a hop whose answer is no longer readable, which a live store
+	// produces by releasing frame bodies to stay inside its byte budget: the frame
+	// is still there and its timing is still exact, so the breakdown is complete
+	// and only this one field is not.
+	Asked        []string
+	AskedUnknown bool
+	// Pending marks a hop whose answer never arrived.
+	Pending bool
+}
+
+// Interactions returns one entry per operation in the session, oldest first.
+//
+// The counts and the two totals come from the call, which accumulates them as
+// frames arrive, so they are exact whatever the store has since released. The
+// per-hop breakdown is read from the frames still held, which is the whole log
+// on a batch read and a window on a live one.
+func (s *Store) Interactions(sessionID string) []InteractionView {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil
+	}
+
+	// One pass, one map. Grouping the frames first and then walking each group
+	// allocated a slice per call, and this runs under the read lock while the live
+	// panel rebuilds on a timer, so every allocation here is one the ingest path
+	// waits behind.
+	out := make([]InteractionView, 0, 16)
+	at := make(map[*call]int, 16)
+	// lastResponse is where each entry's previous hop ended, which is what the
+	// next hop's wait is measured from.
+	lastResponse := make([]time.Time, 0, 16)
+	for _, ev := range sess.events {
+		if ev.call == nil {
+			continue
+		}
+		i, known := at[ev.call]
+		switch ev.kind {
+		case EventRequest:
+			if !known {
+				i = len(out)
+				at[ev.call] = i
+				out = append(out, interactionOf(ev.call))
+				lastResponse = append(lastResponse, time.Time{})
+			}
+			if out[i].RoundTrips < 2 {
+				continue // one hop, and its breakdown is the totals already recorded
+			}
+			hop := HopView{RequestID: ev.id, RequestAt: ev.ts, Pending: true}
+			if prev := lastResponse[i]; !prev.IsZero() && ev.ts.After(prev) {
+				hop.ClientTurnaround = ev.ts.Sub(prev)
+			}
+			out[i].Hops = append(out[i].Hops, hop)
+		case EventResponse:
+			if !known || out[i].RoundTrips < 2 || len(out[i].Hops) == 0 {
+				continue // the request that opened this hop is no longer held
+			}
+			hop := &out[i].Hops[len(out[i].Hops)-1]
+			if !hop.Pending {
+				continue // already answered, a duplicate or late response
+			}
+			hop.ResponseAt, hop.Pending = ev.ts, false
+			if ev.ts.After(hop.RequestAt) {
+				hop.ServerTime = ev.ts.Sub(hop.RequestAt)
+			}
+			hop.Asked, hop.AskedUnknown = askedOf(ev)
+			lastResponse[i] = ev.ts
+		}
+	}
+
+	for i := range out {
+		if out[i].swapped {
+			for h := range out[i].Hops {
+				hop := &out[i].Hops[h]
+				hop.ServerTime, hop.ClientTurnaround = hop.ClientTurnaround, hop.ServerTime
+			}
+		}
+		// Complete means the breakdown accounts for the totals, not merely that the
+		// hop count matches. Work can settle off the request and response pair a hop
+		// is made of, a task handle being the plain case, and a breakdown adding up
+		// to a hundred milliseconds must not describe itself as the whole of a
+		// thirty second operation.
+		var hopServer, hopClient time.Duration
+		for _, h := range out[i].Hops {
+			hopServer += h.ServerTime
+			hopClient += h.ClientTurnaround
+		}
+		if out[i].RoundTrips < 2 {
+			// Nothing to be incomplete about. The totals are the whole description of
+			// an operation that took one request.
+			out[i].HopsComplete = true
+			continue
+		}
+		out[i].HopsComplete = len(out[i].Hops) == out[i].RoundTrips &&
+			hopServer == out[i].ServerTime && hopClient == out[i].ClientTurnaround
+	}
+	return out
+}
+
+// interactionOf builds the totals of one operation from the call that carries
+// them. The hops are filled in by the walk, since they come from frames.
+func interactionOf(c *call) InteractionView {
+	server, client := c.serverTime, c.clientTime
+	swapped := c.reqDir == proxy.ServerToClient
+	if swapped {
+		// A request the server sent is answered by the client, so the interval
+		// between them is the client's and the gap between hops is the server's.
+		// Every revision from 2026-07-28 routes these through MRTR instead, so this
+		// is an older capture or a deprecated shape, and reporting the client's work
+		// under a field named for the server would be wrong in the one place it is
+		// still possible.
+		server, client = client, server
+	}
+	return InteractionView{
+		CallSeq: c.requestSeq, CallID: c.id, Method: c.method, ToolName: c.toolName,
+		RoundTrips:       c.hops,
+		ServerTime:       server,
+		ClientTurnaround: client,
+		// The span the two intervals cover, not the clock since the request. A chain
+		// nobody finished has an open interval that grows with the current time, and
+		// reporting that would make the total disagree with its own parts.
+		Duration: server + client,
+		Start:    c.start, State: c.state, Errored: c.errored, LateResult: c.lateResult,
+		swapped: swapped,
+	}
+}
+
+// askedOf names what an answer asked the client for, sorted so two captures
+// compare. unknown is true when the frame's body is no longer held, which a live
+// store does to stay inside its byte budget, so a hop whose answer cannot be read
+// is told apart from one that asked for nothing.
+func askedOf(ev *event) (asked []string, unknown bool) {
+	if ev.bodyReleased {
+		return nil, true
+	}
+	if len(ev.raw) == 0 {
+		return nil, false
+	}
+	// A substring scan before a decode. Only an InputRequiredResult can name
+	// anything here, and its resultType is that literal, so a frame without those
+	// bytes cannot be one. Decoding every response instead cost a full unmarshal of
+	// each body, which on a live session of forty thousand frames took longer than
+	// the interval the panel refreshes on, so the panel could never keep up and
+	// held the store's read lock while it failed to. A false positive costs one
+	// decode that correctly answers nothing.
+	if !bytes.Contains(ev.raw, []byte(`"input_required"`)) {
+		return nil, false
+	}
+	msg, ok := proxy.ParseRPC(ev.raw)
+	if !ok {
+		return nil, false
+	}
+	state, ok := parseInputRequired(msg.Result)
+	if !ok || len(state.methods) == 0 {
+		return nil, false
+	}
+	return slices.Clone(state.methods), false
+}

--- a/internal/store/interaction_test.go
+++ b/internal/store/interaction_test.go
@@ -1,0 +1,490 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// mrtrFixture is the capture from issue #201: one book_flight chain of three
+// hops where the server works 0.4s, 0.3s and 0.5s while the user takes 12s and
+// then 25s, followed by an ordinary fast call for contrast.
+func mrtrFixture(t *testing.T, s *Store, upTo int) {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight","arguments":{"to":"JFK"}}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create","params":{"message":"Confirm $840?"}}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","arguments":{"to":"JFK"},"requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create","params":{"message":"Window or aisle?"}}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","arguments":{"to":"JFK"},"requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"booked"}]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	if upTo <= 0 || upTo > len(frames) {
+		upTo = len(frames)
+	}
+	for i, f := range frames[:upTo] {
+		s.Ingest(proxy.Envelope{SessionID: "demo", ServerLabel: "booking", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+	}
+}
+
+func interactionFor(t *testing.T, s *Store, tool string) InteractionView {
+	t.Helper()
+	for _, in := range s.Interactions("demo") {
+		if in.ToolName == tool {
+			return in
+		}
+	}
+	t.Fatalf("no interaction for %q in %+v", tool, s.Interactions("demo"))
+	return InteractionView{}
+}
+
+// TestInteractionsSplitServerTimeFromHumanTime is the whole feature, on the
+// capture the issue is written around. The server spent 1.2s and the user spent
+// 37s, and until now both landed in one 38.2s scalar.
+func TestInteractionsSplitServerTimeFromHumanTime(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 0)
+
+	book := interactionFor(t, s, "book_flight")
+	if book.RoundTrips != 3 {
+		t.Fatalf("round trips = %d, want 3", book.RoundTrips)
+	}
+	if book.ServerTime != 1200*time.Millisecond {
+		t.Fatalf("server time = %v, want 1.2s", book.ServerTime)
+	}
+	if book.ClientTurnaround != 37*time.Second {
+		t.Fatalf("client turnaround = %v, want 37s", book.ClientTurnaround)
+	}
+
+	quick := interactionFor(t, s, "lookup_price")
+	if quick.RoundTrips != 1 || quick.ServerTime != 200*time.Millisecond || quick.ClientTurnaround != 0 {
+		t.Fatalf("an ordinary call = %d trips, %v server, %v client; want 1, 200ms, 0",
+			quick.RoundTrips, quick.ServerTime, quick.ClientTurnaround)
+	}
+}
+
+// TestTheTwoSharesAlwaysAddUp is the invariant that makes the split trustworthy.
+// It holds by construction rather than by arithmetic anyone has to check, since
+// the intervals telescope from the first request to the last response.
+func TestTheTwoSharesAlwaysAddUp(t *testing.T) {
+	for _, upTo := range []int{2, 4, 6, 8} {
+		t.Run(fmt.Sprintf("through frame %d", upTo), func(t *testing.T) {
+			s := New()
+			mrtrFixture(t, s, upTo)
+			for _, in := range s.Interactions("demo") {
+				if got := in.ServerTime + in.ClientTurnaround; got != in.Duration {
+					t.Fatalf("%s: %v server + %v client = %v, want the %v duration",
+						in.ToolName, in.ServerTime, in.ClientTurnaround, got, in.Duration)
+				}
+			}
+		})
+	}
+}
+
+// TestEveryHopIsMeasuredSeparately covers the breakdown underneath the totals.
+func TestEveryHopIsMeasuredSeparately(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 0)
+	book := interactionFor(t, s, "book_flight")
+	if !book.HopsComplete || len(book.Hops) != 3 {
+		t.Fatalf("hops = %d complete=%v, want all three", len(book.Hops), book.HopsComplete)
+	}
+	for i, want := range []struct {
+		id     string
+		server time.Duration
+		wait   time.Duration
+		asked  int
+	}{
+		{"1", 400 * time.Millisecond, 0, 1},
+		{"2", 300 * time.Millisecond, 12 * time.Second, 1},
+		{"3", 500 * time.Millisecond, 25 * time.Second, 0},
+	} {
+		got := book.Hops[i]
+		if got.RequestID != want.id || got.ServerTime != want.server || got.ClientTurnaround != want.wait {
+			t.Fatalf("hop %d = id %s, %v server, %v wait; want id %s, %v, %v",
+				i+1, got.RequestID, got.ServerTime, got.ClientTurnaround, want.id, want.server, want.wait)
+		}
+		if len(got.Asked) != want.asked {
+			t.Fatalf("hop %d asked %v, want %d entries", i+1, got.Asked, want.asked)
+		}
+		if got.Pending {
+			t.Fatalf("hop %d reads as unanswered", i+1)
+		}
+	}
+	// The per-hop shares are the totals, taken apart.
+	var server, client time.Duration
+	for _, h := range book.Hops {
+		server += h.ServerTime
+		client += h.ClientTurnaround
+	}
+	if server != book.ServerTime || client != book.ClientTurnaround {
+		t.Fatalf("hops sum to %v/%v against totals %v/%v", server, client, book.ServerTime, book.ClientTurnaround)
+	}
+}
+
+// TestAnAbandonedChainReportsWhatItSaw covers the fixture cut after the second
+// answer. MRTR makes an abandoned chain ordinary, since a server must not assume
+// a client will retry, so the view reports the hops observed and invents none.
+func TestAnAbandonedChainReportsWhatItSaw(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 4)
+	book := interactionFor(t, s, "book_flight")
+	if book.RoundTrips != 2 {
+		t.Fatalf("round trips = %d, want the 2 that happened", book.RoundTrips)
+	}
+	if book.State != Pending {
+		t.Fatalf("state = %v, want pending", book.State)
+	}
+	if len(book.Hops) != 2 {
+		t.Fatalf("hops = %d, want 2 with none invented", len(book.Hops))
+	}
+	if book.Hops[1].Pending {
+		t.Fatalf("the second hop was answered, it is the third that never happened")
+	}
+	// 400ms plus 300ms of server, 12s of client, and nothing beyond what was seen.
+	if book.ServerTime != 700*time.Millisecond || book.ClientTurnaround != 12*time.Second {
+		t.Fatalf("server %v client %v, want 700ms and 12s", book.ServerTime, book.ClientTurnaround)
+	}
+}
+
+// TestAnUnlinkedRetryIsItsOwnInteraction keeps the view from filling in a link
+// matchRetry refused. A wrong link silently attributes one operation's timing to
+// another and leaves no symptom, which is why the refusal exists.
+func TestAnUnlinkedRetryIsItsOwnInteraction(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	// Two identical stateless questions in flight at once, so the retry fits both.
+	for i, id := range []string{"1", "2"} {
+		s.Ingest(req(uint64(2*i+1), t0, proxy.ClientToServer, id, "tools/call", `{"name":"book"}`))
+		s.Ingest(resp(uint64(2*i+2), t0.Add(time.Second), proxy.ServerToClient, id,
+			`"result":{"resultType":"input_required","inputRequests":{"who":{"method":"elicitation/create"}}}`))
+	}
+	s.Ingest(req(9, t0.Add(2*time.Second), proxy.ClientToServer, "3", "tools/call",
+		`{"name":"book","inputResponses":{"who":{"action":"accept"}}}`))
+
+	var single, chained int
+	for _, in := range s.Interactions("s1") {
+		if in.RoundTrips == 1 {
+			single++
+		} else {
+			chained++
+		}
+	}
+	if chained != 0 {
+		t.Fatalf("an ambiguous retry was folded into a chain: %+v", s.Interactions("s1"))
+	}
+	if single != 3 {
+		t.Fatalf("interactions = %d, want three separate one hop ones", single)
+	}
+}
+
+// TestAStateViolationStillReportsItsHops keeps a requestState violation from
+// also destroying the timing view. The link was still made, so the hops are
+// still known.
+func TestAStateViolationStillReportsItsHops(t *testing.T) {
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	s := New()
+	s.Ingest(req(1, t0, proxy.ClientToServer, "1", "tools/call", `{"name":"book"}`))
+	s.Ingest(resp(2, t0.Add(time.Second), proxy.ServerToClient, "1",
+		`"result":{"resultType":"input_required","requestState":"issued","inputRequests":{"who":{"method":"elicitation/create"}}}`))
+	// The retry echoes something else, which is the violation.
+	ev := s.Ingest(req(3, t0.Add(5*time.Second), proxy.ClientToServer, "2", "tools/call",
+		`{"name":"book","requestState":"tampered","inputResponses":{"who":{"action":"accept"}}}`))
+	if ev.MRTRStateIssue != MRTRStateChanged {
+		t.Fatalf("the violation was not detected: %q", ev.MRTRStateIssue)
+	}
+	s.Ingest(resp(4, t0.Add(6*time.Second), proxy.ServerToClient, "2", `"result":{"content":[]}`))
+
+	in := interactionForSession(t, s, "s1", "book")
+	if in.RoundTrips != 2 || len(in.Hops) != 2 {
+		t.Fatalf("a chain carrying a state violation lost its hops: %+v", in)
+	}
+	if in.ServerTime != 2*time.Second || in.ClientTurnaround != 4*time.Second {
+		t.Fatalf("server %v client %v, want 2s and 4s", in.ServerTime, in.ClientTurnaround)
+	}
+}
+
+func interactionForSession(t *testing.T, s *Store, session, tool string) InteractionView {
+	t.Helper()
+	for _, in := range s.Interactions(session) {
+		if in.ToolName == tool {
+			return in
+		}
+	}
+	t.Fatalf("no interaction for %q", tool)
+	return InteractionView{}
+}
+
+// TestTheChainStillCountsOnce keeps this a view rather than a re-split of the
+// operation, which is what correlating MRTR was written to prevent.
+func TestTheChainStillCountsOnce(t *testing.T) {
+	s := New()
+	mrtrFixture(t, s, 0)
+	if n := len(s.Calls("demo")); n != 2 {
+		t.Fatalf("calls = %d, want one per operation", n)
+	}
+	summary, ok := s.ToolSummary("demo")
+	if !ok {
+		t.Fatal("no tool summary")
+	}
+	for _, tool := range summary.Tools {
+		if tool.Calls != 1 {
+			t.Fatalf("%s counted %d calls, want 1", tool.Name, tool.Calls)
+		}
+		want := 1
+		if tool.Name == "book_flight" {
+			want = 3
+		}
+		if tool.MaxRoundTrips != want {
+			t.Fatalf("%s round trips = %d, want %d", tool.Name, tool.MaxRoundTrips, want)
+		}
+	}
+}
+
+// TestTheTotalsSurviveEviction is why the counts are accumulated as frames
+// arrive rather than derived from the timeline. A live store releases old frames
+// to stay inside its budget, so a derived answer would silently be a window.
+func TestTheTotalsSurviveEviction(t *testing.T) {
+	s := NewBounded(64<<10, 5) // a window smaller than the chain
+	mrtrFixture(t, s, 6)       // the chain alone, no trailing call to evict it
+	book := interactionForSession(t, s, "demo", "book_flight")
+	if book.RoundTrips != 3 {
+		t.Fatalf("round trips = %d, want the 3 that happened even though the frames are gone", book.RoundTrips)
+	}
+	if book.ServerTime != 1200*time.Millisecond || book.ClientTurnaround != 37*time.Second {
+		t.Fatalf("server %v client %v, want 1.2s and 37s", book.ServerTime, book.ClientTurnaround)
+	}
+	if book.HopsComplete {
+		t.Fatalf("a partial breakdown claims to be whole: %d hops of %d", len(book.Hops), book.RoundTrips)
+	}
+	if len(book.Hops) >= book.RoundTrips {
+		t.Fatalf("hops = %d, want fewer than the %d round trips once frames are released", len(book.Hops), book.RoundTrips)
+	}
+}
+
+// ingestFrames feeds a session one capture, given as direction, offset in
+// milliseconds and raw body.
+func ingestFrames(t *testing.T, s *Store, frames [][3]any) {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	for i, f := range frames {
+		s.Ingest(proxy.Envelope{SessionID: "demo", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f[1].(int)) * time.Millisecond), Direction: f[0].(proxy.Direction),
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f[2].(string))})
+	}
+}
+
+// TestServerTimeIsClosedOnEverySettlement covers the paths that settle a call
+// outside the ordinary terminal branch. Each of them left the server's share at
+// zero while the call itself reported a duration, so the interaction contradicted
+// the call it describes.
+func TestServerTimeIsClosedOnEverySettlement(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		frames [][3]any
+		server time.Duration
+	}{
+		{
+			// A tools/call answered with a task handle, finished through the task.
+			name: "task handle",
+			frames: [][3]any{
+				{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"long_job"}}`},
+				{proxy.ServerToClient, 100, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"task","taskId":"t-1","status":"working"}}`},
+				{proxy.ClientToServer, 29000, `{"jsonrpc":"2.0","id":"2","method":"tasks/get","params":{"taskId":"t-1"}}`},
+				{proxy.ServerToClient, 30050, `{"jsonrpc":"2.0","id":"2","result":{"taskId":"t-1","status":"completed","result":{"content":[]}}}`},
+			},
+			server: 30050 * time.Millisecond,
+		},
+		{
+			// Cancelled, then answered anyway.
+			name: "late result after a cancel",
+			frames: [][3]any{
+				{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"slow"}}`},
+				{proxy.ClientToServer, 2000, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"1"}}`},
+				{proxy.ServerToClient, 9000, `{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`},
+			},
+			server: 9 * time.Second,
+		},
+		{
+			// A long-lived stream closed gracefully.
+			name: "graceful stream close",
+			frames: [][3]any{
+				{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"subscriptions/listen","params":{}}`},
+				{proxy.ServerToClient, 4000, `{"jsonrpc":"2.0","id":"1","result":{}}`},
+			},
+			server: 4 * time.Second,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			ingestFrames(t, s, tc.frames)
+			all := s.Interactions("demo")
+			if len(all) == 0 {
+				t.Fatal("no interaction")
+			}
+			in := all[0]
+			if in.ServerTime != tc.server {
+				t.Fatalf("server time = %v, want %v; the interval was never closed", in.ServerTime, tc.server)
+			}
+			if in.Duration != tc.server {
+				t.Fatalf("duration = %v, want %v", in.Duration, tc.server)
+			}
+			// And the view agrees with the call it describes.
+			for _, c := range s.Calls("demo") {
+				if c.RequestSeq == in.CallSeq && c.Done() && c.Duration() != in.Duration {
+					t.Fatalf("the interaction says %v and the call says %v", in.Duration, c.Duration())
+				}
+			}
+		})
+	}
+}
+
+// TestAResentResultIsNotAHop keeps the gap between two copies of one answer off
+// the server's account. Parking leaves the call Pending, so the duplicate guard
+// cannot catch a server that repeats itself.
+func TestAResentResultIsNotAHop(t *testing.T) {
+	const asked = `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 400, asked},
+		{proxy.ServerToClient, 10000, asked}, // the same answer again, nine and a half seconds later
+		{proxy.ClientToServer, 20000, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t","requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 20500, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if in.RoundTrips != 2 {
+		t.Fatalf("round trips = %d, want 2; a resend is not a hop", in.RoundTrips)
+	}
+	if in.ServerTime != 900*time.Millisecond {
+		t.Fatalf("server time = %v, want 900ms; the idle gap between two copies is not server work", in.ServerTime)
+	}
+	if in.ClientTurnaround != 19600*time.Millisecond {
+		t.Fatalf("client turnaround = %v, want 19.6s", in.ClientTurnaround)
+	}
+	if in.ServerTime+in.ClientTurnaround != in.Duration {
+		t.Fatalf("the shares do not add up: %+v", in)
+	}
+}
+
+// TestAFrameOutOfOrderIsDroppedNotDeferred covers a log that was hand-edited or
+// two captures concatenated. Skipping the interval but moving the mark charged
+// the skew to whichever hop closed next, which is worse than declining to
+// measure the one that was wrong.
+func TestAFrameOutOfOrderIsDroppedNotDeferred(t *testing.T) {
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 5000, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`},
+		// The retry claims to have happened before the answer it answers.
+		{proxy.ClientToServer, 3000, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t","requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`},
+		// And the operation then finishes normally, which is where a mark left on the
+		// backwards frame would surface: the last hop would be measured from 3000
+		// rather than from 5000 and report seven seconds of server work that never
+		// happened.
+		{proxy.ServerToClient, 10000, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if in.ClientTurnaround != 0 {
+		t.Fatalf("client turnaround = %v, want none; the retry went backwards", in.ClientTurnaround)
+	}
+	// Five seconds to the answer, then five more to the final result, and nothing
+	// from the frame that went backwards.
+	if in.ServerTime != 10*time.Second {
+		t.Fatalf("server time = %v, want 10s, with the skew dropped rather than charged to the next hop", in.ServerTime)
+	}
+	if in.ServerTime+in.ClientTurnaround != in.Duration {
+		t.Fatalf("the shares do not add up: %+v", in)
+	}
+}
+
+// TestAServerInitiatedRequestDoesNotBlameTheServer covers the deprecated shape
+// that 2026-07-28 replaced with MRTR. The peer that answers a server's request
+// is the client, so the interval between them is not the server's time.
+func TestAServerInitiatedRequestDoesNotBlameTheServer(t *testing.T) {
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ServerToClient, 0, `{"jsonrpc":"2.0","id":"1","method":"sampling/createMessage","params":{"messages":[]}}`},
+		{proxy.ClientToServer, 3000, `{"jsonrpc":"2.0","id":"1","result":{"role":"assistant"}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if in.ServerTime != 0 {
+		t.Fatalf("server time = %v, want none; the client is what answered", in.ServerTime)
+	}
+	if in.ClientTurnaround != 3*time.Second {
+		t.Fatalf("client turnaround = %v, want 3s", in.ClientTurnaround)
+	}
+	if in.ServerTime+in.ClientTurnaround != in.Duration {
+		t.Fatalf("the shares do not add up: %+v", in)
+	}
+}
+
+// TestAOneHopInteractionCarriesNoRedundantBreakdown keeps the common case cheap.
+// One hop's breakdown is the totals word for word, and producing one allocated a
+// slice per call under the read lock a live panel holds.
+func TestAOneHopInteractionCarriesNoRedundantBreakdown(t *testing.T) {
+	s := New()
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 200, `{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`},
+	})
+	in := s.Interactions("demo")[0]
+	if len(in.Hops) != 0 {
+		t.Fatalf("hops = %+v, want none for a single request", in.Hops)
+	}
+	if !in.HopsComplete {
+		t.Fatal("a one hop interaction has nothing to be incomplete about")
+	}
+	if in.RoundTrips != 1 || in.ServerTime != 200*time.Millisecond {
+		t.Fatalf("the totals are still the whole description: %+v", in)
+	}
+}
+
+// TestAnUnreadableAnswerIsNotAnEmptyOne keeps the two apart. A live store
+// releases frame bodies to stay inside its byte budget, and a hop whose answer is
+// gone did not ask for nothing.
+func TestAnUnreadableAnswerIsNotAnEmptyOne(t *testing.T) {
+	s := NewBounded(1, 0) // one byte of bodies, so everything is released at once
+	ingestFrames(t, s, [][3]any{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"t"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 5000, `{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"t","requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 5100, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	})
+	all := s.Interactions("demo")
+	if len(all) == 0 {
+		t.Fatal("no interaction")
+	}
+	in := all[0]
+	if in.RoundTrips != 2 {
+		t.Fatalf("round trips = %d, want 2", in.RoundTrips)
+	}
+	var unknown int
+	for _, h := range in.Hops {
+		if h.AskedUnknown {
+			unknown++
+		}
+		if h.AskedUnknown && len(h.Asked) > 0 {
+			t.Fatalf("a hop is both unreadable and readable: %+v", h)
+		}
+	}
+	if unknown == 0 {
+		t.Fatalf("a released body reads as a hop that asked for nothing: %+v", in.Hops)
+	}
+	// The timings are exact regardless, so the breakdown is not incomplete.
+	if in.ServerTime != 500*time.Millisecond || in.ClientTurnaround != 4600*time.Millisecond {
+		t.Fatalf("releasing a body changed a timing: %+v", in)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -189,6 +189,24 @@ type call struct {
 	// only be answering the round it was issued from.
 	elicitations []*elicitation
 	elicitRound  int
+	// hops, serverTime and clientTime describe a multi round-trip operation as it
+	// is observed, and hopMark is the frame the current interval started at.
+	//
+	// Accumulated at ingest rather than derived from the timeline on read. The
+	// specification puts no bound on how many hops a chain may take, so a slice of
+	// them would grow without one, but three scalars do not. Deriving was the other
+	// option and a bounded live store rules it out: with a window of four frames a
+	// three hop chain shows two request frames and no call at all, so the answer
+	// would silently be a window rather than a chain. These survive eviction.
+	//
+	// The intervals alternate, so one mark is enough. A request starts the server's
+	// interval, its response ends it and starts the client's, and the retry ends
+	// that and starts the next. They telescope, so serverTime + clientTime is
+	// exactly the span from the first request to the last response.
+	hops       int
+	serverTime time.Duration
+	clientTime time.Duration
+	hopMark    time.Time
 	// retired marks an operation the parking cap dropped. Nothing can continue it
 	// any more, so a bounded store may forget it even though it is still Pending,
 	// which it is: no response ever came, and saying otherwise would change what
@@ -702,6 +720,11 @@ func (s *Store) Ingest(e proxy.Envelope) EventView {
 			root.mrtrState, root.mrtrKeys = "", ""
 			root.mrtrHasState = false
 			sess.unpark(root)
+			// The client's interval ends where the retry starts, and this is the hop
+			// the answers belong to. Counted here rather than from the timeline, since
+			// a bounded store evicts the frames a derived count would need.
+			root.markHop(e.TS, &root.clientTime)
+			root.hops++
 			ev.call = root
 			ev.kind = EventRequest
 			ev.method = msg.Method
@@ -1178,6 +1201,8 @@ func (sess *session) openCall(id string, msg proxy.RPCMessage, e proxy.Envelope)
 		params:     msg.Params,
 		start:      e.TS,
 		state:      Pending,
+		hops:       1,
+		hopMark:    e.TS,
 	}
 	if isStreamOpeningMethod(msg.Method) {
 		c.state = Streaming
@@ -1221,11 +1246,13 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		// late result nor the duplicate this branch used to report.
 		if c.method == "subscriptions/listen" {
 			c.end = ts
+			c.markHop(ts, &c.serverTime)
 			c.result = msg.Result
 			c.err = msg.Error
 			return c, true
 		}
 		c.end = ts
+		c.markHop(ts, &c.serverTime)
 		c.result = msg.Result
 		c.err = msg.Error
 		c.toolErr = isToolError(msg.Result)
@@ -1269,6 +1296,11 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 		if round := parseElicitations(state.requests, ts); !sameElicitRound(c.elicitations[c.elicitRound:], round) {
 			c.elicitRound = len(c.elicitations)
 			c.elicitations = append(c.elicitations, round...)
+			// This hop's server interval ends here and the client's begins. Inside the
+			// fresh-round test on purpose: a server resending the same result on one id
+			// is not a new hop, and charging the gap between the two copies to the
+			// server made the totals contradict the breakdown printed under them.
+			c.markHop(ts, &c.serverTime)
 		}
 		sess.park(c)
 		return c, true
@@ -1285,6 +1317,7 @@ func (sess *session) completeCall(id string, respDir proxy.Direction, conn strin
 	c.end = ts
 	c.result = msg.Result
 	c.err = msg.Error
+	c.markHop(ts, &c.serverTime)
 	wasPending := c.state == Pending
 	switch {
 	case msg.Error != nil:
@@ -1403,6 +1436,7 @@ func (sess *session) applyParsedTaskState(state taskState, ts time.Time) (*call,
 		return c, false
 	}
 	c.end = ts
+	c.markHop(ts, &c.serverTime)
 	c.errored = countsAsError // the failed and completed-with-isError cases, not cancelled
 	sess.pending--
 	return c, countsAsError
@@ -2016,6 +2050,7 @@ func (sess *session) cancelCall(id string, dir proxy.Direction, conn string, ts 
 	c.state = Cancelled
 	c.cancelledAt = ts
 	c.cancelReason = reason
+	c.markHop(ts, &c.serverTime)
 	sess.pending--
 	return c
 }
@@ -2035,6 +2070,7 @@ func (sess *session) closeStreamingCall(id, conn string, ts time.Time, reason st
 		c := sess.calls[key]
 		if c != nil && c.state == Streaming {
 			c.end = ts
+			c.markHop(ts, &c.serverTime)
 			c.state = Cancelled
 			c.cancelledAt = ts
 			c.cancelReason = reason
@@ -2317,4 +2353,27 @@ func opposite(d proxy.Direction) proxy.Direction {
 		return proxy.ServerToClient
 	}
 	return proxy.ClientToServer
+}
+
+// markHop closes the interval that began at the last mark, adding it to into,
+// and starts the next one at ts.
+//
+// A frame out of order adds nothing rather than a negative interval. Envelope
+// sequence is monotonic per session and the proxy holds a lock across the emit,
+// so this is the log being edited or two captures being concatenated, and a
+// negative hop would make serverTime and clientTime disagree with the wall clock
+// they are supposed to add up to.
+func (c *call) markHop(ts time.Time, into *time.Duration) {
+	if c.hopMark.IsZero() {
+		c.hopMark = ts
+		return
+	}
+	if !ts.After(c.hopMark) {
+		// The mark stays where it was. Moving it to a frame that went backwards
+		// would drop nothing and instead charge the skew to whichever hop closed
+		// next, which is worse than declining to measure the one that was wrong.
+		return
+	}
+	*into += ts.Sub(c.hopMark)
+	c.hopMark = ts
 }

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -380,9 +380,14 @@ type ToolStats struct {
 	ProtocolErrors int
 	ToolErrors     int
 	Pending        int
-	P50            time.Duration
-	P95            time.Duration
-	P99            time.Duration
+	// MaxRoundTrips is the most requests any one call of this tool took. One means
+	// no call of it was ever retried. It is the maximum rather than a total,
+	// because the question it answers is whether this tool is chatty, and a total
+	// only says the tool was called a lot.
+	MaxRoundTrips int
+	P50           time.Duration
+	P95           time.Duration
+	P99           time.Duration
 	// ResultBytes totals this tool's results and MaxResultBytes is the largest
 	// single one, both as observed on the wire. Unlike the definition cost this
 	// half is paid per call, so a tool that is cheap to advertise can still be
@@ -906,6 +911,7 @@ func foldToolCall(byName map[string]*toolAggregate, slowest *[]SlowToolCall, cal
 		byName[c.toolName] = agg
 	}
 	agg.stats.Calls++
+	agg.stats.MaxRoundTrips = max(agg.stats.MaxRoundTrips, c.hops)
 	if c.state == Pending {
 		agg.stats.Pending++
 		return

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -24,6 +24,7 @@ type keyMap struct {
 	Caps       key.Binding
 	Summary    key.Binding
 	Elicit     key.Binding
+	Interact   key.Binding
 	Pause      key.Binding
 	Follow     key.Binding
 	Copy       key.Binding
@@ -53,6 +54,7 @@ func defaultKeys() keyMap {
 		Caps:       key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capabilities")),
 		Summary:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "tool summary")),
 		Elicit:     key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "elicitations")),
+		Interact:   key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "interactions")),
 		Pause:      key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "pause")),
 		Follow:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "follow")),
 		Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy JSON")),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -62,6 +62,7 @@ const (
 	overlayCaps
 	overlaySummary
 	overlayElicit
+	overlayInteract
 	overlayReplay
 )
 
@@ -273,14 +274,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// The spinner advances every tick, the store refresh only every fifth and
 			// only when a frame arrived since, so a burst of traffic cannot force a
 			// refresh per envelope (which is quadratic over a session).
+			changed := m.dirty
 			if m.spin%refreshEvery == 0 && m.dirty {
 				m.refresh()
 				m.dirty = false
 			}
-			// An open live overlay rebuilds every tick so a pending spinner animates
-			// at the tick cadence. The content-diff guard makes this a no-op when
-			// nothing changed.
-			m.refreshLiveOverlay()
+			// An open live overlay rebuilds so a pending spinner animates at the tick
+			// cadence, but only the panels that animate pay for it every tick. The
+			// content-diff guard below is downstream of building the content, so a
+			// panel that walks the whole window was doing that walk, under the store's
+			// read lock, twelve times a second whether or not a frame had arrived.
+			m.refreshLiveOverlay(changed)
 		}
 		return m, tick()
 
@@ -386,7 +390,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Copy):
 			m.copyCurrent()
 		case key.Matches(msg, m.keys.Enter, m.keys.Back, m.keys.Quit),
-			key.Matches(msg, m.keys.Caps, m.keys.Summary, m.keys.Elicit):
+			key.Matches(msg, m.keys.Caps, m.keys.Summary, m.keys.Elicit, m.keys.Interact):
 			m.closeOverlay()
 		default:
 			var cmd tea.Cmd
@@ -446,6 +450,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Elicit):
 		if m.currentSessionID() != "" {
 			m.openOverlay(overlayElicit, m.elicitContent())
+		}
+	case key.Matches(msg, m.keys.Interact):
+		if m.currentSessionID() != "" {
+			m.openOverlay(overlayInteract, m.interactContent())
 		}
 	case key.Matches(msg, m.keys.Replay):
 		if cmd := m.startReplay(); cmd != nil {
@@ -559,6 +567,11 @@ func (m Model) runCommand(cmd string) (Model, tea.Cmd) {
 	case "elicitations":
 		if m.currentSessionID() != "" {
 			m.openOverlay(overlayElicit, m.elicitContent())
+		}
+		return m, nil
+	case "interactions":
+		if m.currentSessionID() != "" {
+			m.openOverlay(overlayInteract, m.interactContent())
 		}
 		return m, nil
 	case "export":
@@ -996,19 +1009,37 @@ func (m *Model) refresh() {
 }
 
 // refreshLiveOverlay rebuilds an open live overlay from the current store state,
-// so a capabilities or tool-summary view left open keeps up with the session
-// instead of going stale until it is closed and reopened. It reads the store
-// directly, so it works in any view, and it re-renders only when the content
-// actually changed so the scroll position never jumps on an idle tick.
-func (m *Model) refreshLiveOverlay() {
+// so a panel left open keeps up with the session instead of going stale until it
+// is closed and reopened. It reads the store directly, so it works in any view,
+// and it re-renders only when the content actually changed so the scroll
+// position never jumps on an idle tick.
+//
+// storeChanged says whether a frame has arrived since the last rebuild. Only the
+// panel that animates ignores it, because the content diff below cannot save the
+// cost of producing the content, and producing it means walking the window under
+// the store's read lock while ingest waits for the write one.
+func (m *Model) refreshLiveOverlay(storeChanged bool) {
 	var content string
 	switch m.overlay {
-	case overlayCaps:
-		content = m.capsContent()
 	case overlaySummary:
+		// The only one that animates: a tool whose calls are all in flight shows a
+		// live spinner, so it rebuilds whether or not the store moved.
 		content = m.summaryContent()
+	case overlayCaps:
+		if !storeChanged {
+			return
+		}
+		content = m.capsContent()
 	case overlayElicit:
+		if !storeChanged {
+			return
+		}
 		content = m.elicitContent()
+	case overlayInteract:
+		if !storeChanged {
+			return
+		}
+		content = m.interactContent()
 	default:
 		return
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1474,6 +1474,42 @@ func summaryHasRow(styled, name, cell string) bool {
 	return false
 }
 
+// summaryCell reads one column of a tool's row by the header above it, so an
+// assertion names the column it means. Searching the whole row for a marker
+// worked only while exactly one column could produce it, and a column added
+// later silently broke that.
+func summaryCell(t *testing.T, styled, name, column string) string {
+	t.Helper()
+	lines := strings.Split(ansi.Strip(styled), "\n")
+	header := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "TOOL") && strings.Contains(ln, "CALLS") {
+			header = i
+			break
+		}
+	}
+	if header < 0 {
+		t.Fatalf("no summary header in:\n%s", ansi.Strip(styled))
+	}
+	// Indexed in runes, not bytes. The header is ASCII so the two agree there, but
+	// a row can hold a multi-byte rune before the column, and slicing by byte cut
+	// one in half.
+	start := strings.Index(lines[header], column)
+	if start < 0 {
+		t.Fatalf("no %s column in %q", column, lines[header])
+	}
+	end := start + len([]rune(column))
+	for _, ln := range lines[header+1:] {
+		row := []rune(ln)
+		if !strings.HasPrefix(strings.TrimSpace(ln), name+" ") || len(row) < start {
+			continue
+		}
+		return strings.TrimSpace(string(row[start:min(end, len(row))]))
+	}
+	t.Fatalf("no row for %q in:\n%s", name, ansi.Strip(styled))
+	return ""
+}
+
 func TestSummaryHeaderShowsOnlyCallsAndSort(t *testing.T) {
 	st := store.New()
 	base := time.Now()
@@ -1501,11 +1537,14 @@ func TestSummaryHeaderShowsOnlyCallsAndSort(t *testing.T) {
 			t.Fatalf("header should show only calls, found %q: %q", banned, header)
 		}
 	}
-	// The clean tool shows · for zero errors; the erroring tool shows a count.
-	// This works because an empty SCHEMA cell is blank, so the only · in a row
-	// is the ERR one.
-	if !summaryHasRow(out, "good", "·") || summaryHasRow(out, "bad", "·") {
-		t.Fatalf("ERR column should show · only for the clean tool\n%s", out)
+	// The clean tool shows · for zero errors and the erroring tool shows a count,
+	// read from the ERR column by name rather than by hunting the row for a marker
+	// that another column could also produce.
+	if got := summaryCell(t, out, "good", "ERR"); got != "·" {
+		t.Fatalf("clean tool ERR = %q, want ·\n%s", got, out)
+	}
+	if got := summaryCell(t, out, "bad", "ERR"); got != "1" {
+		t.Fatalf("erroring tool ERR = %q, want 1\n%s", got, out)
 	}
 	// The erroring tool sorts above the clean one, not alphabetically.
 	if strings.Index(out, "bad") > strings.Index(out, "good") {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -1030,6 +1031,7 @@ func (m Model) renderHelp() string {
 		{"c", "show negotiated capabilities"},
 		{"s", "show per-tool latency and error summary"},
 		{"l", "show what servers asked the user for"},
+		{"i", "show interactions with per-hop timing"},
 		{"p", "pause or resume the stream"},
 		{"f", "toggle follow"},
 	}}
@@ -1479,10 +1481,16 @@ const (
 	// and a tool with one problem renders exactly like a tool with five.
 	sumSchemaW = 8
 	sumCallsW  = 7
-	sumErrW    = 6
-	sumLatW    = 10
-	sumDefW    = 9
-	sumResW    = 10
+	sumTripsW  = 6
+	// The fixed columns without TRIPS come to seventy cells, which is exactly what
+	// an eighty-column terminal gives an overlay. TRIPS is the one that drops when
+	// there is no room, the way ACTIVITY and CLIENT drop from the sessions table,
+	// so adding it did not start wrapping every row on a narrow screen.
+	sumWidthWithoutTrips = 70
+	sumErrW              = 6
+	sumLatW              = 10
+	sumDefW              = 9
+	sumResW              = 10
 	// covLabelW fits the longest gutter label plus a space. "definitions" is
 	// eleven cells wide, so eleven would leave no gap at all and run the label
 	// into its value.
@@ -1586,8 +1594,14 @@ func (m Model) summaryContent() string {
 		}
 	})
 	var t strings.Builder
+	overlayW, _ := m.overlayDims()
+	showTrips := overlayW >= sumWidthWithoutTrips+sumTripsW
+	tripsHead := ""
+	if showTrips {
+		tripsHead = cellR("TRIPS", sumTripsW)
+	}
 	t.WriteString(m.styles.dim.Render(cellL("TOOL", sumToolW) +
-		cellR("CALLS", sumCallsW) + cellR("ERR", sumErrW) + cellR("LATENCY", sumLatW) +
+		cellR("CALLS", sumCallsW) + tripsHead + cellR("ERR", sumErrW) + cellR("LATENCY", sumLatW) +
 		cellR("DEF", sumDefW) + cellR("RESULT", sumResW) +
 		"  " + cellL("SCHEMA", sumSchemaW)))
 	for _, tool := range tools {
@@ -1630,8 +1644,20 @@ func (m Model) summaryContent() string {
 			defCell = cellR(base.Render(formatBytes(int64(c.Bytes))), sumDefW)
 		}
 		resCell := cellR(base.Render(formatBytes(tool.ResultBytes)), sumResW)
+		// TRIPS is the most requests any one call of this tool took, so a tool that
+		// elicits is visible without opening a panel. One round trip is what almost
+		// every row says, so it is left blank rather than dotted. A column of dots is
+		// noise, and the point of the column is the row that is not one.
+		trips := ""
+		if showTrips {
+			trips = cellR("", sumTripsW)
+			if tool.MaxRoundTrips > 1 {
+				trips = cellR(m.styles.warn.Render(fmt.Sprintf("%d", tool.MaxRoundTrips)), sumTripsW)
+			}
+		}
 		t.WriteString("\n" + base.Render(cellL(tool.Name, sumToolW)) +
 			cellR(base.Render(fmt.Sprintf("%d", tool.Calls)), sumCallsW) +
+			trips +
 			cellR(errCell, sumErrW) +
 			cellR(lat, sumLatW) +
 			defCell + resCell +
@@ -2519,4 +2545,87 @@ func (m Model) elicitAnswer(row store.ElicitationView) string {
 	}
 	return style.Render(row.Action) +
 		m.styles.faint.Render("  after "+formatLatency(row.Elapsed))
+}
+
+// interactContent renders the interactions overlay: one entry per logical
+// operation, with the per-hop breakdown of a chain.
+//
+// Under multi round-trip requests one tool call is several requests, and the
+// seconds a person spent answering sit inside the total, which is deliberate.
+// This panel is where that total comes apart into the share the server held and
+// the share it was waiting on the client.
+func (m Model) interactContent() string {
+	all := m.store.Interactions(m.currentSessionID())
+	chained := make([]store.InteractionView, 0, len(all))
+	for _, in := range all {
+		if in.RoundTrips > 1 {
+			chained = append(chained, in)
+		}
+	}
+	if len(chained) == 0 {
+		body := "no operation in this session took more than one request"
+		if len(all) > 0 {
+			body += fmt.Sprintf(", so all %s read as they look", countLabel(len(all), len(all), "call"))
+		}
+		return m.styles.panelTitle.Render("interactions") + "\n\n" + m.styles.dim.Render(body)
+	}
+
+	var b strings.Builder
+	b.WriteString(m.styles.panelTitle.Render("interactions") + "  " +
+		m.styles.faint.Render(countLabel(len(chained), len(all), "operation")) + "\n")
+	b.WriteString(m.styles.faint.Render("operations that took more than one request. the total includes the time "+
+		"a person spent answering, so the server's own share is separated out") + "\n")
+
+	for _, in := range chained {
+		who := in.Method
+		if in.ToolName != "" {
+			who = in.Method + " " + in.ToolName
+		}
+		b.WriteString("\n" + m.styles.bright.Render(safeCell(who)) +
+			m.styles.faint.Render(fmt.Sprintf("  id %s  %d round trips", safeCell(in.CallID), in.RoundTrips)) + "\n")
+		b.WriteString(m.styles.dim.Render(cellL("  total", 10)) + m.styles.neutral.Render(formatLatency(in.Duration)) +
+			m.styles.faint.Render("  = ") + m.styles.resp.Render(formatLatency(in.ServerTime)) +
+			m.styles.faint.Render(" server + ") + m.styles.warn.Render(formatLatency(in.ClientTurnaround)) +
+			m.styles.faint.Render(" client") + "\n")
+		for i, hop := range in.Hops {
+			line := fmt.Sprintf("  hop %d", i+1)
+			b.WriteString(m.styles.dim.Render(cellL(line, 10)) +
+				m.styles.faint.Render("id "+safeCell(hop.RequestID)+"  ") +
+				m.styles.resp.Render(formatLatency(hop.ServerTime)))
+			if hop.ClientTurnaround > 0 {
+				b.WriteString(m.styles.faint.Render(" + ") + m.styles.warn.Render(formatLatency(hop.ClientTurnaround)))
+			}
+			if len(hop.Asked) > 0 {
+				b.WriteString(m.styles.faint.Render("  asked " + safeCell(strings.Join(hop.Asked, ", "))))
+			}
+			if hop.Pending {
+				b.WriteString(m.styles.pending.Render("  no answer"))
+			}
+			b.WriteString("\n")
+		}
+		if !in.HopsComplete {
+			// A live store releases old frames, so the breakdown can be a window while
+			// the totals above it stay exact. Saying so keeps the two from reading as
+			// a contradiction.
+			b.WriteString(m.styles.dim.Render(cellL("", 10)) +
+				m.styles.faint.Render(fmt.Sprintf("%d of %d hops still held, the rest were released to stay inside the memory budget",
+					len(in.Hops), in.RoundTrips)) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// safeCell keeps a value the wire supplied from ending the line it is printed on
+// or driving the terminal.
+//
+// A tool name, a method and a JSON-RPC id are all written by whoever wrote the
+// server, and a newline in one closes the row it lands in while an escape
+// sequence moves the cursor out of the panel. paths.CheckLabel refuses a control
+// character for the same reason, and the inventory and stats tables quote rather
+// than drop one so the value stays recoverable.
+func safeCell(s string) string {
+	if strings.ContainsFunc(s, unicode.IsControl) {
+		return strconv.Quote(s)
+	}
+	return s
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -332,3 +332,167 @@ func TestElicitKeyIsBoundAndDocumented(t *testing.T) {
 		t.Fatalf("the help never mentions the panel:\n%s", help)
 	}
 }
+
+// mrtrStore builds the capture from issue #201 in a store.
+func mrtrStore(t *testing.T) *store.Store {
+	t.Helper()
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"book_flight"}}`},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","requestState":"st-1","inputRequests":{"confirm":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 12400, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"book_flight","requestState":"st-1","inputResponses":{"confirm":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 12700, `{"jsonrpc":"2.0","id":2,"result":{"resultType":"input_required","requestState":"st-2","inputRequests":{"seat":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 37700, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"book_flight","requestState":"st-2","inputResponses":{"seat":{"action":"accept"}}}}`},
+		{proxy.ServerToClient, 38200, `{"jsonrpc":"2.0","id":3,"result":{"content":[]}}`},
+		{proxy.ClientToServer, 39000, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"lookup_price"}}`},
+		{proxy.ServerToClient, 39200, `{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`},
+	}
+	for i, f := range frames {
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "booking", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+	}
+	return st
+}
+
+// TestInteractPanelSplitsTheTotal covers the panel where a wall clock comes
+// apart into the server's share and the client's.
+func TestInteractPanelSplitsTheTotal(t *testing.T) {
+	m := New(mrtrStore(t))
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.interactContent()
+
+	for _, want := range []string{"book_flight", "3 round trips", "hop 1", "hop 2", "hop 3", "elicitation/create"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("the panel does not show %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "lookup_price") {
+		t.Fatalf("an ordinary one hop call is already a line in the stream:\n%s", out)
+	}
+	// The three figures, rendered the way the rest of the TUI renders a latency.
+	for _, want := range []string{"38.2s", "1.2s", "37s"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("the panel does not show %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestInteractPanelOnASessionWithNoChainSaysSo keeps an empty panel from reading
+// as a broken one.
+func TestInteractPanelOnASessionWithNoChainSaysSo(t *testing.T) {
+	m := New(store.New())
+	m.streamSessionID = "s1"
+	if out := m.interactContent(); !strings.Contains(out, "no operation in this session took more than one request") {
+		t.Fatalf("out = %q", out)
+	}
+}
+
+// TestSummaryShowsRoundTrips covers the column that makes a chatty tool visible
+// without opening a panel, and keeps it quiet for the ordinary case.
+func TestSummaryShowsRoundTrips(t *testing.T) {
+	m := New(mrtrStore(t))
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.summaryContent()
+	if !strings.Contains(out, "TRIPS") {
+		t.Fatalf("the summary has no round trips column:\n%s", out)
+	}
+	// Read by column name, since CALLS also carries small numbers and hunting the
+	// row for one would find the wrong column.
+	if got := summaryCell(t, out, "book_flight", "TRIPS"); got != "3" {
+		t.Fatalf("book_flight TRIPS = %q, want 3\n%s", got, out)
+	}
+	// One round trip is the ordinary case and says nothing.
+	if got := summaryCell(t, out, "lookup_price", "TRIPS"); got != "" {
+		t.Fatalf("lookup_price TRIPS = %q, want blank\n%s", got, out)
+	}
+}
+
+// TestInteractKeyIsBoundAndDocumented keeps the panel reachable and the help
+// honest.
+func TestInteractKeyIsBoundAndDocumented(t *testing.T) {
+	m := New(store.New())
+	if got := m.keys.Interact.Keys(); len(got) != 1 || got[0] != "i" {
+		t.Fatalf("bound to %v, want i", got)
+	}
+	m.width, m.height = 120, 40
+	if help := m.renderHelp(); !strings.Contains(help, "per-hop timing") {
+		t.Fatalf("the help never mentions the panel:\n%s", help)
+	}
+}
+
+// TestInteractPanelCannotBeMadeToForgeRows covers the class of defect the
+// inventory and stats tables were fixed for. A tool name and a method come from
+// whoever wrote the server, so a newline in one would close the row it lands in
+// and an escape sequence would drive the terminal.
+func TestInteractPanelCannotBeMadeToForgeRows(t *testing.T) {
+	t0 := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	st := store.New()
+	const forged = "book\x1b[31mflight\r\n  total     FORGED"
+	// Encoded as JSON, not with %q. Go's quoting spells an escape as \x1b, which
+	// JSON has no such escape for, so the frame would be malformed and the store
+	// would drop it rather than render it.
+	name, err := json.Marshal(forged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frames := []struct {
+		dir proxy.Direction
+		ms  int
+		raw string
+	}{
+		{proxy.ClientToServer, 0, fmt.Sprintf(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":%s}}`, name)},
+		{proxy.ServerToClient, 400, `{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"st","inputRequests":{"k":{"method":"elicitation/create"}}}}`},
+		{proxy.ClientToServer, 5000, fmt.Sprintf(`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":%s,"requestState":"st","inputResponses":{"k":{"action":"accept"}}}}`, name)},
+		{proxy.ServerToClient, 5100, `{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`},
+	}
+	for i, f := range frames {
+		st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: uint64(i + 1),
+			TS: t0.Add(time.Duration(f.ms) * time.Millisecond), Direction: f.dir,
+			Transport: proxy.TransportStdio, Raw: json.RawMessage(f.raw)})
+	}
+
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.width, m.height = 120, 40
+	out := m.interactContent()
+	if strings.ContainsRune(out, 0x1b) {
+		t.Fatalf("an escape sequence reached the panel:\n%q", out)
+	}
+	if strings.Contains(out, "\n  total     FORGED") {
+		t.Fatalf("a forged line reached the panel:\n%s", out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("the value was dropped rather than quoted, so it is not recoverable:\n%s", out)
+	}
+}
+
+// TestSummaryTableFitsANarrowTerminal keeps the new column from wrapping every
+// row on an eighty-column screen, which is exactly the width the panel was
+// already sized to fill.
+func TestSummaryTableFitsANarrowTerminal(t *testing.T) {
+	for _, width := range []int{80, 84, 90, 120} {
+		m := New(mrtrStore(t))
+		m.streamSessionID = "s1"
+		m.width, m.height = width, 40
+		panelW, _ := m.overlayDims()
+		out := m.summaryContent()
+		for _, line := range strings.Split(out, "\n") {
+			if got := lipgloss.Width(line); got > panelW {
+				t.Fatalf("at %d columns a row is %d cells wide against a %d-cell panel:\n%s",
+					width, got, panelW, line)
+			}
+		}
+		// The column is there when there is room for it, and gone when there is not.
+		if wantTrips := panelW >= sumWidthWithoutTrips+sumTripsW; strings.Contains(out, "TRIPS") != wantTrips {
+			t.Fatalf("at %d columns TRIPS present = %v, want %v", width, strings.Contains(out, "TRIPS"), wantTrips)
+		}
+	}
+}


### PR DESCRIPTION
Closes #201