### PR TITLE
feat(replay): re-issue a captured call against an HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Run `mcpsnoop help` for the full list, or `mcpsnoop help <command>` for the flag
 | Interactive terminal UI | no | yes |
 | Zero-config, no flags or ordering | no | yes |
 | Capability inspector | partial | yes |
-| Replay a captured call | no | yes |
+| Replay a captured call | no | yes, over stdio and over HTTP |
 | Session export (json / html / text / otlp) | no | yes |
 | Single binary, no runtime deps | no | yes |
 
@@ -723,6 +723,65 @@ mcpsnoop still changes nothing about the traffic it forwards.
 
 Nothing is resolved or fetched. An external `$ref` is recognized by its form
 alone, and the schema it points at is never read.
+
+### Replay a call captured over HTTP
+
+`r` re-issues a captured call against a live server. For a stdio capture the
+command is in the log, so mcpsnoop launches an isolated copy and sends the
+request to that. An HTTP capture has no command to launch, and the endpoint it
+records is stripped of its userinfo and every query value, so it names the server
+without being an address to dial.
+
+So you say where a replay goes, and mcpsnoop never dials a production endpoint
+because somebody pressed a key.
+
+```bash
+mcpsnoop open --replay-target https://api.example.com/mcp session.jsonl
+mcpsnoop open --replay-target https://api.example.com/mcp \
+  --replay-header 'Authorization: Bearer sk-…' session.jsonl
+```
+
+Without `--replay-target` an HTTP session says so rather than offering a key that
+cannot work. With one, `r` still asks before the first send of a session, the
+same way a recorded command is answered for before it is run.
+
+A credential reaches the server through `--replay-header` and nowhere else.
+mcpsnoop records no `Authorization` header and replays none, so there is nothing
+captured for a replay to leak.
+
+The replayed POST carries what the transport makes mandatory, which a POST of the
+bare captured body does not: `MCP-Protocol-Version`, an `Accept` listing both
+`application/json` and `text/event-stream`, `Mcp-Method`, `Mcp-Name` where the
+spec requires it, and every captured `Mcp-Param-*`. Those are re-sent verbatim
+from the capture, base64 sentinel and all, so they cannot disagree with the body
+the way a re-derivation could. The one header that is not copied is the protocol
+version, because the replayed body declares the revision mcpsnoop speaks and the
+header has to match the body.
+
+`Mcp-Name` is derived from the body being sent rather than copied, because the
+spec sources it from `params.name` or `params.uri` and requires a server to
+reject a header that disagrees with the body, so an edit that renames the tool
+would otherwise send the old name. The `Mcp-Param-*` headers mirror the captured
+arguments, so an edited replay sends none of them rather than asserting
+something about a body somebody rewrote. A capture can only set headers in that
+one family: a log is a file people hand around, and letting it name any header
+would let it overwrite the mandatory ones or add a credential nobody passed.
+
+A `Mcp-Param-*` a redaction rule scrubbed stops the replay with a reason. Sending
+the placeholder would put mcpsnoop's own bytes on a live server as though a user
+had typed them.
+
+A redirect is refused rather than followed. The address is the one you named and
+answered for, and following a 307 would hand that choice to the far end, resending
+the body and, on a hop that only changes the port, the credential too. mcpsnoop
+reports where the server wanted to send it and lets you decide whether to name
+that one instead.
+
+An answer arriving as a single JSON object and one arriving as an event stream
+are both read, and a failure is named rather than numbered: a 401 reports the
+scheme the server demanded, a `-32020` reports what it objected to, and a
+non-JSON-RPC 400 or 404 says the address is not a Streamable HTTP endpoint of
+this revision.
 
 ### Tell the server's latency from the user's
 

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/otlpsink"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/replay"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 	"github.com/kerlenton/mcpsnoop/internal/tui"
 )
@@ -829,6 +830,8 @@ func newOpenCmd() *cobra.Command {
 		redactValues  redactValuesFlag
 		redactPaths   redactPathsFlag
 	)
+	var replayTarget string
+	var replayHeaders []string
 	cmd := &cobra.Command{
 		Use:   "open [session-id|session.jsonl|-]",
 		Short: "Open a captured session in the TUI, or - to read from stdin",
@@ -839,7 +842,23 @@ func newOpenCmd() *cobra.Command {
 			if len(args) == 1 {
 				arg = args[0]
 			}
-			return codeOf(runOpen(arg, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths)))
+			target := replay.HTTPTarget{URL: strings.TrimSpace(replayTarget), Headers: replayHeaders}
+			if target.URL == "" && len(replayHeaders) > 0 {
+				fmt.Fprintln(cmd.ErrOrStderr(), "mcpsnoop open: --replay-header needs --replay-target, since there is nowhere to send them")
+				return codeOf(2)
+			}
+			// Checked here rather than dropped at send time. A header that never
+			// reached the request produced a 401 telling the operator to pass the
+			// credential they had already passed, which is the worst way to be told
+			// about a typo.
+			for _, h := range replayHeaders {
+				name, _, ok := strings.Cut(h, ":")
+				if !ok || strings.TrimSpace(name) == "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "mcpsnoop open: --replay-header %q is not a header, want 'Name: value'\n", h)
+					return codeOf(2)
+				}
+			}
+			return codeOf(runOpen(arg, redactConfig(redactSecrets, redactKeys, redactValues, redactPaths), target))
 		},
 	}
 	cmd.Flags().SortFlags = false
@@ -847,11 +866,13 @@ func newOpenCmd() *cobra.Command {
 	cmd.Flags().Var(&redactKeys, "redact-key", "JSON key name to scrub in captured JSON-RPC payloads, repeat or comma-separated")
 	cmd.Flags().Var(&redactValues, "redact-value", "regular expression to scrub inside captured JSON-RPC string values, stderr, and non-JSON text, repeatable")
 	cmd.Flags().Var(&redactPaths, "redact-path", "JSONPath selecting values in captured JSON-RPC payloads to scrub, repeatable")
+	cmd.Flags().StringVar(&replayTarget, "replay-target", "", "MCP endpoint a replay of an HTTP-captured session posts to; a capture records the endpoint stripped of anything credential-shaped, so it is not an address to dial and this is where you say where a replay goes")
+	cmd.Flags().StringArrayVar(&replayHeaders, "replay-header", nil, "extra header for a replayed request as 'Name: value', repeatable; this is how a credential reaches the server, since mcpsnoop never records one")
 	return cmd
 }
 
 // runOpen loads a session (id, path, or - for stdin) and shows it in the TUI.
-func runOpen(arg string, redaction proxy.RedactConfig) int {
+func runOpen(arg string, redaction proxy.RedactConfig, replayTarget replay.HTTPTarget) int {
 	inPath, usedStdin, err := resolveOpenSessionPath(arg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
@@ -886,12 +907,12 @@ func runOpen(arg string, redaction proxy.RedactConfig) int {
 			return 1
 		}
 		defer tty.Close()
-		if err := tui.RunOpenWithInput(ctx, st, tty); err != nil {
+		if err := tui.RunOpenWithInput(ctx, st, tty, tui.WithHTTPReplay(replayTarget)); err != nil {
 			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 			return 1
 		}
 	} else {
-		if err := runOpenTUIFn(ctx, st); err != nil {
+		if err := runOpenTUIFn(ctx, st, tui.WithHTTPReplay(replayTarget)); err != nil {
 			fmt.Fprintln(os.Stderr, "mcpsnoop open:", err)
 			return 1
 		}

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
+	"github.com/kerlenton/mcpsnoop/internal/tui"
 )
 
 func TestLabelFor(t *testing.T) {
@@ -392,7 +393,7 @@ func TestOpenRedactsCapturedSessionInMemoryWithoutModifyingInput(t *testing.T) {
 	input, original := writeUnredactedSession(t)
 	var opened *store.Store
 	previous := runOpenTUIFn
-	runOpenTUIFn = func(_ context.Context, st *store.Store) error {
+	runOpenTUIFn = func(_ context.Context, st *store.Store, _ ...tui.Option) error {
 		opened = st
 		return nil
 	}
@@ -432,7 +433,7 @@ func TestCapturedSessionReadDefaultsRemainUnredacted(t *testing.T) {
 
 	var opened *store.Store
 	previous := runOpenTUIFn
-	runOpenTUIFn = func(_ context.Context, st *store.Store) error {
+	runOpenTUIFn = func(_ context.Context, st *store.Store, _ ...tui.Option) error {
 		opened = st
 		return nil
 	}
@@ -1050,4 +1051,28 @@ func TestTraceSinkReportsOnlyTheFileSinkDrops(t *testing.T) {
 			t.Fatal("--no-trace writes nothing, so nothing can be incomplete")
 		}
 	})
+}
+
+// TestOpenRejectsAMalformedReplayHeader catches a typo at the flag rather than
+// dropping it at send time, where the resulting 401 told the operator to pass
+// the credential they had already passed.
+func TestOpenRejectsAMalformedReplayHeader(t *testing.T) {
+	t.Setenv("MCPSNOOP_HOME", t.TempDir())
+	for _, value := range []string{"Authorization Bearer sk", "  : value", ""} {
+		cmd := newOpenCmd()
+		cmd.SetArgs([]string{"--replay-target", "https://h/mcp", "--replay-header", value, "-"})
+		var stdout, stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		cmd.SilenceErrors, cmd.SilenceUsage = true, true
+
+		err := cmd.Execute()
+		var code exitCode
+		if err == nil || !errors.As(err, &code) || int(code) != 2 {
+			t.Fatalf("--replay-header %q exited %v, want a usage error", value, err)
+		}
+		if !strings.Contains(stderr.String(), "is not a header") {
+			t.Fatalf("--replay-header %q: stderr %q", value, stderr.String())
+		}
+	}
 }

--- a/docs/TRY_IT.md
+++ b/docs/TRY_IT.md
@@ -59,7 +59,9 @@ well. When you're done, `mcpsnoop unwrap everything` puts it back.
 
 4. Drill into a frame with `enter`, filter with `/`, inspect capabilities with
    `c`, see what servers asked the user for with `l`, replay a call with `r`,
-   or edit its params and replay with `R`.
+   or edit its params and replay with `R`. A session captured over HTTP needs
+   `mcpsnoop open --replay-target <url>` before `r` will send anywhere, since a
+   capture records the endpoint stripped of anything credential-shaped.
 
 Frames stream in as the client works. The quick calls come back OK, and the long
 one sends progress notifications and shows a visibly higher latency.

--- a/internal/proxy/header.go
+++ b/internal/proxy/header.go
@@ -52,3 +52,42 @@ func DecodeHeaderValue(value string) (string, bool) {
 	}
 	return "", false
 }
+
+// EncodeHeaderValue renders a value for a routing header, wrapping it in the
+// Base64 sentinel when it cannot travel as it stands.
+//
+// This is the other half of DecodeHeaderValue and it exists for the one caller
+// that has to build a header rather than read one: a replay derives Mcp-Name
+// from the body it is about to send, because the header "MUST match" that body
+// and a value copied from the capture would not when the body has been edited.
+//
+// The rule is the transport's. A field value may hold only visible ASCII, space
+// and tab, so anything outside that set is wrapped, and so is a value with
+// leading or trailing whitespace, which a reader would strip. A plain value that
+// happens to spell the sentinel is wrapped too, for the same reason the decoder
+// only unwraps once: left alone it would decode into something the body never
+// said.
+func EncodeHeaderValue(value string) string {
+	if needsSentinel(value) {
+		return Base64SentinelPrefix + base64.StdEncoding.EncodeToString([]byte(value)) + Base64SentinelSuffix
+	}
+	return value
+}
+
+func needsSentinel(value string) bool {
+	if value == "" {
+		return false
+	}
+	if strings.TrimSpace(value) != value {
+		return true
+	}
+	if strings.HasPrefix(value, Base64SentinelPrefix) && strings.HasSuffix(value, Base64SentinelSuffix) {
+		return true
+	}
+	for i := range len(value) {
+		if c := value[i]; c != '\t' && (c < 0x20 || c > 0x7e) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/replay/http.go
+++ b/internal/replay/http.go
@@ -1,0 +1,391 @@
+package replay
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// HTTPTarget is where a replayed request goes and what it carries besides the
+// body.
+//
+// URL comes from whoever is replaying, never from the capture. What a capture
+// records is the endpoint with its userinfo and every query value removed, on
+// purpose, so it identifies the server without being an address to dial. A
+// replay reaches a live server, which may be the production one, so the person
+// asking for it says where it goes.
+type HTTPTarget struct {
+	URL string
+	// Headers are extra request headers as "Name: value". They are applied last,
+	// so a caller can override anything below, and they are how a credential
+	// reaches the request. mcpsnoop never records one and never replays one.
+	Headers []string
+}
+
+// Routing is the request metadata a captured frame carried, re-sent verbatim.
+//
+// The transport makes these mandatory: Mcp-Method on every request, Mcp-Name on
+// tools/call, resources/read and prompts/get, and one Mcp-Param-{Name} per
+// parameter a tool annotated with x-mcp-header. A server rejects a mismatch with
+// 400 and -32020, so a POST of the bare captured body gets an error rather than
+// a result.
+//
+// Verbatim matters. A value outside the safe ASCII set travels Base64-wrapped in
+// the =?base64?…?= sentinel, and the capture holds whatever the client sent, so
+// re-sending it needs no encoder and cannot disagree with what the body says.
+type Routing struct {
+	// Name is the Mcp-Name the capture carried. It is a fallback: the header is
+	// derived from the body actually being sent, because the transport says it
+	// "MUST match" that body and an edit can change what the body names. The
+	// captured value is used only when the body names nothing, which is what a
+	// capture from a client that predates this revision looks like.
+	Name         string
+	ParamHeaders []proxy.MCPParamHeader
+	// Edited says the person replaying rewrote the params. The captured
+	// Mcp-Param-* headers mirror the captured arguments, so against a body
+	// somebody rewrote they assert something mcpsnoop cannot know is still true.
+	Edited bool
+}
+
+// methodsNeedingName are the requests the transport marks Mcp-Name REQUIRED for.
+var methodsNeedingName = map[string]struct{}{
+	"tools/call":     {},
+	"resources/read": {},
+	"prompts/get":    {},
+}
+
+// ReplayHTTP re-issues one captured request as an HTTP POST against target.
+//
+// It sends exactly one request. The transport makes every message its own POST
+// and this revision has no handshake to perform, so there is nothing to
+// negotiate first: the request describes itself in its own _meta, which
+// withClientMeta builds, and in the headers that mirror it.
+func ReplayHTTP(ctx context.Context, target HTTPTarget, method string, params json.RawMessage, routing Routing, timeout time.Duration) (Result, error) {
+	if strings.TrimSpace(target.URL) == "" {
+		return Result{}, errors.New("replay: no target to send to, pass --replay-target")
+	}
+	if _, err := url.Parse(target.URL); err != nil {
+		return Result{}, fmt.Errorf("replay: invalid target %q: %w", target.URL, err)
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	// A redacted header value is mcpsnoop's placeholder, not the client's data.
+	// Sending it would put that placeholder on a live server as though a user had
+	// typed it, and omitting it would produce a header mismatch the server reports
+	// as the client's fault. Refusing says which it is.
+	for _, h := range routing.ParamHeaders {
+		if h.Redacted {
+			return Result{}, fmt.Errorf("replay: %s was scrubbed by redaction in this capture, so there is nothing to re-send; replay from an unredacted capture", h.Name)
+		}
+	}
+
+	body := withClientMeta(params)
+	frame := map[string]any{"jsonrpc": "2.0", "id": 1, "method": method, "params": body}
+	encoded, err := json.Marshal(frame)
+	if err != nil {
+		return Result{}, fmt.Errorf("replay: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.URL, bytes.NewReader(encoded))
+	if err != nil {
+		return Result{}, fmt.Errorf("replay: %w", err)
+	}
+	applyReplayHeaders(req, method, body, routing, target.Headers)
+
+	start := time.Now()
+	resp, err := replayClient.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("replay: %w", err)
+	}
+	defer resp.Body.Close()
+
+	out := Result{Method: method, Params: body}
+	raw, err := readReplayResponse(resp)
+	out.Duration = time.Since(start)
+	if err != nil {
+		return out, err
+	}
+	out.Response = raw
+
+	var msg struct {
+		Result json.RawMessage `json:"result"`
+		Error  *proxy.RPCError `json:"error"`
+	}
+	// Both halves. Valid JSON that carries neither a result nor an error is not a
+	// response to anything, and reporting it as ok let a proxy's own success page
+	// read as the server having answered.
+	if json.Unmarshal(raw, &msg) != nil || (len(msg.Result) == 0 && msg.Error == nil) {
+		return out, fmt.Errorf("replay: the server answered something that is not a JSON-RPC response: %s", clip(raw))
+	}
+	out.RPCResult, out.Err = msg.Result, msg.Error
+	out.ToolErr = isToolError(msg.Result)
+	return out, nil
+}
+
+// applyReplayHeaders sets what the transport requires of every POST, then
+// whatever the caller asked for, so a caller can override any of it.
+func applyReplayHeaders(req *http.Request, method string, body json.RawMessage, routing Routing, extra []string) {
+	req.Header.Set("Content-Type", "application/json")
+	// Both types, because the client "MUST include an Accept header listing both
+	// application/json and text/event-stream", and a server may answer either.
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	// Derived from what withClientMeta put in the body, never copied from the
+	// capture. The header value "MUST match the io.modelcontextprotocol/protocolVersion
+	// field carried in the request body's _meta", and the body is rebuilt here, so
+	// echoing the captured revision would disagree with it by construction.
+	req.Header.Set("MCP-Protocol-Version", statelessProtocolVersion)
+	req.Header.Set("Mcp-Method", method)
+	if _, needs := methodsNeedingName[method]; needs {
+		if name := mcpName(body, routing.Name); name != "" {
+			req.Header.Set("Mcp-Name", name)
+		}
+	}
+	if !routing.Edited {
+		for _, h := range routing.ParamHeaders {
+			// Only the family the annotations produce. A capture is a file people hand
+			// around, and setting whatever name it carries let a doctored one overwrite
+			// the mandatory headers above, or add an Authorization the operator never
+			// passed.
+			if !strings.HasPrefix(textproto.CanonicalMIMEHeaderKey(h.Name), mcpParamPrefix) {
+				continue
+			}
+			req.Header.Set(h.Name, h.Value)
+		}
+	}
+	for _, h := range extra {
+		name, value, ok := strings.Cut(h, ":")
+		if !ok {
+			continue
+		}
+		req.Header.Set(strings.TrimSpace(name), strings.TrimSpace(value))
+	}
+}
+
+// mcpParamPrefix is the header family a tool's x-mcp-header annotations produce,
+// in the spelling net/http canonicalises to.
+const mcpParamPrefix = "Mcp-Param-"
+
+// mcpName is the operation the request names, taken from the body being sent.
+//
+// The transport sources this header from "params.name or params.uri", and
+// requires a server to reject a header that disagrees with the body. So it is
+// derived rather than copied: an edit that renames the tool would otherwise send
+// the captured name against a body naming another, which is exactly the mismatch
+// the server is told to refuse. The captured value is the fallback for a body
+// that names nothing.
+func mcpName(body json.RawMessage, captured string) string {
+	var params struct {
+		Name string `json:"name"`
+		URI  string `json:"uri"`
+	}
+	if json.Unmarshal(body, &params) == nil {
+		if params.Name != "" {
+			return proxy.EncodeHeaderValue(params.Name)
+		}
+		if params.URI != "" {
+			return proxy.EncodeHeaderValue(params.URI)
+		}
+	}
+	return captured
+}
+
+// readReplayResponse reads whichever of the two shapes the server chose.
+//
+// A request is answered with "either Content-Type: application/json (a single
+// JSON object) or Content-Type: text/event-stream (an SSE response stream)", and
+// on a stream "the final JSON-RPC response SHOULD terminate the stream", with
+// request-scoped notifications before it. A replay wants the response, so the
+// notifications are read past.
+func readReplayResponse(resp *http.Response) (json.RawMessage, error) {
+	if resp.StatusCode != http.StatusOK {
+		return nil, statusError(resp)
+	}
+	// Compared case-insensitively. A media type is case-insensitive in HTTP and Go
+	// canonicalises header names but never values, so a server spelling it
+	// Text/Event-Stream sent a perfectly legal answer that was then parsed as one
+	// JSON object and reported as garbage.
+	if isEventStream(resp.Header.Get("Content-Type")) {
+		return readSSEResponse(resp.Body)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxReplayBody+1))
+	if err != nil {
+		return nil, fmt.Errorf("replay: %w", err)
+	}
+	if len(raw) > maxReplayBody {
+		// Said rather than handed over cut in half. A truncated body is not a server
+		// that answered nonsense, and blaming it for one would send somebody looking
+		// in the wrong place.
+		return nil, fmt.Errorf("replay: the answer is larger than the %d MiB a replay will hold, so it was not read", maxReplayBody>>20)
+	}
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("replay: the server answered %d with an empty body", resp.StatusCode)
+	}
+	return json.RawMessage(raw), nil
+}
+
+// isEventStream reports whether a Content-Type names the streamed shape,
+// ignoring case and any parameters after the type itself.
+func isEventStream(contentType string) bool {
+	media, _, _ := strings.Cut(contentType, ";")
+	return strings.EqualFold(strings.TrimSpace(media), "text/event-stream")
+}
+
+// maxReplayBody bounds what one replayed answer may hand back, since the overlay
+// that renders it holds it in memory and the server on the other end is not
+// mcpsnoop's.
+const maxReplayBody = 8 << 20
+
+// replayClient refuses to follow a redirect.
+//
+// The address a replay posts to is the one the person replaying named and
+// answered for, and following a redirect hands that choice back to the far end.
+// Go's default client would resend the body and, on a hop that only changes the
+// port, the Authorization header too, so a staging endpoint answering 307 could
+// deliver a mutating tools/call and a credential to production while the overlay
+// reported success and never named the host that answered. A 301, 302 or 303
+// would additionally rewrite the POST into a bodiless GET.
+//
+// So the hop is reported instead, with the address it wanted, and the person
+// decides whether to name that one.
+var replayClient = &http.Client{
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// statusError turns a non-200 into a message that says what to do about it.
+//
+// The transport distinguishes these, so the reader is told which one happened
+// rather than being handed a number. A 400 is where a modern server reports a
+// header or version problem, which is exactly what a replay gets wrong, and a
+// 404 with a JSON-RPC body is an unknown method rather than a wrong address.
+func statusError(resp *http.Response) error {
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxReplayBody))
+	raw = bytes.TrimSpace(raw)
+	var msg struct {
+		Error *proxy.RPCError `json:"error"`
+	}
+	modern := json.Unmarshal(raw, &msg) == nil && msg.Error != nil
+
+	switch {
+	case isRedirect(resp.StatusCode):
+		to := resp.Header.Get("Location")
+		if to == "" {
+			to = "somewhere it did not name"
+		}
+		return fmt.Errorf("replay: %s answered %d redirecting to %s, and a replay goes only where you named; pass --replay-target %s if that is where you meant to send it",
+			resp.Request.URL.Redacted(), resp.StatusCode, to, to)
+	case resp.StatusCode == http.StatusUnauthorized:
+		challenge := strings.Join(resp.Header.Values("WWW-Authenticate"), ", ")
+		if challenge == "" {
+			return errors.New("replay: the server answered 401 and named no scheme; pass a credential with --replay-header")
+		}
+		return fmt.Errorf("replay: the server answered 401 demanding %s; pass a credential with --replay-header", challenge)
+	case modern && msg.Error.Code == headerMismatchCode:
+		return fmt.Errorf("replay: the server rejected the request metadata: %s", msg.Error.Message)
+	case modern:
+		return fmt.Errorf("replay: the server answered %d with %s", resp.StatusCode, msg.Error.Message)
+	case resp.StatusCode == http.StatusBadRequest, resp.StatusCode == http.StatusNotFound,
+		resp.StatusCode == http.StatusMethodNotAllowed:
+		// The era test the transport prescribes, run the other way round from the
+		// stdio one. A modern server answers these with a JSON-RPC error, so a body
+		// that is not one means the address is not a modern MCP endpoint.
+		return fmt.Errorf("replay: %s answered %d with no JSON-RPC error, so it is not a Streamable HTTP MCP endpoint of this revision",
+			resp.Request.URL.Redacted(), resp.StatusCode)
+	case len(raw) == 0:
+		return fmt.Errorf("replay: the server answered %d with an empty body", resp.StatusCode)
+	default:
+		return fmt.Errorf("replay: the server answered %d: %s", resp.StatusCode, clip(raw))
+	}
+}
+
+// headerMismatchCode is what a server returns when the mirrored headers and the
+// body disagree, which is the failure a replay is most likely to cause.
+const headerMismatchCode = -32020
+
+// isRedirect covers the codes a client would otherwise follow.
+func isRedirect(code int) bool {
+	switch code {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
+		http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		return true
+	}
+	return false
+}
+
+// readSSEResponse reads an event stream until the JSON-RPC response arrives.
+func readSSEResponse(r io.Reader) (json.RawMessage, error) {
+	scanner := bufio.NewScanner(io.LimitReader(r, maxReplayBody))
+	scanner.Buffer(make([]byte, 0, 64<<10), maxReplayBody)
+	var data []byte
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		switch {
+		case len(bytes.TrimSpace(line)) == 0:
+			// End of one event. A response terminates the stream; anything else is a
+			// request-scoped notification and is read past.
+			if len(data) > 0 {
+				if isRPCResponse(data) {
+					return json.RawMessage(append([]byte(nil), data...)), nil
+				}
+				data = data[:0]
+			}
+		case bytes.HasPrefix(line, []byte(":")):
+			// A comment, which servers send as a keep-alive. Ignored, as the spec says.
+		case bytes.HasPrefix(line, []byte("data:")):
+			chunk := bytes.TrimPrefix(line, []byte("data:"))
+			chunk = bytes.TrimPrefix(chunk, []byte(" "))
+			if len(data) > 0 {
+				data = append(data, '\n')
+			}
+			data = append(data, chunk...)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("replay: reading the response stream: %w", err)
+	}
+	if len(data) > 0 && isRPCResponse(data) {
+		return json.RawMessage(data), nil
+	}
+	return nil, errors.New("replay: the response stream ended without a JSON-RPC response")
+}
+
+// isRPCResponse reports whether a stream event is the answer rather than one of
+// the notifications that precede it.
+func isRPCResponse(data []byte) bool {
+	var msg struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal(data, &msg) != nil {
+		return false
+	}
+	return msg.Method == "" && len(msg.ID) > 0 && (len(msg.Result) > 0 || len(msg.Error) > 0)
+}
+
+// clip bounds a server's answer when it goes into an error message, since it is
+// a stranger's bytes and the message is read in a terminal.
+func clip(raw []byte) string {
+	const limit = 200
+	if len(raw) <= limit {
+		return string(raw)
+	}
+	return string(raw[:limit]) + "…"
+}

--- a/internal/replay/http_test.go
+++ b/internal/replay/http_test.go
@@ -1,0 +1,506 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+// mcpEndpoint is a server that enforces what the transport makes mandatory, so a
+// replay missing any of it gets the error a real server would send rather than a
+// result.
+func mcpEndpoint(t *testing.T, answer func(w http.ResponseWriter, seen http.Header, msg map[string]json.RawMessage)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		var method string
+		_ = json.Unmarshal(msg["method"], &method)
+		reject := func(message string) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1,
+				"error": map[string]any{"code": -32020, "message": message}})
+		}
+		switch {
+		case r.Header.Get("MCP-Protocol-Version") == "":
+			reject("missing MCP-Protocol-Version")
+		case r.Header.Get("Mcp-Method") != method:
+			reject("Mcp-Method does not match the body")
+		case !strings.Contains(r.Header.Get("Accept"), "application/json") ||
+			!strings.Contains(r.Header.Get("Accept"), "text/event-stream"):
+			reject("Accept must list both types")
+		default:
+			answer(w, r.Header, msg)
+		}
+	}))
+}
+
+func okJSON(w http.ResponseWriter, text string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1,
+		"result": map[string]any{"content": []any{map[string]any{"type": "text", "text": text}}}})
+}
+
+// TestReplayHTTPSendsWhatTheTransportRequires is the whole point: a POST of the
+// bare captured body gets a -32020, not a result, so the replay carries the
+// request metadata the specification makes mandatory.
+func TestReplayHTTPSendsWhatTheTransportRequires(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	res, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo","arguments":{"text":"hi"}}`),
+		Routing{Name: "echo", ParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}}},
+		5*time.Second)
+	if err != nil {
+		t.Fatalf("replay failed: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("the server answered an error: %+v", res.Err)
+	}
+	for name, want := range map[string]string{
+		"Mcp-Method":           "tools/call",
+		"Mcp-Name":             "echo",
+		"Mcp-Param-Region":     "us-west1",
+		"Mcp-Protocol-Version": statelessProtocolVersion,
+		"Content-Type":         "application/json",
+	} {
+		if got := seen.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+	if accept := seen.Get("Accept"); !strings.Contains(accept, "application/json") || !strings.Contains(accept, "text/event-stream") {
+		t.Fatalf("Accept = %q, want both types", accept)
+	}
+}
+
+// TestReplayHTTPDeclaresTheRevisionItActuallySends covers the one header that
+// cannot be copied from the capture. withClientMeta rewrites the body's
+// protocolVersion, and the header "MUST match" it, so echoing what the capture
+// declared would disagree with the body by construction.
+func TestReplayHTTPDeclaresTheRevisionItActuallySends(t *testing.T) {
+	var header, body string
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, msg map[string]json.RawMessage) {
+		header = h.Get("MCP-Protocol-Version")
+		var params struct {
+			Meta struct {
+				Version string `json:"io.modelcontextprotocol/protocolVersion"`
+			} `json:"_meta"`
+		}
+		_ = json.Unmarshal(msg["params"], &params)
+		body = params.Meta.Version
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	// The captured body declares an older revision, which withClientMeta replaces.
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo","_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}`),
+		Routing{Name: "echo"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if header != body {
+		t.Fatalf("header says %q and the body says %q; a server rejects that with -32020", header, body)
+	}
+	if header != statelessProtocolVersion {
+		t.Fatalf("declared %q, want the revision the replay actually speaks", header)
+	}
+}
+
+// TestReplayHTTPReadsAStreamedAnswer covers the other shape a server may choose,
+// where request-scoped notifications precede the response.
+func TestReplayHTTPReadsAStreamedAnswer(t *testing.T) {
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, ":\r\n\r\n") // a keep-alive comment, which clients must ignore
+		fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{}}\n\n")
+		fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"streamed\"}]}}\n\n")
+	})
+	defer srv.Close()
+
+	res, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Err != nil {
+		t.Fatalf("error: %+v", res.Err)
+	}
+	if !strings.Contains(string(res.RPCResult), "streamed") {
+		t.Fatalf("the answer was not read past the notifications: %s", res.RPCResult)
+	}
+}
+
+// TestReplayHTTPNamesWhatWentWrong covers the failures a replay is most likely
+// to cause, so a reader is told what to do rather than handed a status code.
+func TestReplayHTTPNamesWhatWentWrong(t *testing.T) {
+	t.Run("a credential is missing", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="https://h/.well-known/x"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "--replay-header") {
+			t.Fatalf("err = %v, want it to name the way to send one", err)
+		}
+		if !strings.Contains(err.Error(), "Bearer") {
+			t.Fatalf("err = %v, want the scheme the server demanded", err)
+		}
+	})
+
+	t.Run("the address is not an MCP endpoint", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}))
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "not a Streamable HTTP MCP endpoint") {
+			t.Fatalf("err = %v, want it to say the address is wrong", err)
+		}
+	})
+
+	t.Run("the server rejected the metadata", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1,
+				"error": map[string]any{"code": -32020, "message": "Mcp-Name does not match"}})
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "rejected the request metadata") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("no target", func(t *testing.T) {
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{}, "tools/call", nil, Routing{}, time.Second)
+		if err == nil || !strings.Contains(err.Error(), "--replay-target") {
+			t.Fatalf("err = %v, want it to name the flag", err)
+		}
+	})
+}
+
+// TestReplayHTTPRefusesToSendAPlaceholder keeps mcpsnoop's own scrubbing off a
+// live server. A redacted header value is not the client's data, and sending it
+// would put that placeholder on the server as though a user had typed it.
+func TestReplayHTTPRefusesToSendAPlaceholder(t *testing.T) {
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+		t.Error("the request should never have been sent")
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`),
+		Routing{Name: "echo", ParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Token", Value: "[REDACTED]", Redacted: true}}},
+		5*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "scrubbed by redaction") {
+		t.Fatalf("err = %v, want a refusal naming the reason", err)
+	}
+}
+
+// TestReplayHTTPCarriesACallerHeader is how a credential reaches the server,
+// since mcpsnoop records none and replays none.
+func TestReplayHTTPCarriesACallerHeader(t *testing.T) {
+	var auth string
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		auth = h.Get("Authorization")
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL, Headers: []string{"Authorization: Bearer sk-test"}},
+		"tools/call", json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if auth != "Bearer sk-test" {
+		t.Fatalf("Authorization = %q", auth)
+	}
+}
+
+// TestReplayHTTPSendsMcpNameOnlyWhereItIsRequired keeps a header off a request
+// the transport does not ask it for.
+func TestReplayHTTPSendsMcpNameOnlyWhereItIsRequired(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/list",
+		json.RawMessage(`{}`), Routing{Name: "leftover"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := seen.Get("Mcp-Name"); got != "" {
+		t.Fatalf("Mcp-Name = %q on tools/list, which the transport does not require it for", got)
+	}
+	if got := seen.Get("Mcp-Method"); got != "tools/list" {
+		t.Fatalf("Mcp-Method = %q", got)
+	}
+}
+
+// TestReplayHTTPDeclaresEveryRequiredMetaField covers the body, which the header
+// tests do not. From this revision clientCapabilities is required on every
+// request and clientInfo is not, and a request missing a required field is
+// malformed: the server "MUST reject it with JSON-RPC error code -32602" and
+// answer 400. mcpsnoop's own checker reports a client that omits it, so leaving
+// it out meant flagging its own replayed request.
+func TestReplayHTTPDeclaresEveryRequiredMetaField(t *testing.T) {
+	var meta map[string]json.RawMessage
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, msg map[string]json.RawMessage) {
+		var params struct {
+			Meta map[string]json.RawMessage `json:"_meta"`
+		}
+		_ = json.Unmarshal(msg["params"], &params)
+		meta = params.Meta
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		"io.modelcontextprotocol/protocolVersion",
+		"io.modelcontextprotocol/clientCapabilities",
+	} {
+		if _, ok := meta[field]; !ok {
+			t.Fatalf("_meta is missing %s, which the revision requires on every request: %v", field, meta)
+		}
+	}
+	if got := string(meta["io.modelcontextprotocol/clientCapabilities"]); got != "{}" {
+		t.Fatalf("clientCapabilities = %s, want an empty declaration; a one-shot replay can answer no input request", got)
+	}
+}
+
+// TestReplayHTTPWillNotFollowARedirect is the safety property the whole design
+// rests on. The address is the one the person replaying named and answered for,
+// and following a redirect hands that choice back to the far end: a 307 resends
+// the body, and on a hop that only changes the port Go forwards Authorization
+// too, so a staging endpoint could deliver a mutating call and a credential to
+// production while the overlay reported success.
+func TestReplayHTTPWillNotFollowARedirect(t *testing.T) {
+	var reached string
+	var sawAuth string
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = r.Host
+		sawAuth = r.Header.Get("Authorization")
+		okJSON(w, "reached the wrong host")
+	}))
+	defer second.Close()
+
+	for _, code := range []int{301, 302, 303, 307, 308} {
+		t.Run(fmt.Sprintf("%d", code), func(t *testing.T) {
+			reached, sawAuth = "", ""
+			first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Location", second.URL)
+				w.WriteHeader(code)
+			}))
+			defer first.Close()
+
+			_, err := ReplayHTTP(context.Background(),
+				HTTPTarget{URL: first.URL, Headers: []string{"Authorization: Bearer sk-secret", "X-Api-Key: k-secret"}},
+				"tools/call", json.RawMessage(`{"name":"echo","arguments":{"t":"private"}}`),
+				Routing{Name: "echo"}, 5*time.Second)
+			if err == nil {
+				t.Fatal("a redirect was followed and reported as a success")
+			}
+			if reached != "" {
+				t.Fatalf("the request reached %s, which nobody named; auth forwarded = %q", reached, sawAuth)
+			}
+			if !strings.Contains(err.Error(), "--replay-target") {
+				t.Fatalf("err = %v, want it to name where it wanted to go and how to allow it", err)
+			}
+		})
+	}
+}
+
+// TestReplayHTTPDerivesMcpNameFromTheBody covers the header the transport
+// sources from "params.name or params.uri" and requires a server to reject when
+// it disagrees with the body. Copying the captured one sent the old name against
+// a body somebody had renamed, and sent nothing at all for a capture from a
+// client that predates the header.
+func TestReplayHTTPDerivesMcpNameFromTheBody(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		method   string
+		params   string
+		captured string
+		want     string
+	}{
+		{"the body names the tool", "tools/call", `{"name":"renamed"}`, "captured", "renamed"},
+		{"a capture that carried none", "tools/call", `{"name":"echo"}`, "", "echo"},
+		{"a resource names its uri", "resources/read", `{"uri":"file:///a.txt"}`, "", "file:///a.txt"},
+		{"a body naming nothing falls back", "tools/call", `{}`, "captured", "captured"},
+		{"a name outside plain ascii is wrapped", "tools/call", `{"name":"Hello, 世界"}`, "", "=?base64?SGVsbG8sIOS4lueVjA==?="},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen string
+			srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+				seen = h.Get("Mcp-Name")
+				okJSON(w, "ok")
+			})
+			defer srv.Close()
+			if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, tc.method,
+				json.RawMessage(tc.params), Routing{Name: tc.captured}, 5*time.Second); err != nil {
+				t.Fatal(err)
+			}
+			if seen != tc.want {
+				t.Fatalf("Mcp-Name = %q, want %q", seen, tc.want)
+			}
+		})
+	}
+}
+
+// TestReplayHTTPOnlySetsTheParamFamilyFromACapture keeps a log from choosing the
+// request's headers. A capture is a file people hand around, and setting
+// whatever name it carries let a doctored one overwrite the mandatory headers or
+// add a credential the operator never passed.
+func TestReplayHTTPOnlySetsTheParamFamilyFromACapture(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo", ParamHeaders: []proxy.MCPParamHeader{
+			{Name: "Mcp-Param-Region", Value: "us-west1"},
+			{Name: "Authorization", Value: "Bearer stolen"},
+			{Name: "MCP-Protocol-Version", Value: "1999-01-01"},
+			{Name: "Accept", Value: "text/plain"},
+			{Name: "Mcp-Method", Value: "tools/list"},
+		}}, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := seen.Get("Mcp-Param-Region"); got != "us-west1" {
+		t.Fatalf("the family that should be replayed was dropped: %q", got)
+	}
+	for name, notWant := range map[string]string{
+		"Authorization":        "Bearer stolen",
+		"MCP-Protocol-Version": "1999-01-01",
+		"Accept":               "text/plain",
+		"Mcp-Method":           "tools/list",
+	} {
+		if seen.Get(name) == notWant {
+			t.Fatalf("a capture set %s to %q", name, notWant)
+		}
+	}
+}
+
+// TestReplayHTTPDropsMirroredHeadersOnAnEditedBody keeps a stale assertion off
+// the request. An Mcp-Param-* mirrors a captured argument, so against a body
+// somebody rewrote it claims something mcpsnoop cannot know is still true.
+func TestReplayHTTPDropsMirroredHeadersOnAnEditedBody(t *testing.T) {
+	var seen http.Header
+	srv := mcpEndpoint(t, func(w http.ResponseWriter, h http.Header, _ map[string]json.RawMessage) {
+		seen = h.Clone()
+		okJSON(w, "ok")
+	})
+	defer srv.Close()
+
+	if _, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+		json.RawMessage(`{"name":"echo","arguments":{"region":"eu-west1"}}`),
+		Routing{Name: "echo", Edited: true,
+			ParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}}},
+		5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := seen.Get("Mcp-Param-Region"); got != "" {
+		t.Fatalf("Mcp-Param-Region = %q, want none; the body was rewritten and the header mirrors the old one", got)
+	}
+	// The name is still derived, since it comes from the body being sent.
+	if got := seen.Get("Mcp-Name"); got != "echo" {
+		t.Fatalf("Mcp-Name = %q", got)
+	}
+}
+
+// TestReplayHTTPNamesAnAnswerItCannotUse covers the shapes that used to be
+// reported as a success or blamed on the wrong thing.
+func TestReplayHTTPNamesAnAnswerItCannotUse(t *testing.T) {
+	t.Run("valid json that is not a response", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","message":"proxy says hello"}`))
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "not a JSON-RPC response") {
+			t.Fatalf("err = %v, want it to say the answer is not a response", err)
+		}
+	})
+
+	t.Run("an empty body", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "empty body") {
+			t.Fatalf("err = %v, want it to name the empty body", err)
+		}
+	})
+
+	t.Run("a stream whose media type is spelled differently", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "Text/Event-Stream; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[]}}\n\n")
+		})
+		defer srv.Close()
+		res, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 5*time.Second)
+		if err != nil {
+			t.Fatalf("a media type is case-insensitive: %v", err)
+		}
+		if res.Err != nil {
+			t.Fatalf("error: %+v", res.Err)
+		}
+	})
+
+	t.Run("an answer past the cap", func(t *testing.T) {
+		srv := mcpEndpoint(t, func(w http.ResponseWriter, _ http.Header, _ map[string]json.RawMessage) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"`))
+			chunk := strings.Repeat("x", 64<<10)
+			for range (maxReplayBody / len(chunk)) + 2 {
+				_, _ = w.Write([]byte(chunk))
+			}
+			_, _ = w.Write([]byte(`"}]}}`))
+		})
+		defer srv.Close()
+		_, err := ReplayHTTP(context.Background(), HTTPTarget{URL: srv.URL}, "tools/call",
+			json.RawMessage(`{"name":"echo"}`), Routing{Name: "echo"}, 20*time.Second)
+		if err == nil || !strings.Contains(err.Error(), "larger than") {
+			t.Fatalf("err = %v, want the size named rather than the server blamed for a cut body", err)
+		}
+	})
+}

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -170,6 +170,18 @@ func withClientMeta(params json.RawMessage) json.RawMessage {
 	meta["io.modelcontextprotocol/protocolVersion"] = json.RawMessage(strconv.Quote(statelessProtocolVersion))
 	meta["io.modelcontextprotocol/clientInfo"] = json.RawMessage(
 		fmt.Sprintf(`{"name":%q,"version":"dev"}`, clientName))
+	// Required on every request from this revision, unlike clientInfo, which is
+	// not. A request missing a required field is malformed and the server "MUST
+	// reject it with JSON-RPC error code -32602", answering 400 over HTTP, so
+	// leaving it out made every replay fail against a conforming server. The
+	// store's own checker reports a client that omits it, which is to say
+	// mcpsnoop was flagging its own replayed request.
+	//
+	// An empty object is the honest declaration rather than a placeholder. It says
+	// this client has nothing to offer, which is true of a one-shot replay: it
+	// cannot answer an input request, and a server is told not to rely on a
+	// capability nobody declared.
+	meta["io.modelcontextprotocol/clientCapabilities"] = json.RawMessage(`{}`)
 
 	// jsonwire on all three marshals in this file: these carry captured params
 	// back to a live server, and the replay overlay renders what is built here.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/replay"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 )
 
@@ -137,6 +138,14 @@ type Model struct {
 
 	paused bool
 
+	// httpReplay is where a replay of an HTTP session goes, supplied by whoever
+	// opened the capture. Empty means this build of the session cannot replay one.
+	httpReplay replay.HTTPTarget
+	// replayRouting is the request metadata of the frame a replay came from, kept
+	// so repeating one, or sending it again after an edit, carries the same
+	// headers as the first attempt rather than none.
+	replayRouting replay.Routing
+
 	overlay        overlayMode
 	replayReq      store.CallView  // last user-supplied request sent to replay, so r can re-run it from the result
 	replayCaptured json.RawMessage // immutable params from the observed request behind the current replay loop
@@ -227,7 +236,18 @@ func (m Model) flashActive() bool {
 // its own version resolution, so New stays test friendly.
 var Version = "dev"
 
-func New(st *store.Store) Model {
+// Option configures a Model at construction. It is variadic so the callers that
+// need nothing keep their call sites.
+type Option func(*Model)
+
+// WithHTTPReplay says where a replay of an HTTP-captured session goes. Without
+// it such a session is not replayable, because what a capture records is the
+// endpoint stripped of anything credential-shaped and is not an address to dial.
+func WithHTTPReplay(target replay.HTTPTarget) Option {
+	return func(m *Model) { m.httpReplay = target }
+}
+
+func New(st *store.Store, opts ...Option) Model {
 	ti := textinput.New()
 	ti.Prompt = ""
 
@@ -240,6 +260,10 @@ func New(st *store.Store) Model {
 		view:   viewSessions,
 		follow: true,
 		input:  ti,
+	}
+
+	for _, opt := range opts {
+		opt(&m)
 	}
 
 	m.refresh()
@@ -306,7 +330,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		edited := !replayParamsEquivalent(msg.captured, msg.call.Params)
-		return m, m.runReplay(msg.call, msg.captured, edited)
+		routing := m.replayRouting
+		routing.Edited = edited
+		return m, m.runReplay(msg.call, msg.captured, edited, routing)
 
 	case replayDoneMsg:
 		if !m.replaying || msg.token != m.replayToken {
@@ -815,8 +841,23 @@ func (m Model) canReplay() bool {
 // per-frame flicker, so replay is never offered for a session that can never
 // run it (for example a log opened without its meta frame).
 func (m Model) sessionReplayable() bool {
-	_, _, ok := m.store.Command(m.streamSessionID)
-	return ok
+	if _, _, ok := m.store.Command(m.streamSessionID); ok {
+		return true
+	}
+	// An HTTP session records no command to run, because mcpsnoop launched
+	// nothing, and the endpoint it does record is deliberately not an address to
+	// dial. So it is replayable only once somebody has said where a replay goes.
+	return m.httpReplay.URL != "" && m.sessionTransport() == proxy.TransportHTTP
+}
+
+// sessionTransport is the channel the streamed session was captured on.
+func (m Model) sessionTransport() string {
+	for _, h := range m.allSessions {
+		if h.ID == m.streamSessionID {
+			return h.Transport
+		}
+	}
+	return ""
 }
 
 func (m *Model) startReplay() tea.Cmd {
@@ -832,7 +873,8 @@ func (m *Model) startReplay() tea.Cmd {
 		m.setFlash("this frame's body was released to stay inside the live memory budget; reopen the session log to replay it")
 		return nil
 	}
-	return m.runReplay(*ev.Call, ev.Call.Params, false)
+	m.replayRouting = routingOf(ev)
+	return m.runReplay(*ev.Call, ev.Call.Params, false, m.replayRouting)
 }
 
 // replayAgain re-runs the last replayed request, so r works straight from the
@@ -841,7 +883,7 @@ func (m *Model) replayAgain() tea.Cmd {
 	if m.replayReq.Method == "" {
 		return nil
 	}
-	return m.runReplay(m.replayReq, m.replayCaptured, m.replayEdited)
+	return m.runReplay(m.replayReq, m.replayCaptured, m.replayEdited, m.replayRouting)
 }
 
 // startEditReplay opens the focused request, or the current replay candidate,
@@ -863,6 +905,7 @@ func (m *Model) startEditReplay() tea.Cmd {
 			m.setFlash("edit replay needs a request frame")
 			return nil
 		}
+		m.replayRouting = routingOf(ev)
 		if ev.BodyReleased {
 			m.setFlash("this frame's body was released to stay inside the live memory budget; reopen the session log to edit it")
 			return nil
@@ -872,7 +915,7 @@ func (m *Model) startEditReplay() tea.Cmd {
 	}
 
 	if !m.sessionReplayable() {
-		m.setFlash("no recorded server command to replay")
+		m.setFlash(m.unreplayableReason())
 		return nil
 	}
 	cmd, err := editReplayCmd(call, captured)
@@ -883,14 +926,13 @@ func (m *Model) startEditReplay() tea.Cmd {
 	return cmd
 }
 
-func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited bool) tea.Cmd {
+func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited bool, routing replay.Routing) tea.Cmd {
 	if m.replaying {
 		return nil // a replay is already in flight; ignore until it lands or is abandoned
 	}
 	command, cwd, ok := m.store.Command(m.streamSessionID)
 	if !ok {
-		m.setFlash("no recorded server command to replay")
-		return nil
+		return m.runHTTPReplay(call, captured, edited, routing)
 	}
 	// The command comes out of the log's meta frame, so replaying runs whatever
 	// that file says. A log is data people hand around, and the hub backfills any
@@ -906,7 +948,10 @@ func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited 
 		m.replayToken++
 		return replayCmd(m.replayToken, command, cwd, call.Method, call.Params)
 	}
-	if m.replayConfirmed == m.streamSessionID {
+	// An empty session id is not a session anybody confirmed. A log whose frames
+	// carry no session_id decodes to one, and the zero value of replayConfirmed
+	// would otherwise match it, so the first r would send unprompted.
+	if m.streamSessionID != "" && m.replayConfirmed == m.streamSessionID {
 		return start(m)
 	}
 	// The prompt names the edit, so answering n is unambiguously declining to send
@@ -918,6 +963,68 @@ func (m *Model) runReplay(call store.CallView, captured json.RawMessage, edited 
 	}
 	m.ask(what+strings.Join(command, " ")+"  y/n", start)
 	return nil
+}
+
+// unreplayableReason says why this session cannot replay, in its own terms. An
+// HTTP capture has no command and never had one, so telling its reader that a
+// command is missing describes a transport they are not using.
+func (m Model) unreplayableReason() string {
+	if m.sessionTransport() == proxy.TransportHTTP {
+		return "this session was captured over HTTP, so replay needs an address: reopen with --replay-target"
+	}
+	return "no recorded server command to replay"
+}
+
+// runHTTPReplay sends a captured request to a live endpoint over HTTP.
+//
+// The address is not the one in the capture. What a capture records is the
+// endpoint with its userinfo and every query value removed, so it names the
+// server without being dialable, and a replay reaches something real that may be
+// production. The person replaying says where it goes, with --replay-target, and
+// still answers for it once per session the way a recorded command is answered
+// for before it is run.
+func (m *Model) runHTTPReplay(call store.CallView, captured json.RawMessage, edited bool, routing replay.Routing) tea.Cmd {
+	if m.sessionTransport() != proxy.TransportHTTP {
+		m.setFlash(m.unreplayableReason())
+		return nil
+	}
+	if m.httpReplay.URL == "" {
+		m.setFlash(m.unreplayableReason())
+		return nil
+	}
+	start := func(m *Model) tea.Cmd {
+		m.replayConfirmed = m.streamSessionID
+		m.replayReq = call
+		m.replayReq.Params = append(json.RawMessage(nil), call.Params...)
+		m.replayCaptured = append(json.RawMessage(nil), captured...)
+		m.replayEdited = edited
+		m.replaying = true
+		m.replayToken++
+		return replayHTTPCmd(m.replayToken, m.httpReplay, call.Method, call.Params, routing)
+	}
+	if m.streamSessionID != "" && m.replayConfirmed == m.streamSessionID {
+		return start(m)
+	}
+	what := "replay posts to: "
+	if edited {
+		what = "replay your edited params to: "
+	}
+	m.ask(what+m.httpReplay.URL+"  y/n", start)
+	return nil
+}
+
+// routingOf reads the request metadata a captured frame carried, so a replay
+// re-sends what the client sent rather than deriving it again. The transport
+// makes these mandatory and a server rejects a mismatch, so re-deriving would be
+// a second chance to get them wrong. A value outside the safe ASCII set travels
+// base64-wrapped, and the capture holds whatever the client sent, so re-sending
+// it needs no encoder and cannot disagree with the body.
+//
+// Read off the frame rather than looked up by call, because the timeline is a
+// window on the current view and the frame is already in hand where replay
+// starts.
+func routingOf(ev store.EventView) replay.Routing {
+	return replay.Routing{Name: ev.MCPName, ParamHeaders: ev.MCPParamHeaders}
 }
 
 // applySortKey maps a shift+<letter> to a column sort for the current view.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2304,3 +2304,229 @@ func TestStreamSaysWhenOlderFramesAreOnlyOnDisk(t *testing.T) {
 		t.Fatalf("dropped frames are being reported as a hole in the capture:\n%s", view)
 	}
 }
+
+// httpSessionStore builds a capture of an HTTP session with its meta frame and
+// one tools/call carrying the routing headers the transport requires.
+func httpSessionStore(t *testing.T) *store.Store {
+	t.Helper()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Target: "https://api.example.com/mcp?key=[stripped]"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "httpdemo", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportHTTP, Raw: meta})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "httpdemo", Seq: 2, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportHTTP,
+		MCPMethod: "tools/call", MCPName: "echo",
+		MCPParamHeaders: []proxy.MCPParamHeader{{Name: "Mcp-Param-Region", Value: "us-west1"}},
+		Raw:             json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`)})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "httpdemo", Seq: 3, TS: t0.Add(10 * time.Millisecond),
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`)})
+	return st
+}
+
+// TestHTTPSessionIsReplayableOnlyWithATarget is the gate. An HTTP capture
+// records no command to run, and the endpoint it does record is stripped of
+// anything credential-shaped, so it is not an address to dial. Replay is offered
+// once somebody has said where it goes and not before.
+func TestHTTPSessionIsReplayableOnlyWithATarget(t *testing.T) {
+	st := httpSessionStore(t)
+
+	without := New(st)
+	without.streamSessionID = "s1"
+	without.allSessions = st.Sessions()
+	if without.sessionReplayable() {
+		t.Fatal("an HTTP session with no target should not offer replay")
+	}
+
+	with := New(st, WithHTTPReplay(replay.HTTPTarget{URL: "https://api.example.com/mcp?key=real"}))
+	with.streamSessionID = "s1"
+	with.allSessions = st.Sessions()
+	if !with.sessionReplayable() {
+		t.Fatal("an HTTP session with a target should offer replay")
+	}
+}
+
+// TestHTTPReplayWithoutATargetSaysWhy keeps the key from failing silently, and
+// keeps the stdio message off a session that never had a command to begin with.
+func TestHTTPReplayWithoutATargetSaysWhy(t *testing.T) {
+	st := httpSessionStore(t)
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	if cmd := m.runReplay(call, nil, false, replay.Routing{}); cmd != nil {
+		t.Fatal("a replay was started with nowhere to send it")
+	}
+	if !strings.Contains(m.flash, "--replay-target") {
+		t.Fatalf("flash = %q, want it to name the flag", m.flash)
+	}
+	if strings.Contains(m.flash, "no recorded server command") {
+		t.Fatalf("an HTTP session was told it is missing a command it never had: %q", m.flash)
+	}
+}
+
+// TestHTTPReplayAsksBeforeItSends keeps the once-per-session confirmation that
+// a recorded command already gets, because a replay reaches a live server that
+// may be the production one.
+func TestHTTPReplayAsksBeforeItSends(t *testing.T) {
+	st := httpSessionStore(t)
+	const target = "https://api.example.com/mcp?key=real"
+	m := New(st, WithHTTPReplay(replay.HTTPTarget{URL: target}))
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	if cmd := m.runReplay(call, nil, false, replay.Routing{}); cmd != nil {
+		t.Fatal("a replay was sent before it was answered for")
+	}
+	if !strings.Contains(m.confirm, target) {
+		t.Fatalf("the prompt does not name where it posts: %q", m.confirm)
+	}
+	if m.replaying {
+		t.Fatal("the replay is already in flight")
+	}
+}
+
+// TestHTTPReplayReusesTheCapturedRoutingHeaders keeps a replay from deriving the
+// request metadata a second time. The capture holds what the client sent,
+// including any base64 sentinel form, so re-sending it cannot disagree with the
+// body the way a re-derivation could.
+func TestHTTPReplayReusesTheCapturedRoutingHeaders(t *testing.T) {
+	st := httpSessionStore(t)
+	m := New(st, WithHTTPReplay(replay.HTTPTarget{URL: "https://h/mcp"}))
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	_ = call
+	// Read off the frame where a replay starts, which is where the headers are.
+	m.view = viewStream
+	m.refresh()
+	ev, ok := m.focusedFrameByMethod("tools/call")
+	if !ok {
+		t.Fatalf("no request frame in the timeline: %d frames", len(m.timeline))
+	}
+	routing := routingOf(ev)
+	if routing.Name != "echo" {
+		t.Fatalf("Mcp-Name = %q, want the captured one", routing.Name)
+	}
+	if len(routing.ParamHeaders) != 1 || routing.ParamHeaders[0].Name != "Mcp-Param-Region" ||
+		routing.ParamHeaders[0].Value != "us-west1" {
+		t.Fatalf("param headers = %+v, want the captured one", routing.ParamHeaders)
+	}
+}
+
+// TestAStdioSessionStillReplaysItsCommand keeps the transport that already
+// worked working, and keeps its prompt naming the command rather than an address.
+func TestAStdioSessionStillReplaysItsCommand(t *testing.T) {
+	st := store.New()
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "server.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+	st.Ingest(proxy.Envelope{SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`)})
+
+	m := New(st, WithHTTPReplay(replay.HTTPTarget{URL: "https://h/mcp"}))
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+	if !m.sessionReplayable() {
+		t.Fatal("a stdio session lost its replay")
+	}
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	m.runReplay(call, nil, false, replay.Routing{})
+	if !strings.Contains(m.confirm, "node server.js") {
+		t.Fatalf("the prompt should still name the command it runs: %q", m.confirm)
+	}
+	if strings.Contains(m.confirm, "https://h/mcp") {
+		t.Fatalf("a stdio session was offered an HTTP target: %q", m.confirm)
+	}
+}
+
+// focusedFrameByMethod finds a request frame in the current timeline, so a test
+// can read the routing headers a replay would send without driving the cursor.
+func (m Model) focusedFrameByMethod(method string) (store.EventView, bool) {
+	for _, ev := range m.timeline {
+		if ev.Kind == store.EventRequest && ev.Method == method {
+			return ev, true
+		}
+	}
+	return store.EventView{}, false
+}
+
+// TestEditReplayOnAnHTTPSessionSaysWhy keeps R from telling an HTTP reader that
+// a command is missing. It never had one, and the message describes a transport
+// they are not using.
+func TestEditReplayOnAnHTTPSessionSaysWhy(t *testing.T) {
+	st := httpSessionStore(t)
+	m := New(st)
+	m.streamSessionID = "s1"
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.view = viewStream
+	m.refresh()
+	for i, ev := range m.timeline {
+		if ev.Kind == store.EventRequest {
+			m.selEvent = i
+		}
+	}
+
+	if cmd := m.startEditReplay(); cmd != nil {
+		t.Fatal("an editor was opened for a session with nowhere to send the result")
+	}
+	if !strings.Contains(m.flash, "--replay-target") {
+		t.Fatalf("flash = %q, want it to name the flag", m.flash)
+	}
+	if strings.Contains(m.flash, "no recorded server command") {
+		t.Fatalf("an HTTP session was told it is missing a command it never had: %q", m.flash)
+	}
+}
+
+// TestAnEmptySessionIdStillAsksBeforeReplaying keeps the once-per-session
+// confirmation from being satisfied by a zero value. A log whose frames carry no
+// session_id decodes to a session whose id is empty, which the unset
+// replayConfirmed matched.
+func TestAnEmptySessionIdStillAsksBeforeReplaying(t *testing.T) {
+	t0 := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	meta, err := json.Marshal(proxy.SessionMeta{Command: []string{"node", "server.js"}, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	st.Ingest(proxy.Envelope{ServerLabel: "srv", Seq: 1, TS: t0,
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta})
+	st.Ingest(proxy.Envelope{ServerLabel: "srv", Seq: 2, TS: t0.Add(time.Millisecond),
+		Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+		Raw: json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo"}}`)})
+
+	m := New(st)
+	m.streamSessionID = ""
+	m.allSessions = st.Sessions()
+	m.width, m.height = 120, 40
+	m.refresh()
+
+	call := store.CallView{RequestSeq: 2, Method: "tools/call", ToolName: "echo", IsTool: true}
+	if cmd := m.runReplay(call, nil, false, replay.Routing{}); cmd != nil {
+		t.Fatal("a replay was sent without being answered for")
+	}
+	if m.confirm == "" {
+		t.Fatal("no confirmation was asked for")
+	}
+}

--- a/internal/tui/replay.go
+++ b/internal/tui/replay.go
@@ -256,3 +256,14 @@ func indentJSON(raw json.RawMessage) string {
 	}
 	return buf.String()
 }
+
+// replayHTTPCmd sends a captured request to a live endpoint over HTTP, off the
+// UI goroutine, and reports the outcome under the token of the run that asked
+// for it so a result the user walked away from cannot be rendered against the
+// run that replaced it.
+func replayHTTPCmd(token uint64, target replay.HTTPTarget, method string, params json.RawMessage, routing replay.Routing) tea.Cmd {
+	return func() tea.Msg {
+		res, err := replay.ReplayHTTP(context.Background(), target, method, params, routing, replayTimeout)
+		return replayDoneMsg{token: token, res: res, err: err}
+	}
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -123,8 +123,8 @@ func observeAndNudge(m *toolbaseline.Manager, st *store.Store, sessionID string,
 }
 
 // RunOpen starts the TUI using a preloaded store without starting the live hub.
-func RunOpen(ctx context.Context, st *store.Store) error {
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
+func RunOpen(ctx context.Context, st *store.Store, opts ...Option) error {
+	p := tea.NewProgram(New(st, opts...), tea.WithAltScreen(), tea.WithContext(ctx))
 	go observeAllInBackground(p, st)
 	_, err := p.Run()
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {
@@ -134,8 +134,8 @@ func RunOpen(ctx context.Context, st *store.Store) error {
 }
 
 // RunOpenWithInput starts the TUI using a preloaded store and a custom input reader (e.g., controlling TTY).
-func RunOpenWithInput(ctx context.Context, st *store.Store, in io.Reader) error {
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx), tea.WithInput(in))
+func RunOpenWithInput(ctx context.Context, st *store.Store, in io.Reader, opts ...Option) error {
+	p := tea.NewProgram(New(st, opts...), tea.WithAltScreen(), tea.WithContext(ctx), tea.WithInput(in))
 	go observeAllInBackground(p, st)
 	_, err := p.Run()
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Closes #164