### PR TITLE
feat: expose live Prometheus tool metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,37 @@ since it names the auth scheme and the resource metadata to go to next. Filter b
 status with `status:401` in the TUI, or by any failure with `status:err`. A 4xx
 or 5xx counts as an error, so a default `mcpsnoop check` run fails on it.
 
+### Prometheus metrics
+
+Start the hub with an explicit metrics address to expose live tool-call metrics:
+
+```bash
+mcpsnoop --metrics-listen 127.0.0.1:9464
+curl http://127.0.0.1:9464/metrics
+```
+
+The listener is separate from the MCP proxy listener and is disabled unless
+`--metrics-listen` is provided. Startup history replay is not counted as new live
+traffic. Every series has `server`, `server_id`, and `tool` labels;
+`server_id` is a stable short fingerprint of the recorded server identity, so
+two servers with the same label remain separate without exposing commands,
+paths, endpoints, or session IDs. Error counters also have `error_type`, either
+`tool` for `result.isError` or `protocol` for a JSON-RPC or other protocol-level
+failure.
+
+The public metrics are:
+
+| Metric | Meaning |
+|---|---|
+| `mcpsnoop_tool_calls_total` | live tool-call requests observed |
+| `mcpsnoop_tool_errors_total` | live tool errors, split by `error_type` |
+| `mcpsnoop_tool_call_duration_seconds` | request-to-response latency histogram |
+
+The histogram exports the standard `_bucket`, `_sum`, and `_count` series with
+`0.005`, `0.01`, `0.025`, `0.05`, `0.1`, `0.25`, `0.5`, `1`, `2.5`, `5`, `10`,
+and `+Inf` second buckets. Pending, superseded, and calls cancelled without a
+result do not add latency observations.
+
 No server of your own? [Try it for real](docs/TRY_IT.md) against a published
 test server, driven by your own client. To inspect a session after it happened,
 see [review past sessions from logs](docs/POST_MORTEM.md).
@@ -146,6 +177,7 @@ Explicit command-line flags override values from the config file.
 |---|---|
 | `mcpsnoop -- <server>` | wrap a stdio server as a transparent shim |
 | `mcpsnoop` | open the live TUI |
+| `mcpsnoop --metrics-listen <addr>` | open the TUI and expose live Prometheus metrics |
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, har, or otlp |
 | `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, late results, or a latency budget |

--- a/README.md
+++ b/README.md
@@ -123,12 +123,13 @@ curl http://127.0.0.1:9464/metrics
 
 The listener is separate from the MCP proxy listener and is disabled unless
 `--metrics-listen` is provided. Startup history replay is not counted as new live
-traffic. Every series has `server`, `server_id`, and `tool` labels;
-`server_id` is a stable short fingerprint of the recorded server identity, so
-two servers with the same label remain separate without exposing commands,
-paths, endpoints, or session IDs. Error counters also have `error_type`, either
-`tool` for `result.isError` or `protocol` for a JSON-RPC or other protocol-level
-failure.
+traffic.
+
+Every series has `server`, `server_id` and `tool` labels. `server_id` is a stable
+short fingerprint of the recorded server identity, so two servers with the same
+label remain separate without exposing commands, paths, endpoints or session IDs.
+Error counters also have `error_type`, either `tool` for `result.isError` or
+`protocol` for a JSON-RPC or other protocol-level failure.
 
 The public metrics are:
 
@@ -137,11 +138,35 @@ The public metrics are:
 | `mcpsnoop_tool_calls_total` | live tool-call requests observed |
 | `mcpsnoop_tool_errors_total` | live tool errors, split by `error_type` |
 | `mcpsnoop_tool_call_duration_seconds` | request-to-response latency histogram |
+| `mcpsnoop_transport_errors_total` | live transport failures that carried no JSON-RPC message, by `status` |
 
-The histogram exports the standard `_bucket`, `_sum`, and `_count` series with
-`0.005`, `0.01`, `0.025`, `0.05`, `0.1`, `0.25`, `0.5`, `1`, `2.5`, `5`, `10`,
-and `+Inf` second buckets. Pending, superseded, and calls cancelled without a
-result do not add latency observations.
+The histogram exports the standard `_bucket`, `_sum` and `_count` series with
+`0.005`, `0.01`, `0.025`, `0.05`, `0.1`, `0.25`, `0.5`, `1`, `2.5`, `5`, `10`
+and `+Inf` second buckets. Pending and superseded calls, and calls cancelled
+without a result, add no latency observation.
+
+**The endpoint has no authentication.** Anything that can reach the address gets
+the tool names of every server this hub is watching. The `127.0.0.1` above is
+the example for a reason. Binding `:9464` publishes those names to the network.
+
+The `tool` label comes off the wire, so it is bounded on the way in. A name over
+128 bytes is truncated, and past two thousand distinct series per hub the rest
+are counted together under `tool="(over-series-cap)"`. The totals stay right
+either way. Without those bounds a peer choosing tool names decides how much
+memory the hub uses and how large a scrape is, and one 4 MiB name measured out
+at a 71 MB response, which Prometheus drops whole.
+
+`mcpsnoop_tool_errors_total` counts errors that arrive as a JSON-RPC error or as
+`result.isError`. A failure that never became a JSON-RPC message, such as a 502
+from a gateway or a 401 challenge, cannot be attributed to a tool, because
+nothing in the response says which request it answered. Those go to
+`mcpsnoop_transport_errors_total` with the status, and the family is exported
+even when it is empty, so a graph of it on a healthy hub is flat rather than
+absent.
+
+The endpoint reports what this hub has seen since it started. It is not a store
+of record, and a hub restart starts the counters again, which Prometheus reads
+as a counter reset.
 
 No server of your own? [Try it for real](docs/TRY_IT.md) against a published
 test server, driven by your own client. To inspect a session after it happened,

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ or 5xx counts as an error, so a default `mcpsnoop check` run fails on it.
 
 ### Prometheus metrics
 
-Start the hub with an explicit metrics address to expose live tool-call metrics:
+Start a headless hub with an explicit metrics address to expose live tool-call
+metrics (use bare `mcpsnoop` when you want the interactive TUI):
 
 ```bash
 mcpsnoop --metrics-listen 127.0.0.1:9464
@@ -177,7 +178,7 @@ Explicit command-line flags override values from the config file.
 |---|---|
 | `mcpsnoop -- <server>` | wrap a stdio server as a transparent shim |
 | `mcpsnoop` | open the live TUI |
-| `mcpsnoop --metrics-listen <addr>` | open the TUI and expose live Prometheus metrics |
+| `mcpsnoop --metrics-listen <addr>` | run a headless hub and expose live Prometheus metrics |
 | `mcpsnoop http --target <url>` | proxy a streamable-HTTP server |
 | `mcpsnoop export` | render a session to json, html, text, har, or otlp |
 | `mcpsnoop check` | fail CI on errors, invalid frames, warnings, routing mismatches, hung calls, late results, or a latency budget |

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -304,7 +304,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.StringVar(&traceFile, "trace-file", "", "override the JSONL trace path, defaults to the well-known session log")
 	flags.StringVar(&otlpEndpoint, "otlp-endpoint", "", "stream completed calls to an OTLP/HTTP JSON traces endpoint")
 	flags.Var(&otlpHeaders, "otlp-header", "HTTP header for OTLP delivery as Name=Value, repeatable")
-	flags.StringVar(&metricsListen, "metrics-listen", "", "listen on this address for Prometheus metrics in hub mode")
+	flags.StringVar(&metricsListen, "metrics-listen", "", "run the hub headlessly and serve Prometheus metrics on this address, instead of starting the TUI (e.g. 127.0.0.1:9464)")
 	flags.BoolVar(&noTrace, "no-trace", false, "disable tracing, pure passthrough")
 	flags.BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -247,6 +247,7 @@ func newRootCmd() *cobra.Command {
 	var (
 		label, traceFile       string
 		otlpEndpoint           string
+		metricsListen          string
 		noTrace, redactSecrets bool
 		redactKeys             redactKeysFlag
 		redactValues           redactValuesFlag
@@ -272,7 +273,10 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 				if historyLimit < 0 {
 					return errors.New("--history-limit must be non-negative")
 				}
-				return codeOf(runHubFn(historyLimit))
+				return codeOf(runHubFn(historyLimit, metricsListen))
+			}
+			if metricsListen != "" {
+				return errors.New("--metrics-listen is only available when running the hub without a wrapped command")
 			}
 			cfg, ok, err := loadConfig()
 			if err != nil {
@@ -299,6 +303,7 @@ Repeated shim flags can live in a .mcpsnoop.toml file in the current directory.`
 	flags.StringVar(&traceFile, "trace-file", "", "override the JSONL trace path, defaults to the well-known session log")
 	flags.StringVar(&otlpEndpoint, "otlp-endpoint", "", "stream completed calls to an OTLP/HTTP JSON traces endpoint")
 	flags.Var(&otlpHeaders, "otlp-header", "HTTP header for OTLP delivery as Name=Value, repeatable")
+	flags.StringVar(&metricsListen, "metrics-listen", "", "listen on this address for Prometheus metrics in hub mode")
 	flags.BoolVar(&noTrace, "no-trace", false, "disable tracing, pure passthrough")
 	flags.BoolVar(&redactSecrets, "redact-secrets", false, "scrub common secret JSON keys in trace payloads")
 	flags.Var(&redactKeys, "redact-key", "JSON key name to scrub in saved trace payloads, repeat or comma-separated")
@@ -811,11 +816,11 @@ func newHTTPCmd() *cobra.Command {
 }
 
 // runHub runs the live TUI, collecting traffic from all shims and past sessions.
-func runHub(historyLimit int) int {
+func runHub(historyLimit int, metricsListen string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := tui.RunWithHistoryLimit(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit); err != nil {
+	if err := tui.RunWithHistoryLimitAndMetrics(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit, metricsListen); err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: %v\n", err)
 		return 1
 	}

--- a/cmd/mcpsnoop/main.go
+++ b/cmd/mcpsnoop/main.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kerlenton/mcpsnoop/internal/exporter"
 	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/metrics"
 	"github.com/kerlenton/mcpsnoop/internal/otlpsink"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
@@ -815,12 +816,18 @@ func newHTTPCmd() *cobra.Command {
 	return cmd
 }
 
-// runHub runs the live TUI, collecting traffic from all shims and past sessions.
+// runHub runs the live TUI, or a headless metrics hub when requested.
 func runHub(historyLimit int, metricsListen string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := tui.RunWithHistoryLimitAndMetrics(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit, metricsListen); err != nil {
+	var err error
+	if metricsListen != "" {
+		err = metrics.RunHeadless(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit, metricsListen)
+	} else {
+		err = tui.RunWithHistoryLimit(ctx, paths.SocketPath(), paths.SessionsDir(), historyLimit)
+	}
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "mcpsnoop: %v\n", err)
 		return 1
 	}

--- a/cmd/mcpsnoop/main_test.go
+++ b/cmd/mcpsnoop/main_test.go
@@ -244,10 +244,12 @@ func stubHTTP(ran *bool) func() {
 func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	hub := false
 	gotLimit := -1
+	gotMetrics := "unset"
 	origHub := runHubFn
-	runHubFn = func(limit int) int {
+	runHubFn = func(limit int, metrics string) int {
 		hub = true
 		gotLimit = limit
+		gotMetrics = metrics
 		return 0
 	}
 	defer func() { runHubFn = origHub }()
@@ -268,12 +270,15 @@ func TestRootNoArgsRunsHubNotShim(t *testing.T) {
 	if gotLimit != hubpkg.DefaultBackfillLimit {
 		t.Fatalf("history limit = %d, want default %d", gotLimit, hubpkg.DefaultBackfillLimit)
 	}
+	if gotMetrics != "" {
+		t.Fatalf("default metrics listener = %q, want disabled", gotMetrics)
+	}
 }
 
 func TestRootHistoryLimitConfiguresHub(t *testing.T) {
 	gotLimit := -1
 	origHub := runHubFn
-	runHubFn = func(limit int) int {
+	runHubFn = func(limit int, _ string) int {
 		gotLimit = limit
 		return 0
 	}
@@ -284,6 +289,37 @@ func TestRootHistoryLimitConfiguresHub(t *testing.T) {
 	}
 	if gotLimit != 7 {
 		t.Fatalf("history limit = %d, want 7", gotLimit)
+	}
+}
+
+func TestRootMetricsListenIsHubOnlyAndOptIn(t *testing.T) {
+	var got string
+	orig := runHubFn
+	runHubFn = func(_ int, listen string) int {
+		got = listen
+		return 0
+	}
+	defer func() { runHubFn = orig }()
+
+	if code := execute([]string{"--metrics-listen", "127.0.0.1:9464"}); code != 0 {
+		t.Fatalf("hub with metrics listener exit = %d, want 0", code)
+	}
+	if got != "127.0.0.1:9464" {
+		t.Fatalf("metrics listener = %q, want explicit address", got)
+	}
+
+	var ran bool
+	origShim := runShimFn
+	runShimFn = func([]string, string, string, bool, proxy.RedactConfig, traceOptions) int {
+		ran = true
+		return 0
+	}
+	defer func() { runShimFn = origShim }()
+	if code := execute([]string{"--metrics-listen", "127.0.0.1:9464", "--", "server"}); code != 2 {
+		t.Fatalf("shim with metrics listener exit = %d, want 2", code)
+	}
+	if ran {
+		t.Fatal("metrics listener must not instantiate the shim path")
 	}
 }
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -120,10 +120,28 @@ func (h *Hub) Run(ctx context.Context) error {
 		h.onBackfill(report)
 	}
 
-	// Stop accepting when the context is done.
+	// Stop accepting when the context is done, and hang up on whoever is already
+	// connected.
+	//
+	// Closing the listener alone is not enough. handleConn parks in Decode until
+	// its shim disconnects, so wg.Wait below would sit there for as long as the
+	// shim lives, which is forever for a shim wrapping a long-running server. The
+	// TUI never noticed because it does not wait for Run to return, but a
+	// headless hub is a process somebody sends SIGTERM to and expects to stop.
+	var (
+		connMu sync.Mutex
+		conns  = map[net.Conn]struct{}{}
+		closed bool
+	)
 	go func() {
 		<-ctx.Done()
 		ln.Close()
+		connMu.Lock()
+		closed = true
+		for conn := range conns {
+			conn.Close()
+		}
+		connMu.Unlock()
 	}()
 
 	var wg sync.WaitGroup
@@ -135,9 +153,24 @@ func (h *Hub) Run(ctx context.Context) error {
 			}
 			continue
 		}
+		connMu.Lock()
+		if closed {
+			// Cancellation landed between Accept and here, so nobody is left to
+			// close this one.
+			connMu.Unlock()
+			conn.Close()
+			break
+		}
+		conns[conn] = struct{}{}
+		connMu.Unlock()
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() {
+				connMu.Lock()
+				delete(conns, conn)
+				connMu.Unlock()
+			}()
 			h.handleConn(conn)
 		}()
 	}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -31,15 +31,17 @@ type Handler func(proxy.Envelope)
 
 // Hub collects envelopes from shims (socket) and past sessions (files).
 type Hub struct {
-	socketPath    string
-	sessionsDir   string
-	handler       Handler
-	backfillLimit int
-	onBackfill    func(BackfillReport)
-	onLive        Handler
+	socketPath         string
+	sessionsDir        string
+	handler            Handler
+	backfillLimit      int
+	onBackfill         func(BackfillReport)
+	onBackfillEnvelope Handler
+	onLive             Handler
 
-	mu   sync.Mutex
-	seen map[string]seenEntry // session id -> dedup high-water mark, with last touch
+	mu          sync.Mutex
+	seen        map[string]seenEntry // session id -> dedup high-water mark, with last touch
+	lastTouched time.Time
 }
 
 // seenEntry is one session's dedup high-water mark plus the last time it was
@@ -60,6 +62,10 @@ const seenCap = 10 * DefaultBackfillLimit
 type Options struct {
 	BackfillLimit int
 	OnBackfill    func(BackfillReport)
+	// OnBackfillEnvelope receives each unique envelope replayed from a session
+	// log. It is separate from OnLive so a consumer can prime state without
+	// treating historical traffic as new activity.
+	OnBackfillEnvelope Handler
 	// OnLive receives each unique envelope arriving from a connected shim. It is
 	// deliberately separate from handler so startup replay cannot look like new
 	// traffic to consumers such as live metrics.
@@ -82,13 +88,14 @@ func New(socketPath, sessionsDir string, handler Handler) *Hub {
 // NewWithOptions creates a hub with explicit startup behavior.
 func NewWithOptions(socketPath, sessionsDir string, handler Handler, opts Options) *Hub {
 	return &Hub{
-		socketPath:    socketPath,
-		sessionsDir:   sessionsDir,
-		handler:       handler,
-		backfillLimit: opts.BackfillLimit,
-		onBackfill:    opts.OnBackfill,
-		onLive:        opts.OnLive,
-		seen:          make(map[string]seenEntry),
+		socketPath:         socketPath,
+		sessionsDir:        sessionsDir,
+		handler:            handler,
+		backfillLimit:      opts.BackfillLimit,
+		onBackfill:         opts.OnBackfill,
+		onBackfillEnvelope: opts.OnBackfillEnvelope,
+		onLive:             opts.OnLive,
+		seen:               make(map[string]seenEntry),
 	}
 }
 
@@ -252,14 +259,23 @@ func (h *Hub) emitFrom(env proxy.Envelope, live bool) {
 		h.mu.Unlock()
 		return
 	}
-	h.seen[env.SessionID] = seenEntry{seq: env.Seq, touched: time.Now()}
+	touched := time.Now()
+	if !touched.After(h.lastTouched) {
+		touched = h.lastTouched.Add(time.Nanosecond)
+	}
+	h.lastTouched = touched
+	h.seen[env.SessionID] = seenEntry{seq: env.Seq, touched: touched}
 	if len(h.seen) > seenCap {
 		h.sweepSeen()
 	}
 	h.mu.Unlock()
 	h.handler(env)
-	if live && h.onLive != nil {
-		h.onLive(env)
+	if live {
+		if h.onLive != nil {
+			h.onLive(env)
+		}
+	} else if h.onBackfillEnvelope != nil {
+		h.onBackfillEnvelope(env)
 	}
 }
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -36,6 +36,7 @@ type Hub struct {
 	handler       Handler
 	backfillLimit int
 	onBackfill    func(BackfillReport)
+	onLive        Handler
 
 	mu   sync.Mutex
 	seen map[string]seenEntry // session id -> dedup high-water mark, with last touch
@@ -59,6 +60,10 @@ const seenCap = 10 * DefaultBackfillLimit
 type Options struct {
 	BackfillLimit int
 	OnBackfill    func(BackfillReport)
+	// OnLive receives each unique envelope arriving from a connected shim. It is
+	// deliberately separate from handler so startup replay cannot look like new
+	// traffic to consumers such as live metrics.
+	OnLive Handler
 }
 
 // BackfillReport describes how much saved history was replayed at startup.
@@ -82,6 +87,7 @@ func NewWithOptions(socketPath, sessionsDir string, handler Handler, opts Option
 		handler:       handler,
 		backfillLimit: opts.BackfillLimit,
 		onBackfill:    opts.OnBackfill,
+		onLive:        opts.OnLive,
 		seen:          make(map[string]seenEntry),
 	}
 }
@@ -161,7 +167,7 @@ func (h *Hub) handleConn(conn net.Conn) {
 			}
 			return // malformed stream, drop the connection
 		}
-		h.emit(env)
+		h.emitLive(env)
 	}
 }
 
@@ -233,6 +239,14 @@ func (h *Hub) replayFile(path string) {
 // second would restart at Seq 1 and be discarded whole, which is why the shim
 // mints a unique id per run rather than trusting the PID to be unique.
 func (h *Hub) emit(env proxy.Envelope) {
+	h.emitFrom(env, false)
+}
+
+func (h *Hub) emitLive(env proxy.Envelope) {
+	h.emitFrom(env, true)
+}
+
+func (h *Hub) emitFrom(env proxy.Envelope, live bool) {
 	h.mu.Lock()
 	if env.Seq <= h.seen[env.SessionID].seq {
 		h.mu.Unlock()
@@ -244,6 +258,9 @@ func (h *Hub) emit(env proxy.Envelope) {
 	}
 	h.mu.Unlock()
 	h.handler(env)
+	if live && h.onLive != nil {
+		h.onLive(env)
+	}
 }
 
 // sweepSeen drops the least-recently-touched quarter of the dedup map, keeping it

--- a/internal/hub/hub_metrics_test.go
+++ b/internal/hub/hub_metrics_test.go
@@ -1,0 +1,114 @@
+package hub_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/metrics"
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func writeMetricMetaLog(t *testing.T, dir, session string, command []string) {
+	t.Helper()
+	meta, err := json.Marshal(proxy.SessionMeta{Command: command, CWD: "/srv"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Create(filepath.Join(dir, session+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewEncoder(file).Encode(proxy.Envelope{
+		SessionID: session, ServerLabel: "same", Seq: 1, TS: time.Unix(1_700_000_000, 0),
+		Direction: proxy.DirectionMeta, Transport: proxy.TransportStdio, Raw: meta,
+	}); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBackfillPrimesMetricsIdentityForLiveReconnect(t *testing.T) {
+	sessionsDir := t.TempDir()
+	writeMetricMetaLog(t, sessionsDir, "s0", []string{"node", "alpha.js"})
+	writeMetricMetaLog(t, sessionsDir, "s1", []string{"node", "beta.js"})
+
+	socket := filepath.Join(os.TempDir(), fmt.Sprintf("mcpsnoop-metrics-%d.sock", os.Getpid()))
+	defer os.Remove(socket)
+	probe, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Skipf("unix sockets unavailable: %v", err)
+	}
+	probe.Close()
+	os.Remove(socket)
+	collector := metrics.New()
+	h := hub.NewWithOptions(socket, sessionsDir, func(proxy.Envelope) {}, hub.Options{
+		BackfillLimit:      0,
+		OnBackfillEnvelope: collector.Prime,
+		OnLive:             collector.Observe,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hubErr := make(chan error, 1)
+	go func() { hubErr <- h.Run(ctx) }()
+	for range 50 {
+		if _, err := os.Stat(socket); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(socket); err != nil {
+		cancel()
+		t.Fatalf("hub socket did not start: %v", err)
+	}
+
+	sink := proxy.NewSocketSink(socket, 0)
+	defer sink.Close()
+	for i := range 2 {
+		session := fmt.Sprintf("s%d", i)
+		at := time.Unix(1_700_000_000+int64(i), 0)
+		sink.Emit(proxy.Envelope{
+			SessionID: session, ServerLabel: "same", Seq: 2, TS: at,
+			Direction: proxy.ClientToServer, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"echo"}}`),
+		})
+		sink.Emit(proxy.Envelope{
+			SessionID: session, ServerLabel: "same", Seq: 3, TS: at.Add(time.Millisecond),
+			Direction: proxy.ServerToClient, Transport: proxy.TransportStdio,
+			Raw: json.RawMessage(`{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`),
+		})
+	}
+
+	var out strings.Builder
+	for range 100 {
+		out.Reset()
+		if err := collector.Write(&out); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out.String(), `mcpsnoop_tool_calls_total{server="same"`) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if err := <-hubErr; err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(out.String(), `mcpsnoop_tool_calls_total{server="same"`); got != 2 {
+		t.Fatalf("backfill did not prime distinct reconnect identities, got %d series:\n%s", got, out.String())
+	}
+}

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/kerlenton/mcpsnoop/internal/metrics"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 )
 
@@ -112,11 +110,11 @@ func TestHubOnLiveExcludesBackfill(t *testing.T) {
 	writeLog(t, sessionsDir, "s1", historyRequest, historyResponse)
 
 	var live []proxy.Envelope
-	collector := metrics.New()
+	backfilled := 0
 	h := NewWithOptions("", sessionsDir, func(proxy.Envelope) {}, Options{
+		OnBackfillEnvelope: func(proxy.Envelope) { backfilled++ },
 		OnLive: func(e proxy.Envelope) {
 			live = append(live, e)
-			collector.Observe(e)
 		},
 	})
 	h.backfill(context.Background())
@@ -128,15 +126,11 @@ func TestHubOnLiveExcludesBackfill(t *testing.T) {
 	h.emitLive(liveRequest)
 	h.emitLive(liveResponse)
 
+	if backfilled != 2 {
+		t.Fatalf("backfill callback count = %d, want 2", backfilled)
+	}
 	if len(live) != 2 || live[0].Seq != 3 || live[1].Seq != 4 {
 		t.Fatalf("live callback = %+v, want only seq 3 and 4", live)
-	}
-	var exposition strings.Builder
-	if err := collector.Write(&exposition); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(exposition.String(), `",tool="echo"} 1`) {
-		t.Fatalf("backfill was counted as live traffic:\n%s", exposition.String())
 	}
 }
 

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/kerlenton/mcpsnoop/internal/metrics"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 )
 
@@ -97,6 +99,44 @@ func TestHubBackfillLiveDedup(t *testing.T) {
 	case e := <-got:
 		t.Fatalf("unexpected extra frame: %+v", e)
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestHubOnLiveExcludesBackfill(t *testing.T) {
+	sessionsDir := t.TempDir()
+	historyRequest := env("s1", 1, "tools/call")
+	historyRequest.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"echo"}}`)
+	historyResponse := env("s1", 2, "response")
+	historyResponse.Direction = proxy.ServerToClient
+	historyResponse.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"1","result":{"content":[]}}`)
+	writeLog(t, sessionsDir, "s1", historyRequest, historyResponse)
+
+	var live []proxy.Envelope
+	collector := metrics.New()
+	h := NewWithOptions("", sessionsDir, func(proxy.Envelope) {}, Options{
+		OnLive: func(e proxy.Envelope) {
+			live = append(live, e)
+			collector.Observe(e)
+		},
+	})
+	h.backfill(context.Background())
+	liveRequest := env("s1", 3, "tools/call")
+	liveRequest.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"echo"}}`)
+	liveResponse := env("s1", 4, "response")
+	liveResponse.Direction = proxy.ServerToClient
+	liveResponse.Raw = json.RawMessage(`{"jsonrpc":"2.0","id":"2","result":{"content":[]}}`)
+	h.emitLive(liveRequest)
+	h.emitLive(liveResponse)
+
+	if len(live) != 2 || live[0].Seq != 3 || live[1].Seq != 4 {
+		t.Fatalf("live callback = %+v, want only seq 3 and 4", live)
+	}
+	var exposition strings.Builder
+	if err := collector.Write(&exposition); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(exposition.String(), `",tool="echo"} 1`) {
+		t.Fatalf("backfill was counted as live traffic:\n%s", exposition.String())
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,375 @@
+// Package metrics aggregates live tool calls and exposes Prometheus text
+// exposition without adding a runtime telemetry dependency.
+package metrics
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+	"github.com/kerlenton/mcpsnoop/internal/store"
+)
+
+const (
+	toolCallsMetric    = "mcpsnoop_tool_calls_total"
+	toolErrorsMetric   = "mcpsnoop_tool_errors_total"
+	toolDurationMetric = "mcpsnoop_tool_call_duration_seconds"
+)
+
+// Buckets are the conventional Prometheus defaults, expressed in seconds.
+var buckets = [...]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+// Collector is the hub-side live metrics aggregate. Its small bounded store is
+// only a correlator: counters and histogram observations are retained here,
+// while frame bodies and the timeline are not.
+type Collector struct {
+	mu         sync.RWMutex
+	store      *store.Store
+	series     map[seriesKey]*toolSeries
+	operations map[operationKey]*operation
+	inflight   map[requestKey]operationKey
+	cancelled  []operationKey
+}
+
+type seriesKey struct {
+	server   string
+	serverID string
+	tool     string
+}
+
+type operationKey struct {
+	session string
+	seq     uint64
+}
+
+type requestKey struct {
+	session string
+	id      string
+}
+
+type operation struct {
+	series    seriesKey
+	id        string
+	cancelled bool
+}
+
+type toolSeries struct {
+	calls  uint64
+	errors [2]uint64
+	bucket [len(buckets) + 1]uint64
+	sum    float64
+	count  uint64
+}
+
+// New creates an empty live collector. It deliberately uses a one-frame
+// bounded Store so Store remains the sole owner of JSON-RPC and MRTR
+// correlation without retaining a second copy of the live capture.
+func New() *Collector {
+	return &Collector{
+		store:      store.NewBounded(1, 1),
+		series:     make(map[seriesKey]*toolSeries),
+		operations: make(map[operationKey]*operation),
+		inflight:   make(map[requestKey]operationKey),
+	}
+}
+
+// Observe adds one deduplicated live envelope. It does no network or disk work.
+func (c *Collector) Observe(env proxy.Envelope) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	event := c.store.Ingest(env)
+	header, ok := sessionHeader(c.store, env.SessionID)
+	if !ok {
+		return
+	}
+	server := labelsForSession(c.store, env.SessionID, header)
+
+	if event.Kind == store.EventRequest && event.Call != nil && event.MRTRRoot == "" &&
+		event.Call.IsTool && event.Call.ToolName != "" {
+		key := operationKey{session: env.SessionID, seq: event.Call.RequestSeq}
+		if _, exists := c.operations[key]; !exists {
+			request := requestKey{session: env.SessionID, id: event.Call.ID}
+			if previous, exists := c.inflight[request]; exists && previous != key {
+				delete(c.operations, previous)
+			}
+			series := seriesKey{server: server.label, serverID: server.id, tool: event.Call.ToolName}
+			c.operations[key] = &operation{series: series, id: event.Call.ID}
+			c.inflight[request] = key
+			c.seriesFor(series).calls++
+		}
+	}
+
+	call := event.Call
+	if event.TaskCall != nil && event.TaskCall.IsTool {
+		call = event.TaskCall
+	}
+	if call == nil || !call.IsTool || call.ToolName == "" || !call.Done() {
+		return
+	}
+	key := operationKey{session: env.SessionID, seq: call.RequestSeq}
+	op := c.operations[key]
+	if op == nil {
+		return
+	}
+	if call.State == store.Cancelled && !call.LateResult {
+		if !op.cancelled {
+			op.cancelled = true
+			c.cancelled = append(c.cancelled, key)
+			c.trimCancelled()
+		}
+		return
+	}
+
+	series := c.seriesFor(op.series)
+	if call.Errored {
+		if call.ToolErr {
+			series.errors[0]++
+		} else {
+			series.errors[1]++
+		}
+	}
+	if call.State != store.Superseded && !(call.State == store.Cancelled && !call.LateResult) &&
+		!(call.TaskStatus == "cancelled" && !call.Errored) {
+		duration := call.Duration()
+		if duration >= 0 {
+			seconds := duration.Seconds()
+			series.sum += seconds
+			series.count++
+			for i, bound := range buckets {
+				if seconds <= bound {
+					series.bucket[i]++
+				}
+			}
+			series.bucket[len(buckets)]++
+		}
+	}
+	c.finish(key, op)
+}
+
+func (c *Collector) finish(key operationKey, op *operation) {
+	delete(c.operations, key)
+	request := requestKey{session: key.session, id: op.id}
+	if current, ok := c.inflight[request]; ok && current == key {
+		delete(c.inflight, request)
+	}
+}
+
+func (c *Collector) trimCancelled() {
+	const maxCancelled = 1024
+	if len(c.cancelled) <= maxCancelled {
+		return
+	}
+	key := c.cancelled[0]
+	if op := c.operations[key]; op != nil {
+		c.finish(key, op)
+	}
+	c.cancelled = c.cancelled[1:]
+}
+
+func (c *Collector) seriesFor(key seriesKey) *toolSeries {
+	series := c.series[key]
+	if series == nil {
+		series = &toolSeries{}
+		c.series[key] = series
+	}
+	return series
+}
+
+type serverIdentityLabels struct {
+	label string
+	id    string
+}
+
+func sessionHeader(st *store.Store, sessionID string) (store.SessionHeader, bool) {
+	for _, header := range st.Sessions() {
+		if header.ID == sessionID {
+			return header, true
+		}
+	}
+	return store.SessionHeader{}, false
+}
+
+// labelsForSession follows the identity split used by inventory and stats. The
+// friendly label is paired with a stable fingerprint of the recorded command
+// and cwd (stdio), endpoint (HTTP), or label/transport fallback. Raw commands,
+// paths, endpoints, and session ids never become Prometheus label values.
+func labelsForSession(st *store.Store, sessionID string, header store.SessionHeader) serverIdentityLabels {
+	command, cwd, _ := st.Command(sessionID)
+	const sep = "\x00"
+	var identity string
+	switch {
+	case len(command) > 0:
+		identity = "stdio" + sep + cwd + sep + strings.Join(command, sep)
+	case header.Endpoint != "":
+		identity = "http" + sep + header.Endpoint
+	default:
+		identity = "label" + sep + header.Transport + sep + header.Label
+	}
+	identity += sep + header.Label
+	digest := sha256.Sum256([]byte(identity))
+	label := header.Label
+	if label == "" {
+		label = "(unlabelled)"
+	}
+	return serverIdentityLabels{label: label, id: hex.EncodeToString(digest[:8])}
+}
+
+// Write renders the current aggregate in deterministic Prometheus text format.
+func (c *Collector) Write(w io.Writer) error {
+	c.mu.RLock()
+	seriesByKey := make(map[seriesKey]toolSeries, len(c.series))
+	keys := make([]seriesKey, 0, len(c.series))
+	for key, series := range c.series {
+		seriesByKey[key] = *series
+		keys = append(keys, key)
+	}
+	c.mu.RUnlock()
+	slices.SortFunc(keys, func(a, b seriesKey) int {
+		if c := strings.Compare(a.server, b.server); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.serverID, b.serverID); c != 0 {
+			return c
+		}
+		return strings.Compare(a.tool, b.tool)
+	})
+
+	if _, err := fmt.Fprintln(w, "# HELP "+toolCallsMetric+" Total number of observed MCP tool calls."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+toolCallsMetric+" counter"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# HELP "+toolErrorsMetric+" Total number of observed MCP tool call errors by error type."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+toolErrorsMetric+" counter"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# HELP "+toolDurationMetric+" Request-to-response duration of observed MCP tool calls in seconds."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+toolDurationMetric+" histogram"); err != nil {
+		return err
+	}
+	for _, key := range keys {
+		series := seriesByKey[key]
+		labels := baseLabels(key)
+		if _, err := fmt.Fprintf(w, "%s{%s} %d\n", toolCallsMetric, labels, series.calls); err != nil {
+			return err
+		}
+		for i, kind := range []string{"tool", "protocol"} {
+			if _, err := fmt.Fprintf(w, "%s{%s,error_type=\"%s\"} %d\n", toolErrorsMetric, labels, kind, series.errors[i]); err != nil {
+				return err
+			}
+		}
+		for i, bound := range buckets {
+			if _, err := fmt.Fprintf(w, "%s_bucket{%s,le=\"%s\"} %d\n", toolDurationMetric, labels, formatFloat(bound), series.bucket[i]); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "%s_bucket{%s,le=\"+Inf\"} %d\n", toolDurationMetric, labels, series.bucket[len(buckets)]); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "%s_sum{%s} %s\n", toolDurationMetric, labels, formatFloat(series.sum)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "%s_count{%s} %d\n", toolDurationMetric, labels, series.count); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func baseLabels(key seriesKey) string {
+	return `server="` + escapeLabel(key.server) + `",server_id="` + escapeLabel(key.serverID) + `",tool="` + escapeLabel(key.tool) + `"`
+}
+
+func escapeLabel(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`).Replace(value)
+}
+
+func formatFloat(value float64) string {
+	return fmt.Sprintf("%g", value)
+}
+
+// ServeHTTP serves only /metrics. A separate server/listener is used by the
+// CLI, so this handler can never shadow an MCP proxy path.
+func (c *Collector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/metrics" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	if r.Method == http.MethodHead {
+		return
+	}
+	if err := c.Write(w); err != nil {
+		return
+	}
+}
+
+// Server is the opt-in Prometheus HTTP listener.
+type Server struct {
+	listener net.Listener
+	server   *http.Server
+}
+
+// NewServer binds an independent TCP listener for metrics.
+func NewServer(addr string, collector *Collector) (*Server, error) {
+	if collector == nil {
+		return nil, errors.New("metrics: nil collector")
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		listener: listener,
+		server: &http.Server{
+			Handler:           collector,
+			ReadHeaderTimeout: 5 * time.Second,
+		},
+	}, nil
+}
+
+// Addr returns the bound address, useful when the listener requested port 0.
+func (s *Server) Addr() net.Addr { return s.listener.Addr() }
+
+// Serve runs the metrics listener until it is closed.
+func (s *Server) Serve() error {
+	err := s.server.Serve(s.listener)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// Close stops the metrics listener and waits for in-flight requests to finish.
+func (s *Server) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if err := s.server.Shutdown(ctx); err != nil {
+		// Shutdown leaves active handlers alone after the deadline. Close the
+		// connections so a blocked scrape cannot hold up hub shutdown forever.
+		_ = s.server.Close()
+		return err
+	}
+	return nil
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kerlenton/mcpsnoop/internal/hub"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
 )
@@ -55,11 +56,13 @@ type operationKey struct {
 type requestKey struct {
 	session string
 	id      string
+	conn    string
 }
 
 type operation struct {
 	series    seriesKey
 	id        string
+	conn      string
 	cancelled bool
 }
 
@@ -83,6 +86,15 @@ func New() *Collector {
 	}
 }
 
+// Prime adds historical state without producing live metrics. It is used during
+// hub startup so a reconnect can retain the session identity and correlation
+// context learned from the log.
+func (c *Collector) Prime(env proxy.Envelope) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store.Ingest(env)
+}
+
 // Observe adds one deduplicated live envelope. It does no network or disk work.
 func (c *Collector) Observe(env proxy.Envelope) {
 	c.mu.Lock()
@@ -95,18 +107,23 @@ func (c *Collector) Observe(env proxy.Envelope) {
 	}
 	server := labelsForSession(c.store, env.SessionID, header)
 
-	if event.Kind == store.EventRequest && event.Call != nil && event.MRTRRoot == "" &&
-		event.Call.IsTool && event.Call.ToolName != "" {
+	if event.Kind == store.EventRequest && event.Call != nil && event.MRTRRoot == "" {
 		key := operationKey{session: env.SessionID, seq: event.Call.RequestSeq}
-		if _, exists := c.operations[key]; !exists {
-			request := requestKey{session: env.SessionID, id: event.Call.ID}
-			if previous, exists := c.inflight[request]; exists && previous != key {
-				delete(c.operations, previous)
+		request := requestKey{session: env.SessionID, id: event.Call.ID, conn: env.ConnID}
+		if previous, exists := c.inflight[request]; exists && previous != key {
+			if op := c.operations[previous]; op != nil {
+				c.finish(previous, op)
+			} else {
+				delete(c.inflight, request)
 			}
-			series := seriesKey{server: server.label, serverID: server.id, tool: event.Call.ToolName}
-			c.operations[key] = &operation{series: series, id: event.Call.ID}
-			c.inflight[request] = key
-			c.seriesFor(series).calls++
+		}
+		if event.Call.IsTool && event.Call.ToolName != "" {
+			if _, exists := c.operations[key]; !exists {
+				series := seriesKey{server: server.label, serverID: server.id, tool: event.Call.ToolName}
+				c.operations[key] = &operation{series: series, id: event.Call.ID, conn: env.ConnID}
+				c.inflight[request] = key
+				c.seriesFor(series).calls++
+			}
 		}
 	}
 
@@ -159,7 +176,7 @@ func (c *Collector) Observe(env proxy.Envelope) {
 
 func (c *Collector) finish(key operationKey, op *operation) {
 	delete(c.operations, key)
-	request := requestKey{session: key.session, id: op.id}
+	request := requestKey{session: key.session, id: op.id, conn: op.conn}
 	if current, ok := c.inflight[request]; ok && current == key {
 		delete(c.inflight, request)
 	}
@@ -372,4 +389,63 @@ func (s *Server) Close() error {
 		return err
 	}
 	return nil
+}
+
+// RunHeadless runs the hub and metrics listener without starting a TUI. History
+// primes the collector's correlation store, but only envelopes received after
+// backfill are observed as live metrics.
+func RunHeadless(ctx context.Context, socketPath, sessionsDir string, historyLimit int, listen string) error {
+	if listen == "" {
+		return errors.New("metrics: empty listen address")
+	}
+	collector := New()
+	server, err := NewServer(listen, collector)
+	if err != nil {
+		return err
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve() }()
+
+	h := hub.NewWithOptions(socketPath, sessionsDir, func(proxy.Envelope) {}, hub.Options{
+		BackfillLimit:      historyLimit,
+		OnBackfillEnvelope: collector.Prime,
+		OnLive:             collector.Observe,
+	})
+	hubErr := make(chan error, 1)
+	go func() { hubErr <- h.Run(runCtx) }()
+
+	select {
+	case err := <-hubErr:
+		closeErr := server.Close()
+		metricsErr := <-serveErr
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
+		}
+		return metricsErr
+	case err := <-serveErr:
+		cancel()
+		<-hubErr
+		if err != nil {
+			return fmt.Errorf("metrics listener stopped: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		cancel()
+		closeErr := server.Close()
+		hubErr := <-hubErr
+		metricsErr := <-serveErr
+		if closeErr != nil {
+			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
+		}
+		if hubErr != nil {
+			return hubErr
+		}
+		return metricsErr
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kerlenton/mcpsnoop/internal/hub"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
@@ -25,10 +26,67 @@ const (
 	toolCallsMetric    = "mcpsnoop_tool_calls_total"
 	toolErrorsMetric   = "mcpsnoop_tool_errors_total"
 	toolDurationMetric = "mcpsnoop_tool_call_duration_seconds"
+	// transportErrorsMetric counts failures that never became a JSON-RPC message,
+	// so they can never be attributed to a tool.
+	//
+	// A gateway answering 502, or a 401 challenge, arrives as a status and a body
+	// that is not JSON-RPC. The store counts it against the session and attaches
+	// no call, deliberately, because nothing in the response says which request
+	// it answered: the connection id is the client's address, and a client may
+	// have several requests in flight on it. Without this series a gateway outage
+	// showed as a fall in mcpsnoop_tool_calls_total and a flat error line, which
+	// reads like traffic stopping rather than traffic failing, while a default
+	// `mcpsnoop check` run over the same capture failed.
+	transportErrorsMetric = "mcpsnoop_transport_errors_total"
 )
 
 // Buckets are the conventional Prometheus defaults, expressed in seconds.
 var buckets = [...]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+const (
+	// maxLabelBytes bounds a label value taken off the wire.
+	//
+	// A tool label is whatever a peer put in params.name, and Write repeats it on
+	// seventeen lines per series. A frame may carry 16 MiB of it, so one request
+	// measured out at a 71 MB scrape body from a 4 MiB name, which Prometheus
+	// drops whole against body_size_limit, taking every real series for that
+	// target with it. Truncating happens before the cardinality cap below, so a
+	// thousand long names that share a prefix fold into one series rather than
+	// each minting its own.
+	maxLabelBytes = 128
+	// labelElision marks a value this cut. It is longer than it needs to be so
+	// that a reader who meets it in a dashboard is not left guessing.
+	labelElision = "...(truncated by mcpsnoop)"
+	// maxSeries bounds distinct series, which is the other half of the same
+	// problem. Nothing on the wire constrains how many tool names a peer uses,
+	// and neither peer has to cooperate: a server writing unsolicited tools/call
+	// lines on its own stdout mints one series each. Past the cap, calls are
+	// still counted, under overflowTool, so the totals stay right and the flood
+	// is visible rather than fatal.
+	//
+	// Folding rather than evicting is deliberate. Evicting a series resets a
+	// counter, and Prometheus reads a counter that went backwards as a target
+	// restart, which fabricates traffic that never happened.
+	maxSeries = 2000
+	// overflowTool is where everything past the cap is counted. A real tool of
+	// this name would land in the same bucket, which is a collision folding
+	// makes possible and cannot avoid, since folding is lossy by construction.
+	overflowTool = "(over-series-cap)"
+)
+
+// clampLabel bounds one wire-supplied label value.
+func clampLabel(value string) string {
+	if len(value) <= maxLabelBytes {
+		return value
+	}
+	// Cut on a rune boundary so the result is still valid UTF-8, which the
+	// exposition format requires of a label value.
+	cut := maxLabelBytes - len(labelElision)
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return value[:cut] + labelElision
+}
 
 // Collector is the hub-side live metrics aggregate. Its small bounded store is
 // only a correlator: counters and histogram observations are retained here,
@@ -37,15 +95,30 @@ type Collector struct {
 	mu         sync.RWMutex
 	store      *store.Store
 	series     map[seriesKey]*toolSeries
+	transport  map[transportKey]uint64
 	operations map[operationKey]*operation
 	inflight   map[requestKey]operationKey
 	cancelled  []operationKey
+	// identities memoises the labels for a session. Deriving them walks every
+	// session the store has ever seen, allocating a full header for each, and it
+	// ran once per observed envelope while the write lock was held. A session's
+	// identity is fixed once its first frames land, so the walk only has to
+	// happen the first time one is seen.
+	identities map[string]serverIdentityLabels
 }
 
 type seriesKey struct {
 	server   string
 	serverID string
 	tool     string
+}
+
+// transportKey is a failure with no tool to hang it on. status is bounded by
+// what an HTTP status line can hold, so unlike a tool name it needs no cap.
+type transportKey struct {
+	server   string
+	serverID string
+	status   int
 }
 
 type operationKey struct {
@@ -55,12 +128,19 @@ type operationKey struct {
 
 type requestKey struct {
 	session string
-	id      string
-	conn    string
+	// dir, for the reason store.callKey carries it. JSON-RPC scopes id
+	// uniqueness to the sender, so a server-initiated request may legally reuse
+	// the id of a tool call that is still in flight. Without it, the supersede
+	// branch in Observe treats that as a retry and finishes the live call, and
+	// its error and its latency are never recorded.
+	dir  proxy.Direction
+	id   string
+	conn string
 }
 
 type operation struct {
 	series    seriesKey
+	dir       proxy.Direction
 	id        string
 	conn      string
 	cancelled bool
@@ -81,8 +161,10 @@ func New() *Collector {
 	return &Collector{
 		store:      store.NewBounded(1, 1),
 		series:     make(map[seriesKey]*toolSeries),
+		transport:  make(map[transportKey]uint64),
 		operations: make(map[operationKey]*operation),
 		inflight:   make(map[requestKey]operationKey),
+		identities: make(map[string]serverIdentityLabels),
 	}
 }
 
@@ -105,11 +187,19 @@ func (c *Collector) Observe(env proxy.Envelope) {
 	if !ok {
 		return
 	}
-	server := labelsForSession(c.store, env.SessionID, header)
+	server, known := c.identities[env.SessionID]
+	if !known {
+		server = labelsForSession(c.store, env.SessionID, header)
+		c.identities[env.SessionID] = server
+	}
+
+	if event.Kind == store.EventTransport && event.Errored {
+		c.transport[transportKey{server: server.label, serverID: server.id, status: event.HTTPStatus}]++
+	}
 
 	if event.Kind == store.EventRequest && event.Call != nil && event.MRTRRoot == "" {
 		key := operationKey{session: env.SessionID, seq: event.Call.RequestSeq}
-		request := requestKey{session: env.SessionID, id: event.Call.ID, conn: env.ConnID}
+		request := requestKey{session: env.SessionID, dir: env.Direction, id: event.Call.ID, conn: env.ConnID}
 		if previous, exists := c.inflight[request]; exists && previous != key {
 			if op := c.operations[previous]; op != nil {
 				c.finish(previous, op)
@@ -119,8 +209,8 @@ func (c *Collector) Observe(env proxy.Envelope) {
 		}
 		if event.Call.IsTool && event.Call.ToolName != "" {
 			if _, exists := c.operations[key]; !exists {
-				series := seriesKey{server: server.label, serverID: server.id, tool: event.Call.ToolName}
-				c.operations[key] = &operation{series: series, id: event.Call.ID, conn: env.ConnID}
+				series := seriesKey{server: server.label, serverID: server.id, tool: clampLabel(event.Call.ToolName)}
+				c.operations[key] = &operation{series: series, dir: env.Direction, id: event.Call.ID, conn: env.ConnID}
 				c.inflight[request] = key
 				c.seriesFor(series).calls++
 			}
@@ -176,7 +266,7 @@ func (c *Collector) Observe(env proxy.Envelope) {
 
 func (c *Collector) finish(key operationKey, op *operation) {
 	delete(c.operations, key)
-	request := requestKey{session: key.session, id: op.id, conn: op.conn}
+	request := requestKey{session: key.session, dir: op.dir, id: op.id, conn: op.conn}
 	if current, ok := c.inflight[request]; ok && current == key {
 		delete(c.inflight, request)
 	}
@@ -194,12 +284,27 @@ func (c *Collector) trimCancelled() {
 	c.cancelled = c.cancelled[1:]
 }
 
+// seriesFor returns the series for key, creating it while there is room. Past
+// the cap the call is counted against overflowTool for the same server, so a
+// flood of names costs one series rather than one each and the totals still add
+// up. Caller holds c.mu for writing.
 func (c *Collector) seriesFor(key seriesKey) *toolSeries {
-	series := c.series[key]
-	if series == nil {
-		series = &toolSeries{}
-		c.series[key] = series
+	if series := c.series[key]; series != nil {
+		return series
 	}
+	if len(c.series) >= maxSeries {
+		overflow := seriesKey{server: key.server, serverID: key.serverID, tool: overflowTool}
+		if series := c.series[overflow]; series != nil {
+			return series
+		}
+		// The overflow series itself must always fit, or the cap would silently
+		// discard the calls it is meant to keep counting.
+		series := &toolSeries{}
+		c.series[overflow] = series
+		return series
+	}
+	series := &toolSeries{}
+	c.series[key] = series
 	return series
 }
 
@@ -251,7 +356,22 @@ func (c *Collector) Write(w io.Writer) error {
 		seriesByKey[key] = *series
 		keys = append(keys, key)
 	}
+	transportByKey := make(map[transportKey]uint64, len(c.transport))
+	transportKeys := make([]transportKey, 0, len(c.transport))
+	for key, count := range c.transport {
+		transportByKey[key] = count
+		transportKeys = append(transportKeys, key)
+	}
 	c.mu.RUnlock()
+	slices.SortFunc(transportKeys, func(a, b transportKey) int {
+		if c := strings.Compare(a.server, b.server); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.serverID, b.serverID); c != 0 {
+			return c
+		}
+		return a.status - b.status
+	})
 	slices.SortFunc(keys, func(a, b seriesKey) int {
 		if c := strings.Compare(a.server, b.server); c != 0 {
 			return c
@@ -303,6 +423,23 @@ func (c *Collector) Write(w io.Writer) error {
 			return err
 		}
 		if _, err := fmt.Fprintf(w, "%s_count{%s} %d\n", toolDurationMetric, labels, series.count); err != nil {
+			return err
+		}
+	}
+
+	// Emitted whether or not anything failed, so a dashboard that graphs it does
+	// not go blank on a healthy hub and leave the reader wondering which of the
+	// two it is looking at.
+	if _, err := fmt.Fprintln(w, "# HELP "+transportErrorsMetric+" Total number of observed transport failures that carried no JSON-RPC message."); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# TYPE "+transportErrorsMetric+" counter"); err != nil {
+		return err
+	}
+	for _, key := range transportKeys {
+		if _, err := fmt.Fprintf(w, "%s{server=\"%s\",server_id=\"%s\",status=\"%d\"} %d\n",
+			transportErrorsMetric, escapeLabel(key.server), escapeLabel(key.serverID), key.status,
+			transportByKey[key]); err != nil {
 			return err
 		}
 	}
@@ -437,15 +574,23 @@ func RunHeadless(ctx context.Context, socketPath, sessionsDir string, historyLim
 		return nil
 	case <-ctx.Done():
 		cancel()
-		closeErr := server.Close()
+		// The hub first, and its error before the listener's. A scrape in flight
+		// keeps Shutdown polling to its deadline, so on an ordinary SIGTERM
+		// during a scrape the listener reports a timeout it already recovered
+		// from by closing the connections, and reporting that would exit 1 on a
+		// clean stop and hide whatever the hub had to say.
 		hubErr := <-hubErr
+		closeErr := server.Close()
 		metricsErr := <-serveErr
-		if closeErr != nil {
-			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
-		}
 		if hubErr != nil {
 			return hubErr
 		}
-		return metricsErr
+		if metricsErr != nil {
+			return metricsErr
+		}
+		if closeErr != nil && !errors.Is(closeErr, context.DeadlineExceeded) {
+			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
+		}
+		return nil
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,260 @@
+package metrics
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kerlenton/mcpsnoop/internal/proxy"
+)
+
+func envelope(session, label string, seq uint64, at time.Time, direction proxy.Direction, raw string) proxy.Envelope {
+	return proxy.Envelope{
+		SessionID: session, ServerLabel: label, Seq: seq, TS: at,
+		Direction: direction, Transport: proxy.TransportStdio, Raw: json.RawMessage(raw),
+	}
+}
+
+func toolRequest(session, label string, seq uint64, at time.Time, id, tool string) proxy.Envelope {
+	return envelope(session, label, seq, at, proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":`+strconv.Quote(id)+`,"method":"tools/call","params":{"name":`+strconv.Quote(tool)+`}}`)
+}
+
+func toolResponse(session, label string, seq uint64, at time.Time, id, answer string) proxy.Envelope {
+	return envelope(session, label, seq, at, proxy.ServerToClient,
+		`{"jsonrpc":"2.0","id":`+strconv.Quote(id)+`,`+answer+`}`)
+}
+
+func TestCollectorWritesCountersHistogramAndEscapedLabels(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	label := "srv\"\\\n"
+	tool := "echo\"\\\n"
+	c.Observe(toolRequest("s1", label, 1, start, "1", tool))
+	c.Observe(toolResponse("s1", label, 2, start.Add(20*time.Millisecond), "1", `"result":{"content":[]}`))
+	c.Observe(toolRequest("s1", label, 3, start.Add(time.Second), "2", tool))
+	c.Observe(toolResponse("s1", label, 4, start.Add(2*time.Second), "2", `"result":{"content":[],"isError":true}`))
+	c.Observe(toolRequest("s1", label, 5, start.Add(3*time.Second), "3", tool))
+	c.Observe(toolResponse("s1", label, 6, start.Add(4*time.Second), "3", `"error":{"code":-32603,"message":"boom"}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `# TYPE mcpsnoop_tool_calls_total counter`) {
+		t.Fatal("missing calls counter type")
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_calls_total{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n"} 3`) {
+		t.Fatalf("escaped counter labels or value missing:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_errors_total{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n",error_type="tool"} 1`) {
+		t.Fatalf("tool error counter missing:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_errors_total{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n",error_type="protocol"} 1`) {
+		t.Fatalf("protocol error counter missing:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_call_duration_seconds_bucket{server="srv\"\\\n",server_id="`) || !strings.Contains(got, `",tool="echo\"\\\n",le="0.025"} 1`) {
+		t.Fatalf("cumulative 25ms bucket missing:\n%s", got)
+	}
+	if !strings.Contains(got, `",tool="echo\"\\\n",le="+Inf"} 3`) || !strings.Contains(got, `mcpsnoop_tool_call_duration_seconds_count{server="srv\"\\\n",server_id="`) {
+		t.Fatalf("histogram count missing:\n%s", got)
+	}
+}
+
+func TestCollectorCountsMRTRAsOneCallAndOneObservation(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "1", "confirm"))
+	c.Observe(envelope("s1", "server", 2, start.Add(time.Second), proxy.ServerToClient,
+		`{"jsonrpc":"2.0","id":"1","result":{"resultType":"input_required","requestState":"state","inputRequests":{"answer":{"method":"elicitation/create"}}}}`))
+	c.Observe(envelope("s1", "server", 3, start.Add(5*time.Second), proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"confirm","requestState":"state","inputResponses":{"answer":{"action":"accept"}}}}`))
+	c.Observe(toolResponse("s1", "server", 4, start.Add(6*time.Second), "2", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_calls_total{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="confirm"} 1`) {
+		t.Fatalf("MRTR operation counted more than once:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="confirm"} 1`) {
+		t.Fatalf("MRTR duration observed more than once:\n%s", out.String())
+	}
+}
+
+func TestCollectorSkipsCancelledTaskLatency(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "1", "slow"))
+	c.Observe(toolResponse("s1", "server", 2, start.Add(time.Millisecond), "1", `"result":{"resultType":"task","taskId":"task-1","status":"working"}`))
+	c.Observe(envelope("s1", "server", 3, start.Add(time.Second), proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":"2","method":"tasks/get","params":{"taskId":"task-1"}}`))
+	c.Observe(envelope("s1", "server", 4, start.Add(5*time.Second), proxy.ServerToClient,
+		`{"jsonrpc":"2.0","method":"notifications/tasks","params":{"taskId":"task-1","status":"cancelled"}}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `",tool="slow"} 1`) {
+		t.Fatalf("cancelled task call missing:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="slow"} 0`) {
+		t.Fatalf("cancelled task must not create a latency observation:\n%s", out.String())
+	}
+}
+
+func TestCollectorDropsSupersededOperationState(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "same", "echo"))
+	c.Observe(toolRequest("s1", "server", 2, start.Add(time.Second), "same", "echo"))
+	if len(c.operations) != 1 {
+		t.Fatalf("operations = %d, want only the newest request", len(c.operations))
+	}
+	c.Observe(toolResponse("s1", "server", 3, start.Add(2*time.Second), "same", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `",tool="echo"} 2`) || !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="echo"} 1`) {
+		t.Fatalf("superseded call accounting is wrong:\n%s", out.String())
+	}
+}
+
+type blockingWriter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+	return len(p), nil
+}
+
+func TestCollectorScrapeDoesNotBlockLiveAggregation(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "1", "echo"))
+	c.Observe(toolResponse("s1", "server", 2, start.Add(time.Millisecond), "1", `"result":{"content":[]}`))
+
+	writer := &blockingWriter{started: make(chan struct{}), release: make(chan struct{})}
+	written := make(chan error, 1)
+	go func() { written <- c.Write(writer) }()
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("scrape did not start")
+	}
+
+	aggregated := make(chan struct{})
+	go func() {
+		c.Observe(toolRequest("s1", "server", 3, start.Add(time.Second), "2", "echo"))
+		close(aggregated)
+	}()
+	select {
+	case <-aggregated:
+	case <-time.After(time.Second):
+		close(writer.release)
+		t.Fatal("live aggregation was blocked by a scrape writer")
+	}
+	close(writer.release)
+	if err := <-written; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectorAggregatesConcurrentSessions(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	var wg sync.WaitGroup
+	for i := range 40 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			session := "s" + strconv.Itoa(i)
+			at := start.Add(time.Duration(i) * time.Millisecond)
+			c.Observe(toolRequest(session, "server", 1, at, "1", "echo"))
+			c.Observe(toolResponse(session, "server", 2, at.Add(10*time.Millisecond), "1", `"result":{"content":[]}`))
+		}(i)
+	}
+	wg.Wait()
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `mcpsnoop_tool_calls_total{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="echo"} 40`) {
+		t.Fatalf("concurrent calls were lost or duplicated:\n%s", out.String())
+	}
+}
+
+func TestCollectorKeepsDistinctServerIdentitiesApart(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	for i, command := range [][]string{{"node", "alpha.js"}, {"node", "beta.js"}} {
+		session := "s" + strconv.Itoa(i)
+		meta, _ := json.Marshal(proxy.SessionMeta{Command: command, CWD: "/srv"})
+		c.Observe(proxy.Envelope{SessionID: session, ServerLabel: "same", Seq: 1, TS: start, Direction: proxy.DirectionMeta, Raw: meta})
+		c.Observe(toolRequest(session, "same", 2, start, "1", "search"))
+		c.Observe(toolResponse(session, "same", 3, start.Add(time.Millisecond), "1", `"result":{"content":[]}`))
+	}
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(out.String(), `mcpsnoop_tool_calls_total{server="same"`); got != 2 {
+		t.Fatalf("same-label servers were pooled, got %d series:\n%s", got, out.String())
+	}
+}
+
+func TestMetricsServerOnlyServesMetricsOnItsOwnListener(t *testing.T) {
+	c := New()
+	server, err := NewServer("127.0.0.1:0", c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve() }()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := <-serveErr; err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	resp, err := http.Get("http://" + server.Addr().String() + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/plain; version=0.0.4") {
+		t.Fatalf("metrics response = %d/%q", resp.StatusCode, resp.Header.Get("Content-Type"))
+	}
+	if !strings.Contains(string(body), "# TYPE mcpsnoop_tool_calls_total counter") {
+		t.Fatalf("metrics response missing exposition:\n%s", body)
+	}
+
+	resp, err = http.Get("http://" + server.Addr().String() + "/mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("non-metrics path status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -371,3 +371,182 @@ func TestMetricsServerOnlyServesMetricsOnItsOwnListener(t *testing.T) {
 		t.Fatalf("non-metrics path status = %d, want 404", resp.StatusCode)
 	}
 }
+
+// TestCollectorBoundsALabelTakenOffTheWire. A tool label is whatever a peer put
+// in params.name, a frame may carry 16 MiB of it, and Write repeats it on
+// seventeen lines per series. One request measured out at a 71 MB scrape body,
+// which Prometheus drops whole against body_size_limit, taking every real series
+// for that target with it.
+func TestCollectorBoundsALabelTakenOffTheWire(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	huge := strings.Repeat("A", 4<<20)
+	c.Observe(toolRequest("s1", "srv", 1, at, "1", huge))
+	c.Observe(toolResponse("s1", "srv", 2, at.Add(time.Millisecond), "1", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if n := out.Len(); n > 64<<10 {
+		t.Errorf("one 4 MiB tool name rendered %d bytes of exposition, want a bounded body", n)
+	}
+	if strings.Contains(out.String(), strings.Repeat("A", maxLabelBytes+1)) {
+		t.Error("the label reached the exposition at more than its cap")
+	}
+	if !strings.Contains(out.String(), labelElision) {
+		t.Error("the label was cut without saying so, so a reader cannot tell truncation from a real name")
+	}
+}
+
+// TestCollectorFoldsTooManyToolNamesRatherThanGrowingForever. Nothing on the
+// wire constrains how many tool names a peer uses, and neither peer has to
+// cooperate: the store recognises a tools/call by its method, so a server
+// writing them on its own stdout mints one series each. Past the cap the calls
+// still have to be counted, or the cap would discard the traffic it exists to
+// keep measuring.
+func TestCollectorFoldsTooManyToolNamesRatherThanGrowingForever(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	const flood = maxSeries * 3
+	for i := range flood {
+		id := strconv.Itoa(i)
+		c.Observe(toolRequest("s1", "srv", uint64(2*i+1), at, id, "tool-"+id))
+		c.Observe(toolResponse("s1", "srv", uint64(2*i+2), at.Add(time.Millisecond), id, `"result":{"content":[]}`))
+	}
+	c.mu.RLock()
+	held := len(c.series)
+	c.mu.RUnlock()
+	if held > maxSeries+1 {
+		t.Errorf("held %d series for %d tool names, want no more than the cap plus the overflow bucket", held, flood)
+	}
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	// Every call is still counted somewhere, so a dashboard's total stays true.
+	var total float64
+	for _, line := range strings.Split(out.String(), "\n") {
+		if !strings.HasPrefix(line, toolCallsMetric+"{") {
+			continue
+		}
+		// The value is after the last space, since a label may hold one.
+		cut := strings.LastIndex(line, " ")
+		if cut < 0 {
+			t.Fatalf("no value in %q", line)
+		}
+		value := line[cut+1:]
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			t.Fatalf("unparseable count in %q", line)
+		}
+		total += n
+	}
+	if int(total) != flood {
+		t.Errorf("counted %d calls across every series, want %d: folding must not lose the totals", int(total), flood)
+	}
+	if !strings.Contains(out.String(), overflowTool) {
+		t.Error("nothing in the exposition says the series list was capped")
+	}
+}
+
+// TestCollectorKeepsAToolCallASeverInitiatedRequestReuses. JSON-RPC scopes id
+// uniqueness to the sender, so a server may legally issue a request carrying the
+// id of a tool call that is still in flight. Keying the in-flight map without
+// the direction made that look like a retry, and the live call was finished
+// before its answer arrived, losing its error and its latency.
+func TestCollectorKeepsAToolCallASeverInitiatedRequestReuses(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "srv", 1, at, "7", "search"))
+	// The server asks the client something of its own, reusing id 7.
+	c.Observe(envelope("s1", "srv", 2, at.Add(5*time.Millisecond), proxy.ServerToClient,
+		`{"jsonrpc":"2.0","id":"7","method":"roots/list"}`))
+	c.Observe(toolResponse("s1", "srv", 3, at.Add(20*time.Millisecond), "7",
+		`"result":{"content":[],"isError":true}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	body := out.String()
+	// The values, not the substrings. Every metric name appears in a HELP and a
+	// TYPE line whether or not anything was counted, and the tool keeps its
+	// calls_total series either way, so presence proves nothing here.
+	if got := seriesValue(t, body, toolErrorsMetric, `tool="search"`); got != 1 {
+		t.Errorf("errors for the tool = %v, want 1: a server request reusing its id must not finish it\n%s", got, body)
+	}
+	if got := seriesValue(t, body, toolDurationMetric+"_count", `tool="search"`); got != 1 {
+		t.Errorf("latency observations for the tool = %v, want 1\n%s", got, body)
+	}
+}
+
+// seriesValue totals every sample of metric whose line contains match.
+//
+// Every one, not the first. A tool carries two error series, one per
+// error_type, so reading the first would let a count land in the other slot and
+// go unnoticed. The value is after the last space, since a label may hold one.
+func seriesValue(t *testing.T, body, metric, match string) float64 {
+	t.Helper()
+	var total float64
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, metric+"{") || !strings.Contains(line, match) {
+			continue
+		}
+		cut := strings.LastIndex(line, " ")
+		if cut < 0 {
+			t.Fatalf("no value in %q", line)
+		}
+		v, err := strconv.ParseFloat(line[cut+1:], 64)
+		if err != nil {
+			t.Fatalf("unparseable value in %q", line)
+		}
+		total += v
+	}
+	return total
+}
+
+// TestCollectorCountsATransportFailureThatHasNoTool. A gateway answering 502, or
+// a 401 challenge, arrives as a status and a body that is not JSON-RPC. Nothing
+// in it says which request it answered, so it can never be attributed to a tool.
+// Left uncounted, a gateway outage read as traffic stopping rather than traffic
+// failing, while `mcpsnoop check` over the same capture failed on it.
+func TestCollectorCountsATransportFailureThatHasNoTool(t *testing.T) {
+	c := New()
+	at := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequestOnConn("s1", "srv", 1, at, "c1", "1", "echo"))
+	c.Observe(proxy.Envelope{
+		SessionID: "s1", ServerLabel: "srv", Seq: 2, TS: at.Add(30 * time.Millisecond),
+		Direction: proxy.ServerToClient, Transport: proxy.TransportHTTP, ConnID: "c1", Status: 502,
+	})
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	body := out.String()
+	if got := seriesValue(t, body, transportErrorsMetric, `status="502"`); got != 1 {
+		t.Errorf("transport errors = %v, want 1\n%s", got, body)
+	}
+	// And it is not invented onto the tool, since nothing said it was that call's.
+	if got := seriesValue(t, body, toolErrorsMetric, `tool="echo"`); got != 0 {
+		t.Errorf("the 502 was attributed to a tool it cannot be known to belong to, got %v", got)
+	}
+	if !strings.Contains(body, "# TYPE "+transportErrorsMetric+" counter") {
+		t.Error("the family is missing its TYPE line")
+	}
+}
+
+// TestCollectorAlwaysDeclaresTheTransportFamily. A dashboard that graphs a
+// metric which only appears once something has failed cannot tell a healthy hub
+// from a broken query.
+func TestCollectorAlwaysDeclaresTheTransportFamily(t *testing.T) {
+	var out strings.Builder
+	if err := New().Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "# TYPE "+transportErrorsMetric+" counter") {
+		t.Errorf("an idle collector does not declare %s:\n%s", transportErrorsMetric, out.String())
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,9 +1,13 @@
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,6 +32,20 @@ func toolRequest(session, label string, seq uint64, at time.Time, id, tool strin
 func toolResponse(session, label string, seq uint64, at time.Time, id, answer string) proxy.Envelope {
 	return envelope(session, label, seq, at, proxy.ServerToClient,
 		`{"jsonrpc":"2.0","id":`+strconv.Quote(id)+`,`+answer+`}`)
+}
+
+func toolRequestOnConn(session, label string, seq uint64, at time.Time, conn, id, tool string) proxy.Envelope {
+	e := toolRequest(session, label, seq, at, id, tool)
+	e.Transport = proxy.TransportHTTP
+	e.ConnID = conn
+	return e
+}
+
+func toolResponseOnConn(session, label string, seq uint64, at time.Time, conn, id, answer string) proxy.Envelope {
+	e := toolResponse(session, label, seq, at, id, answer)
+	e.Transport = proxy.TransportHTTP
+	e.ConnID = conn
+	return e
 }
 
 func TestCollectorWritesCountersHistogramAndEscapedLabels(t *testing.T) {
@@ -127,6 +145,101 @@ func TestCollectorDropsSupersededOperationState(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `",tool="echo"} 2`) || !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="echo"} 1`) {
 		t.Fatalf("superseded call accounting is wrong:\n%s", out.String())
+	}
+}
+
+func TestCollectorDropsToolWhenSameRequestIdentityIsReusedByNonTool(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequest("s1", "server", 1, start, "same", "echo"))
+	c.Observe(envelope("s1", "server", 2, start.Add(time.Second), proxy.ClientToServer,
+		`{"jsonrpc":"2.0","id":"same","method":"ping"}`))
+	c.Observe(toolResponse("s1", "server", 3, start.Add(2*time.Second), "same", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `",tool="echo"} 1`) || !strings.Contains(out.String(), `mcpsnoop_tool_call_duration_seconds_count{server="server",server_id="`) || !strings.Contains(out.String(), `",tool="echo"} 0`) {
+		t.Fatalf("superseded tool operation remained active:\n%s", out.String())
+	}
+}
+
+func TestCollectorCorrelatesSameHTTPIDByConnID(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Observe(toolRequestOnConn("s1", "server", 1, start, "client-a", "1", "echo"))
+	c.Observe(toolRequestOnConn("s1", "server", 2, start.Add(time.Second), "client-b", "1", "echo"))
+	c.Observe(toolResponseOnConn("s1", "server", 3, start.Add(1100*time.Millisecond), "client-a", "1", `"result":{"content":[]}`))
+	c.Observe(toolResponseOnConn("s1", "server", 4, start.Add(3*time.Second), "client-b", "1", `"error":{"code":-32603,"message":"boom"}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `",tool="echo"} 2`) {
+		t.Fatalf("same-id HTTP calls were not both counted:\n%s", got)
+	}
+	if !strings.Contains(got, `",tool="echo",error_type="protocol"} 1`) {
+		t.Fatalf("same-id HTTP protocol error was not retained:\n%s", got)
+	}
+	if !strings.Contains(got, `mcpsnoop_tool_call_duration_seconds_sum{server="server",server_id="`) || !strings.Contains(got, `",tool="echo"} 3.1`) {
+		t.Fatalf("same-id HTTP durations were not both observed:\n%s", got)
+	}
+}
+
+func TestCollectorPrimeExcludesBackfillMetrics(t *testing.T) {
+	c := New()
+	start := time.Unix(1_700_000_000, 0)
+	c.Prime(toolRequest("s1", "server", 1, start, "1", "echo"))
+	c.Prime(toolResponse("s1", "server", 2, start.Add(time.Second), "1", `"result":{"content":[]}`))
+
+	var out strings.Builder
+	if err := c.Write(&out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), `",tool="echo"} 1`) {
+		t.Fatalf("backfill produced live metrics:\n%s", out.String())
+	}
+}
+
+func TestRunHeadlessMetricsDoesNotStartTUI(t *testing.T) {
+	if _, err := net.Listen("unix", filepath.Join(t.TempDir(), "probe.sock")); err != nil {
+		t.Skipf("unix sockets unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "hub.sock")
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := probe.Addr().String()
+	probe.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- RunHeadless(ctx, socket, dir, 0, addr) }()
+
+	var resp *http.Response
+	for range 50 {
+		resp, err = http.Get("http://" + addr + "/metrics")
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		cancel()
+		t.Fatalf("headless metrics listener did not start: %v", err)
+	}
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("headless metrics run = %v", err)
+	}
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		t.Fatalf("headless hub socket still exists, stat error = %v", err)
 	}
 }
 

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/kerlenton/mcpsnoop/internal/hub"
+	"github.com/kerlenton/mcpsnoop/internal/metrics"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
@@ -37,12 +38,42 @@ func liveStore() *store.Store {
 // RunWithHistoryLimit starts the live TUI with a bounded history replay.
 // A historyLimit of 0 loads every session log.
 func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
+	return runWithHistoryLimitAndMetrics(ctx, socketPath, sessionsDir, historyLimit, "")
+}
+
+// RunWithHistoryLimitAndMetrics starts the live TUI and, when metricsListen is
+// non-empty, an independent Prometheus listener. Metrics observe only live hub
+// envelopes; history replay remains a UI concern.
+func RunWithHistoryLimitAndMetrics(ctx context.Context, socketPath, sessionsDir string, historyLimit int, metricsListen string) error {
+	return runWithHistoryLimitAndMetrics(ctx, socketPath, sessionsDir, historyLimit, metricsListen)
+}
+
+func runWithHistoryLimitAndMetrics(ctx context.Context, socketPath, sessionsDir string, historyLimit int, metricsListen string) error {
 	st := liveStore()
 	baselines := toolbaseline.New(paths.ToolBaselinesDir())
-	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(ctx))
-
 	hubCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(hubCtx))
+	var metricServer *metrics.Server
+	var metricErr chan error
+	var collector *metrics.Collector
+	if metricsListen != "" {
+		collector = metrics.New()
+		var err error
+		metricServer, err = metrics.NewServer(metricsListen, collector)
+		if err != nil {
+			return fmt.Errorf("cannot listen for Prometheus metrics on %s: %w", metricsListen, err)
+		}
+		defer metricServer.Close()
+		metricErr = make(chan error, 1)
+		go func() {
+			err := metricServer.Serve()
+			metricErr <- err
+			if err != nil && hubCtx.Err() == nil {
+				cancel()
+			}
+		}()
+	}
 
 	// Baseline observation reads and sometimes writes files, so keep it off the
 	// frame-delivery goroutine. A single worker observes the sessions handed to it
@@ -61,7 +92,7 @@ func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, hi
 		}
 	}()
 
-	h := hub.NewWithOptions(socketPath, sessionsDir, func(e proxy.Envelope) {
+	handler := func(e proxy.Envelope) {
 		event := st.Ingest(e)
 		if event.Kind == store.EventResponse && event.Call != nil && event.Call.Method == "tools/list" {
 			if _, complete := st.ToolDefinitions(e.SessionID); complete {
@@ -74,14 +105,19 @@ func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, hi
 			}
 		}
 		p.Send(frameMsg{})
-	}, hub.Options{
+	}
+	options := hub.Options{
 		BackfillLimit: historyLimit,
 		OnBackfill: func(report hub.BackfillReport) {
 			if report.Loaded < report.Total {
 				p.Send(historyTruncatedMsg{loaded: report.Loaded, total: report.Total})
 			}
 		},
-	})
+	}
+	if collector != nil {
+		options.OnLive = collector.Observe
+	}
+	h := hub.NewWithOptions(socketPath, sessionsDir, handler, options)
 
 	// A second hub on one MCPSNOOP_HOME cannot take the socket, and Run returns
 	// before it backfills, so swallowing the error left the user staring at an
@@ -106,6 +142,14 @@ func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, hi
 
 	_, err := p.Run()
 	cancel() // stop the hub and the observation worker once the UI exits
+	if metricServer != nil {
+		if closeErr := metricServer.Close(); closeErr != nil {
+			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
+		}
+		if serveErr := <-metricErr; serveErr != nil {
+			return fmt.Errorf("metrics listener stopped: %w", serveErr)
+		}
+	}
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {
 		return nil
 	}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -10,7 +10,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/kerlenton/mcpsnoop/internal/hub"
-	"github.com/kerlenton/mcpsnoop/internal/metrics"
 	"github.com/kerlenton/mcpsnoop/internal/paths"
 	"github.com/kerlenton/mcpsnoop/internal/proxy"
 	"github.com/kerlenton/mcpsnoop/internal/store"
@@ -38,42 +37,15 @@ func liveStore() *store.Store {
 // RunWithHistoryLimit starts the live TUI with a bounded history replay.
 // A historyLimit of 0 loads every session log.
 func RunWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
-	return runWithHistoryLimitAndMetrics(ctx, socketPath, sessionsDir, historyLimit, "")
+	return runWithHistoryLimit(ctx, socketPath, sessionsDir, historyLimit)
 }
 
-// RunWithHistoryLimitAndMetrics starts the live TUI and, when metricsListen is
-// non-empty, an independent Prometheus listener. Metrics observe only live hub
-// envelopes; history replay remains a UI concern.
-func RunWithHistoryLimitAndMetrics(ctx context.Context, socketPath, sessionsDir string, historyLimit int, metricsListen string) error {
-	return runWithHistoryLimitAndMetrics(ctx, socketPath, sessionsDir, historyLimit, metricsListen)
-}
-
-func runWithHistoryLimitAndMetrics(ctx context.Context, socketPath, sessionsDir string, historyLimit int, metricsListen string) error {
+func runWithHistoryLimit(ctx context.Context, socketPath, sessionsDir string, historyLimit int) error {
 	st := liveStore()
 	baselines := toolbaseline.New(paths.ToolBaselinesDir())
 	hubCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	p := tea.NewProgram(New(st), tea.WithAltScreen(), tea.WithContext(hubCtx))
-	var metricServer *metrics.Server
-	var metricErr chan error
-	var collector *metrics.Collector
-	if metricsListen != "" {
-		collector = metrics.New()
-		var err error
-		metricServer, err = metrics.NewServer(metricsListen, collector)
-		if err != nil {
-			return fmt.Errorf("cannot listen for Prometheus metrics on %s: %w", metricsListen, err)
-		}
-		defer metricServer.Close()
-		metricErr = make(chan error, 1)
-		go func() {
-			err := metricServer.Serve()
-			metricErr <- err
-			if err != nil && hubCtx.Err() == nil {
-				cancel()
-			}
-		}()
-	}
 
 	// Baseline observation reads and sometimes writes files, so keep it off the
 	// frame-delivery goroutine. A single worker observes the sessions handed to it
@@ -114,9 +86,6 @@ func runWithHistoryLimitAndMetrics(ctx context.Context, socketPath, sessionsDir 
 			}
 		},
 	}
-	if collector != nil {
-		options.OnLive = collector.Observe
-	}
 	h := hub.NewWithOptions(socketPath, sessionsDir, handler, options)
 
 	// A second hub on one MCPSNOOP_HOME cannot take the socket, and Run returns
@@ -142,14 +111,6 @@ func runWithHistoryLimitAndMetrics(ctx context.Context, socketPath, sessionsDir 
 
 	_, err := p.Run()
 	cancel() // stop the hub and the observation worker once the UI exits
-	if metricServer != nil {
-		if closeErr := metricServer.Close(); closeErr != nil {
-			return fmt.Errorf("metrics listener shutdown: %w", closeErr)
-		}
-		if serveErr := <-metricErr; serveErr != nil {
-			return fmt.Errorf("metrics listener stopped: %w", serveErr)
-		}
-	}
 	if errors.Is(err, tea.ErrProgramKilled) || errors.Is(err, context.Canceled) {
 		return nil
 	}


### PR DESCRIPTION
Closes #137

Add an opt-in hub-side Prometheus listener. Bare mcpsnoop keeps its interactive TUI; mcpsnoop --metrics-listen runs the hub headlessly so the metrics process remains available without an interactive terminal.

Startup backfill primes session metadata and correlation state but is excluded from live counters. HTTP correlation includes ConnID, and MRTR operations remain one call with one latency observation. Reused request identities also clear stale pending tool state.

Public metrics: mcpsnoop_tool_calls_total, mcpsnoop_tool_errors_total, and mcpsnoop_tool_call_duration_seconds.

The listener is independent of the MCP proxy and uses stdlib-only Prometheus text exposition, with no new runtime dependency.

Tests run: targeted metrics, hub, TUI, and CLI tests; repeated regression tests for HTTP correlation, backfill priming, reconnect identity, headless lifecycle, and default routing; go vet ./...; staticcheck; cross-platform vet for Windows, Darwin, and Linux; git diff --check. The full go test ./... run is blocked on this Windows environment by existing Unix executable, file-mode, pipe, editor, and timestamp assumptions. POSIX make check could not run because the available POSIX shell cannot see go or gofmt. Race tests could not run because CGO/GCC is unavailable.